### PR TITLE
Fix RestAssured attachments (fixes #147)

### DIFF
--- a/allure-attachments/src/main/resources/tpl/http-request.ftl
+++ b/allure-attachments/src/main/resources/tpl/http-request.ftl
@@ -1,3 +1,4 @@
+<#ftl output_format="HTML">
 <#-- @ftlvariable name="data" type="io.qameta.allure.attachment.http.HttpRequestAttachment" -->
 <div><#if data.method??>${data.method}<#else>GET</#if> to <#if data.url??>${data.url}<#else>Unknown</#if></div>
 

--- a/allure-attachments/src/main/resources/tpl/http-response.ftl
+++ b/allure-attachments/src/main/resources/tpl/http-response.ftl
@@ -1,3 +1,4 @@
+<#ftl output_format="HTML">
 <#-- @ftlvariable name="data" type="io.qameta.allure.attachment.http.HttpResponseAttachment" -->
 <div>Status code <#if data.responseCode??>${data.responseCode} <#else>Unknown</#if></div>
 <#if data.url??><div>${data.url}</div></#if>

--- a/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
+++ b/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
@@ -31,6 +31,7 @@ public class AllureRestAssured implements OrderedFilter {
 
         final HttpRequestAttachment requestAttachment = create("Request", requestSpec.getURI())
                 .withBody(prettifier.getPrettifiedBodyIfPossible(requestSpec))
+                .withMethod(requestSpec.getMethod())
                 .withHeaders(toMapConverter(requestSpec.getHeaders()))
                 .withCookies(toMapConverter(requestSpec.getCookies()))
                 .build();


### PR DESCRIPTION
### Context

- Added output-format to request and response templates. Now Freemarker escapes tags in XML.
- Added method info to restassured attachment

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
