### PR TITLE
Add plain link support for cucumber-jvm fixes #124

### DIFF
--- a/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/LabelBuilder.java
+++ b/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/LabelBuilder.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static io.qameta.allure.util.ResultsUtils.createFeatureLabel;
 import static io.qameta.allure.util.ResultsUtils.createSeverityLabel;
@@ -30,6 +31,7 @@ class LabelBuilder {
     private static final String SEVERITY = "@SEVERITY";
     private static final String ISSUE_LINK = "@ISSUE";
     private static final String TMS_LINK = "@TMSLINK";
+    private static final String PLAIN_LINK = "@LINK";
 
     private final List<Label> scenarioLabels = new ArrayList<>();
     private final List<Link> scenarioLinks = new ArrayList<>();
@@ -50,6 +52,22 @@ class LabelBuilder {
                 final String tagKey = tagString.split(COMPOSITE_TAG_DELIMITER)[0].toUpperCase();
                 final String tagValue = tagString.split(COMPOSITE_TAG_DELIMITER)[1];
 
+                // Handle composite named links
+                if (tagKey.startsWith(PLAIN_LINK + ".")) {
+                    final String namedLinkPatternString =  PLAIN_LINK + "\\.(\\w+-?)+=(\\w+(-|_)?)+";
+                    Pattern namedLinkPattern = Pattern.compile(namedLinkPatternString, Pattern.CASE_INSENSITIVE);
+                    if (namedLinkPattern.matcher(tagString).matches()) {
+                        Link plainLink = new Link();
+                        plainLink.setType(tagString.split("=")[0].split("[.]")[1]);
+                        plainLink.setName(tagValue);
+                        getScenarioLinks().add(plainLink);
+                    } else {
+                        LOGGER.warn("Composite named tag {} is not matches regex {}. skipping", tagKey,
+                                namedLinkPatternString);
+                    }
+                    continue;
+                }
+
                 switch (tagKey) {
                     case SEVERITY:
                         getScenarioLabels().add(createSeverityLabel(tagValue.toLowerCase()));
@@ -59,6 +77,11 @@ class LabelBuilder {
                         break;
                     case ISSUE_LINK:
                         getScenarioLinks().add(ResultsUtils.createIssueLink(tagValue));
+                        break;
+                    case PLAIN_LINK:
+                        Link plainLink = new Link();
+                        plainLink.setUrl(tagValue);
+                        getScenarioLinks().add(plainLink);
                         break;
                     default:
                         LOGGER.warn("Composite tag {} is not supported. adding it as RAW", tagKey);

--- a/allure-cucumber-jvm/src/test/resources/features/test.feature
+++ b/allure-cucumber-jvm/src/test/resources/features/test.feature
@@ -11,7 +11,7 @@ Feature: Test One
     When I add a to b
     Then result is 15
 
-  @tmsLink=OAT-219 @severity=blocker @issue=BUG-12312 @known @muted @goofy=dog @melted
+  @tmsLink=OAT-219 @severity=blocker @issue=BUG-12312 @known @muted @goofy=dog @melted @link=http://yandex.ru
   Scenario Outline: Outline
     Given a is <a>
     And b is <b>
@@ -22,7 +22,7 @@ Feature: Test One
       | 1 | 3 | 4      |
       | 2 | 4 | 5      |
 
-  @good
+  @good @link=http://yandex.ru @link.mylink-112-qwe=mylinkname-12  @link.mylink-112-qwe=12_12-12
   Scenario: data table
     Given users are:
       | name    | login    | email          |


### PR DESCRIPTION
Now it's possible to create links directly from features like:
```
@link=http://yandex.ru
Feature: Test feature

  @link.my-link-named-type=my-named-name
  Scenario: test scenario
    Given...
    When...
    Then...
```
Plain links should start with ```@link=```
Named links should match following regex: ```@link\.(\w+-?)+=(\w+(-|_)?)+```