### PR TITLE
[BUGFIX] NPE in StepsAspect while passing null-arg (fixes allure2 #350)

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
@@ -121,8 +121,7 @@ public class StepsAspects {
                                                     final Object... args) {
         return IntStream.range(0, args.length)
                         .filter(i -> parameterName.equals(signature.getParameterNames()[i]))
-                        .mapToObj(i -> args[i])
-                        .map(ob -> Objects.isNull(ob) ? Objects.toString(null) : ob)
+                        .mapToObj(i -> Objects.isNull(args[i]) ? Objects.toString(null) : args[i])
                         .findFirst()
                         .orElse(null);
     }

--- a/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
@@ -122,6 +122,7 @@ public class StepsAspects {
         return IntStream.range(0, args.length)
                         .filter(i -> parameterName.equals(signature.getParameterNames()[i]))
                         .mapToObj(i -> args[i])
+                        .map(ob -> Objects.isNull(ob) ? Objects.toString(null) : ob)
                         .findFirst()
                         .orElse(null);
     }

--- a/allure-java-commons/src/test/java/io/qameta/allure/StepsTests.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/StepsTests.java
@@ -37,8 +37,9 @@ public class StepsTests {
                 null
         };
         final DummyCard card = new DummyCard("1111222233334444");
+        final DummyUser nullUser = null;
 
-        loginWith(new DummyUser(emails, "12345678", card), true);
+        loginWith(new DummyUser(emails, "12345678", card), nullUser, true);
 
         lifecycle.stopTestCase(uuid);
         lifecycle.writeTestCase(uuid);
@@ -52,11 +53,11 @@ public class StepsTests {
                         " null]\"," +
                         " \"[[txt, png], [jpg, mp4], null]\"," +
                         " \"12345678\", \"{}\","
-                        + " \"1111222233334444\", \"{missing}\", true");
+                        + " \"1111222233334444\", \"{missing}\", null, true");
     }
 
-    @Step("\"{user.emails.address}\", \"{user.emails}\", \"{user.emails.attachments}\", \"{user.password}\", \"{}\"," +
-            " \"{user.card.number}\", \"{missing}\", {staySignedIn}")
-    private void loginWith(final DummyUser user, final boolean staySignedIn) {
+    @Step("\"{user1.emails.address}\", \"{user1.emails}\", \"{user1.emails.attachments}\", \"{user1.password}\", \"{}\"," +
+            " \"{user1.card.number}\", \"{missing}\", {user2}, {staySignedIn}")
+    private void loginWith(final DummyUser user1, final DummyUser user2, final boolean staySignedIn) {
     }
 }


### PR DESCRIPTION
Fixed https://github.com/allure-framework/allure2/issues/350 caused by NPE thrown in `StepsAspect`. It occurred due to uncovered case with null-values passing into method signature.

Extended test with corresponding check as well.