### PR TITLE
Support for execution of steps in any thread. (fixes #122\)

### DIFF
--- a/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
+++ b/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
@@ -298,6 +298,8 @@ public class AllureTestNg implements ISuiteListener, ITestListener, IInvokedMeth
     @Override
     public void beforeInvocation(final IInvokedMethod method, final ITestResult testResult,
                                  final ITestContext context) {
+        final String qName = getQualifiedName(method.getTestMethod());
+        getLifecycle().setThread(qName, Thread.currentThread());
         final ITestNGMethod testMethod = method.getTestMethod();
         if (isSupportedConfigurationFixture(testMethod)) {
             ifSuiteFixtureStarted(context.getSuite(), testMethod);


### PR DESCRIPTION
### Context
The code assumed that `@Step` methods are always executed in the same or ancestor thread of some test method(`@Test, @BeforeMethod ` etc).

I removed ThreadLocal from `currentStepContext` in `AllureStorage`. Can you guys pls check if I did not introduce any race conditions? It is possible to have two threads working on the same stepContext in `AllureStorage`.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests -> Can do on request.

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
