### PR TITLE
Feature: async attachments support (fixes #31)

### DIFF
--- a/allure-java-commons/build.gradle
+++ b/allure-java-commons/build.gradle
@@ -12,5 +12,6 @@ dependencies {
 
     testCompile 'junit:junit'
     testCompile 'org.slf4j:slf4j-simple'
+    testCompile 'org.mockito:mockito-core'
     testCompile 'org.assertj:assertj-core'
 }

--- a/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
@@ -5,6 +5,7 @@ import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.model.StepResult;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -87,7 +88,8 @@ public final class Allure {
     public static CompletableFuture<byte[]> addByteAttachmentAsync(
             final String name, final String type, final String fileExtension, final Supplier<byte[]> body) {
         final String source = lifecycle.prepareAttachment(name, type, fileExtension);
-        return supplyAsync(body).whenComplete((result, ex) -> lifecycle.writeAttachment(source, result));
+        return supplyAsync(body).whenComplete((result, ex) ->
+                lifecycle.writeAttachment(source, new ByteArrayInputStream(result)));
     }
 
     public static CompletableFuture<InputStream> addStreamAttachmentAsync(

--- a/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
@@ -8,6 +8,10 @@ import io.qameta.allure.model.StepResult;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
 
 /**
  * The class contains some useful methods to work with {@link AllureLifecycle}.
@@ -73,6 +77,28 @@ public final class Allure {
     public static void addAttachment(final String name, final String type,
                                      final InputStream content, final String fileExtension) {
         lifecycle.addAttachment(name, type, fileExtension, content);
+    }
+
+    public static CompletableFuture<byte[]> addByteAttachmentAsync(
+            final String name, final String type, final Supplier<byte[]> body) {
+        return addByteAttachmentAsync(name, type, "", body);
+    }
+
+    public static CompletableFuture<byte[]> addByteAttachmentAsync(
+            final String name, final String type, final String fileExtension, final Supplier<byte[]> body) {
+        final String source = lifecycle.prepareAttachment(name, type, fileExtension);
+        return supplyAsync(body).whenComplete((result, ex) -> lifecycle.writeAttachment(source, result));
+    }
+
+    public static CompletableFuture<InputStream> addStreamAttachmentAsync(
+            final String name, final String type, final Supplier<InputStream> body) {
+        return addStreamAttachmentAsync(name, type, "", body);
+    }
+
+    public static CompletableFuture<InputStream> addStreamAttachmentAsync(
+            final String name, final String type, final String fileExtension, final Supplier<InputStream> body) {
+        final String source = lifecycle.prepareAttachment(name, type, fileExtension);
+        return supplyAsync(body).whenComplete((result, ex) -> lifecycle.writeAttachment(source, result));
     }
 
     public static void setLifecycle(final AllureLifecycle lifecycle) {

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
@@ -161,9 +161,13 @@ public class AllureLifecycle {
         addAttachment(name, type, fileExtension, new ByteArrayInputStream(body));
     }
 
-    @SuppressWarnings({"PMD.NullAssignment", "PMD.UseObjectForClearerAPI"})
     public void addAttachment(final String name, final String type,
                               final String fileExtension, final InputStream stream) {
+        writeAttachment(prepareAttachment(name, type, fileExtension), stream);
+    }
+
+    @SuppressWarnings({"PMD.NullAssignment", "PMD.UseObjectForClearerAPI"})
+    public String prepareAttachment(final String name, final String type, final String fileExtension) {
         final String uuid = currentStepContext.get().getFirst();
         LOGGER.debug("Adding attachment to item with uuid {}", uuid);
         final String extension = Optional.ofNullable(fileExtension)
@@ -176,8 +180,17 @@ public class AllureLifecycle {
                 .withType(isEmpty(type) ? null : type)
                 .withSource(source);
 
-        writer.write(attachment.getSource(), stream);
         get(uuid, WithAttachments.class).getAttachments().add(attachment);
+
+        return attachment.getSource();
+    }
+
+    public void writeAttachment(final String attachmentSource, final InputStream stream) {
+        writer.write(attachmentSource, stream);
+    }
+
+    public void writeAttachment(final String attachmentSource, final byte[] body) {
+        writer.write(attachmentSource, new ByteArrayInputStream(body));
     }
 
     public void addStep(final StepResult result) {

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
@@ -189,10 +189,6 @@ public class AllureLifecycle {
         writer.write(attachmentSource, stream);
     }
 
-    public void writeAttachment(final String attachmentSource, final byte[] body) {
-        writer.write(attachmentSource, new ByteArrayInputStream(body));
-    }
-
     public void addStep(final StepResult result) {
         get(currentStepContext.get().getFirst(), WithSteps.class).getSteps().add(result);
     }

--- a/allure-java-commons/src/test/java/io/qameta/allure/AttachmentsTests.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AttachmentsTests.java
@@ -1,0 +1,88 @@
+package io.qameta.allure;
+
+import io.qameta.allure.model.Attachment;
+import io.qameta.allure.model.TestResult;
+import io.qameta.allure.testdata.AllureResultsWriterStub;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static io.qameta.allure.Allure.addStreamAttachmentAsync;
+import static io.qameta.allure.Allure.setLifecycle;
+import static java.util.Arrays.asList;
+import static java.util.concurrent.CompletableFuture.allOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author sskorol (Sergey Korol).
+ */
+public class AttachmentsTests {
+
+    private static final List<CompletableFuture<InputStream>> STREAM_FUTURE = new CopyOnWriteArrayList<>();
+
+    @After
+    public void tearDown() {
+        allOf(STREAM_FUTURE.stream().toArray(CompletableFuture[]::new)).join();
+    }
+
+    @Test
+    public void shouldAttachAsync() throws Exception {
+        final AllureResultsWriterStub results = spy(AllureResultsWriterStub.class);
+
+        final ArgumentCaptor<String> sources = ArgumentCaptor.forClass(String.class);
+        doNothing().when(results).write(sources.capture(), any(InputStream.class));
+
+        final AllureLifecycle lifecycle = new AllureLifecycle(results);
+        setLifecycle(lifecycle);
+
+        final String uuid = UUID.randomUUID().toString();
+        final TestResult result = new TestResult().withUuid(uuid);
+
+        lifecycle.scheduleTestCase(result);
+        lifecycle.startTestCase(uuid);
+
+        STREAM_FUTURE.add(addStreamAttachmentAsync(
+                "Async attachment 1", "video/mp4", getStreamWithTimeout(2)));
+        STREAM_FUTURE.add(addStreamAttachmentAsync(
+                "Async attachment 2", "text/plain", getStreamWithTimeout(1)));
+
+        lifecycle.stopTestCase(uuid);
+        lifecycle.writeTestCase(uuid);
+
+        final List<Attachment> attachments = results
+                .getTestResults()
+                .stream()
+                .flatMap(r -> r.getAttachments().stream())
+                .collect(Collectors.toList());
+
+        assertThat(attachments)
+                .as("Attachments list")
+                .hasSize(2);
+
+        assertThat(sources.getAllValues())
+                .as("Sources list")
+                .hasSize(2);
+
+        assertThat(attachments)
+                .flatExtracting(attachment -> asList(attachment.getName(), attachment.getType(), attachment.getSource()))
+                .as("Attachments content")
+                .containsExactly(
+                        "Async attachment 1", "video/mp4", sources.getAllValues().get(0),
+                        "Async attachment 2", "text/plain", sources.getAllValues().get(1));
+    }
+
+    private Supplier<InputStream> getStreamWithTimeout(final long sec) throws InterruptedException {
+        TimeUnit.SECONDS.sleep(sec);
+        return () -> mock(InputStream.class);
+    }
+}

--- a/allure-java-commons/src/test/java/io/qameta/allure/LinksTests.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/LinksTests.java
@@ -1,6 +1,5 @@
-package io.qameta.allure.test;
+package io.qameta.allure;
 
-import io.qameta.allure.ResultsUtils;
 import io.qameta.allure.model.Link;
 import org.junit.After;
 import org.junit.Before;

--- a/allure-java-commons/src/test/java/io/qameta/allure/testdata/AllureResultsWriterStub.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/testdata/AllureResultsWriterStub.java
@@ -1,0 +1,35 @@
+package io.qameta.allure.testdata;
+
+import io.qameta.allure.AllureResultsWriter;
+import io.qameta.allure.model.TestResult;
+import io.qameta.allure.model.TestResultContainer;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class AllureResultsWriterStub implements AllureResultsWriter {
+
+    private List<TestResult> testResults = new CopyOnWriteArrayList<>();
+    private List<TestResultContainer> testContainers = new CopyOnWriteArrayList<>();
+
+    public void write(final TestResult testResult) {
+        testResults.add(testResult);
+    }
+
+    public void write(final TestResultContainer testResultContainer) {
+        testContainers.add(testResultContainer);
+    }
+
+    public void write(final String source, final InputStream attachment) {
+        //not implemented
+    }
+
+    public List<TestResult> getTestResults() {
+        return testResults;
+    }
+
+    public List<TestResultContainer> getTestContainers() {
+        return testContainers;
+    }
+}


### PR DESCRIPTION
#### Change log
 - decomposed attachments [create / write] API;
 - added several utility methods to perform async attachments via `CompletableFuture<InputStream>` and `CompletableFuture<byte[]>`;

#### Usage

```java
public class BaseListener implements IInvokedMethodListener, ISuiteListener {

	private static final List<CompletableFuture<InputStream>> VIDEOS = new CopyOnWriteArrayList<>();

	@Override
	public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
	}

	@Override
	public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
		if (method.isTestMethod()) {
			VIDEOS.add(addStreamAttachmentAsync("Async", "video/mp4",
					() -> getClass().getResourceAsStream("/video.mp4")));
		}
	}

	@Override
	public void onStart(ISuite suite) {
	}

	@Override
	public void onFinish(ISuite suite) {
		CompletableFuture.allOf(VIDEOS.stream().toArray(CompletableFuture[]::new)).join();
	}
}
```