### PR TITLE
Wrong class name for Rest Assured example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ Filter for rest-assured http client, that generates attachment for allure.
 
 Usage example:
 ```
-.filter(new AllureLoggerFilter())
+.filter(new AllureRestAssured())
 ```
 You can specify custom templateName:
 ```
-.filter(new AllureLoggerFilter().withTemplate("/templates/custom_template.ftl"))
+.filter(new AllureRestAssured().withTemplate("/templates/custom_template.ftl"))
 ```
 
 ## Retrofit


### PR DESCRIPTION
Wrong class name for Rest Assured example, changed to AllureRestAssured