### PR TITLE
Test which covers TestNG suite with parameter

### DIFF
--- a/allure-testng/src/test/java/io/qameta/allure/testng/FeatureCombinationsTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/FeatureCombinationsTest.java
@@ -311,6 +311,19 @@ public class FeatureCombinationsTest {
         assertContainersChildren(secondSuiteName, testContainers, getUidsByName(testContainers, secondTagName));
     }
 
+    @Test(description = "Before Suite Parameter")
+    public void testBeforeSuiteParameter() {
+        runTestNgSuites("suites/parameterized-suite1.xml", "suites/parameterized-suite2.xml");
+        List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(2)
+                .extracting(TestResult::getFullName)
+                .containsExactly(
+                        "io.qameta.allure.testng.samples.SuiteParametersTest.simpleTest[param=first]",
+                        "io.qameta.allure.testng.samples.SuiteParametersTest.simpleTest[param=second]"
+                );
+    }
+
     @Test(description = "Parallel methods")
     public void parallelMethods() {
         String before1 = "io.qameta.allure.testng.samples.ParallelMethods.beforeMethod";

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/SuiteParameterTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/SuiteParameterTest.java
@@ -1,0 +1,21 @@
+package io.qameta.allure.testng.samples;
+
+/*
+  @author Andrejs Kalnacs akalnacs@evolutiongaming.com
+ */
+import org.testng.ITestContext;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+public class SuiteParameterTest {
+    @Parameters("parameter")
+    @BeforeSuite
+    public void beforeSuite(String parameter, ITestContext context) {
+        context.getCurrentXmlTest().addParameter("param", parameter);
+    }
+
+    @Test()
+    public void simpleTest() {
+    }
+}

--- a/allure-testng/src/test/resources/suites/parameterized-suite1.xml
+++ b/allure-testng/src/test/resources/suites/parameterized-suite1.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Suite with parameter">
+    <parameter name="parameter" value="first" />
+    <test name="Parameter test">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.SuiteParameterTest">
+            </class>
+        </classes>
+    </test>
+</suite>

--- a/allure-testng/src/test/resources/suites/parameterized-suite2.xml
+++ b/allure-testng/src/test/resources/suites/parameterized-suite2.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Suite with parameter">
+    <parameter name="parameter" value="second" />
+    <test name="Parameter test">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.SuiteParameterTest">
+            </class>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
Now in new Allure report this is shown as one tests with with two runs (one rerun), but actually this is not true, as these are different tests (because they have different parameters).

In old Allure that was distinguished by test case name, so assert is made based on how it was in previous Allure