### PR TITLE
Fix npe with Ignore annotation on classes in JUnit4

### DIFF
--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/FeatureCombinationsTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/FeatureCombinationsTest.java
@@ -5,6 +5,7 @@ import io.qameta.allure.aspects.StepsAspects;
 import io.qameta.allure.junit4.samples.AssumptionFailedTest;
 import io.qameta.allure.junit4.samples.BrokenTest;
 import io.qameta.allure.junit4.samples.FailedTest;
+import io.qameta.allure.junit4.samples.IgnoredClassTest;
 import io.qameta.allure.junit4.samples.IgnoredTests;
 import io.qameta.allure.junit4.samples.OneTest;
 import io.qameta.allure.junit4.samples.TaggedTests;
@@ -142,6 +143,16 @@ public class FeatureCombinationsTest {
                 .extracting(TestResult::getStatusDetails)
                 .extracting(StatusDetails::getMessage)
                 .containsExactlyInAnyOrder("Test ignored (without reason)!", "Ignored for some reason");
+    }
+
+    @Test
+    @DisplayName("Test result for ignored class gets named by the class name")
+    public void shouldSetNameForIgnoredClass() {
+        core.run(Request.aClass(IgnoredClassTest.class));
+        List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .extracting(TestResult::getName)
+                .containsExactly("io.qameta.allure.junit4.samples.IgnoredClassTest");
     }
 
     @Test

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/IgnoredClassTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/IgnoredClassTest.java
@@ -1,0 +1,16 @@
+package io.qameta.allure.junit4.samples;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author gladnik (Nikolai Gladkov)
+ */
+@Ignore
+public class IgnoredClassTest {
+
+    @Test
+    public void ignoredAsPartOfTheIgnoredClassTest() {
+    }
+
+}


### PR DESCRIPTION
This PR fixes NPE in report generation, where it tried to use a label with a null value. Such label was created for a test method name, which was not defined for a class marked with Ignore annotation. 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2