### PR TITLE
Get skipped status for throwable

### DIFF
--- a/allure-java-commons/build.gradle
+++ b/allure-java-commons/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     compile 'com.google.guava:guava'
     compile 'org.jooq:joor'
     compile 'org.apache.commons:commons-lang3'
+    compile 'junit:junit'
 
     testCompile 'junit:junit'
     testCompile 'org.slf4j:slf4j-simple'

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -13,6 +13,7 @@ import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
+import org.junit.AssumptionViolatedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,7 +178,8 @@ public final class ResultsUtils {
 
     public static Optional<Status> getStatus(final Throwable throwable) {
         return Optional.ofNullable(throwable)
-                .map(t -> t instanceof AssertionError ? Status.FAILED : Status.BROKEN);
+                .map(t -> t instanceof AssertionError ? Status.FAILED
+                        : t instanceof AssumptionViolatedException ? Status.SKIPPED : Status.BROKEN);
     }
 
     public static Optional<StatusDetails> getStatusDetails(final Throwable e) {

--- a/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
+++ b/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
@@ -103,20 +103,12 @@ public class AllureJunit4 extends RunListener {
 
     @Override
     public void testFailure(final Failure failure) throws Exception {
-        final String uuid = testCases.get();
-        getLifecycle().updateTestCase(uuid, testResult -> testResult
-                .withStatus(getStatus(failure.getException()).orElse(null))
-                .withStatusDetails(getStatusDetails(failure.getException()).orElse(null))
-        );
+        processTestFailure(failure);
     }
 
     @Override
     public void testAssumptionFailure(final Failure failure) {
-        final String uuid = testCases.get();
-        getLifecycle().updateTestCase(uuid, testResult ->
-                testResult.withStatus(Status.SKIPPED)
-                        .withStatusDetails(getStatusDetails(failure.getException()).orElse(null))
-        );
+        processTestFailure(failure);
     }
 
     @Override
@@ -258,6 +250,14 @@ public class AllureJunit4 extends RunListener {
                         new Label().withName("host").withValue(getHostName()),
                         new Label().withName("thread").withValue(getThreadName())
                 );
+    }
+
+    private void processTestFailure(final Failure failure) {
+        final String uuid = testCases.get();
+        getLifecycle().updateTestCase(uuid, testResult -> testResult
+                .withStatus(getStatus(failure.getException()).orElse(Status.BROKEN))
+                .withStatusDetails(getStatusDetails(failure.getException()).orElse(null))
+        );
     }
 
 }


### PR DESCRIPTION
This would set status correctly for skipped steps. Also it allows to use a common method to process failed and skipped tests.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
