### PR TITLE
[cucumberjvm] Now severity can be parsed by tag name

### DIFF
--- a/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/LabelBuilder.java
+++ b/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/LabelBuilder.java
@@ -65,6 +65,8 @@ class LabelBuilder {
                         getScenarioLabels().add(getTagLabel(tag));
                         break;
                 }
+            } else if (tagParser.isPureSeverityTag(tag)) {
+                getScenarioLabels().add(getSeverityLabel(tagString.substring(1)));
             } else if (!tagParser.isResultTag(tag)) {
                 getScenarioLabels().add(getTagLabel(tag));
             }
@@ -98,7 +100,7 @@ class LabelBuilder {
             @Override
             public SeverityLevel value() {
                 try {
-                    return SeverityLevel.valueOf(severity);
+                    return SeverityLevel.valueOf(severity.toUpperCase());
                 } catch (IllegalArgumentException e) {
                     LOG.warn("There is no severity level {} failing back to 'normal'", e);
                     return SeverityLevel.NORMAL;

--- a/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/TagParser.java
+++ b/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/TagParser.java
@@ -3,6 +3,7 @@ package io.qameta.allure.cucumberjvm;
 import gherkin.formatter.model.Feature;
 import gherkin.formatter.model.Scenario;
 import gherkin.formatter.model.Tag;
+import io.qameta.allure.SeverityLevel;
 
 import java.util.Arrays;
 
@@ -44,6 +45,12 @@ class TagParser {
     protected boolean isResultTag(final Tag tag) {
         return Arrays.asList(new String[]{FLAKY, KNOWN, MUTED})
                 .contains(tag.getName().toUpperCase());
+    }
+
+    protected boolean isPureSeverityTag(final Tag tag) {
+        return Arrays.asList(SeverityLevel.values()).stream()
+                .anyMatch(value -> ("@" + value.name())
+                        .equalsIgnoreCase(tag.getName()));
     }
 
 }

--- a/allure-cucumber-jvm/src/test/java/io/qameta/allure/cucumberjvm/CucumberTest.java
+++ b/allure-cucumber-jvm/src/test/java/io/qameta/allure/cucumberjvm/CucumberTest.java
@@ -8,6 +8,7 @@ import cucumber.api.junit.Cucumber;
 @CucumberOptions(
         features = {"src/test/resources/features"},
         plugin = {"io.qameta.allure.cucumberjvm.AllureCucumberJvm"},
+        junit = {"--filename-compatible-names"},
         tags = {"@good"})
 public class CucumberTest {
 }


### PR DESCRIPTION
- Now severity can be parsed by tag name. Thx @sseliverstov for idea.
- Fix gradle report building by adding JUnit capability for file names.
