### PR TITLE
[Cucumber JVM] Handle composite tags with empty value part

### DIFF
--- a/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/LabelBuilder.java
+++ b/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/LabelBuilder.java
@@ -6,6 +6,7 @@ import gherkin.formatter.model.Tag;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.util.ResultsUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +25,7 @@ import static io.qameta.allure.util.ResultsUtils.getThreadName;
 /**
  * Scenario labels and links builder.
  */
+@SuppressWarnings("CyclomaticComplexity")
 class LabelBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(LabelBuilder.class);
     private static final String COMPOSITE_TAG_DELIMITER = "=";
@@ -49,8 +51,14 @@ class LabelBuilder {
 
             if (tagString.contains(COMPOSITE_TAG_DELIMITER)) {
 
-                final String tagKey = tagString.split(COMPOSITE_TAG_DELIMITER)[0].toUpperCase();
-                final String tagValue = tagString.split(COMPOSITE_TAG_DELIMITER)[1];
+                final String[] tagParts = tagString.split(COMPOSITE_TAG_DELIMITER, 2);
+                if (StringUtils.isEmpty(tagParts[1])) {
+                    // skip empty tags, e.g. '@tmsLink=', to avoid formatter errors
+                    continue;
+                }
+
+                final String tagKey = tagParts[0].toUpperCase();
+                final String tagValue = tagParts[1];
 
                 // Handle composite named links
                 if (tagKey.startsWith(PLAIN_LINK + ".")) {

--- a/allure-cucumber-jvm/src/test/resources/features/test.feature
+++ b/allure-cucumber-jvm/src/test/resources/features/test.feature
@@ -11,6 +11,13 @@ Feature: Test One
     When I add a to b
     Then result is 15
 
+  @good @tmsLink= @tmsLink=ISSUE=12345
+  Scenario: Scenario with empty tag and tag with more than one =
+    Given a is 5
+    And b is 10
+    When I add a to b
+    Then result is 15
+
   @tmsLink=OAT-219 @severity=blocker @issue=BUG-12312 @known @muted @goofy=dog @melted @link=http://yandex.ru
   Scenario Outline: Outline
     Given a is <a>

--- a/allure-cucumber2-jvm/src/main/java/io/qameta/allure/cucumber2jvm/LabelBuilder.java
+++ b/allure-cucumber2-jvm/src/main/java/io/qameta/allure/cucumber2jvm/LabelBuilder.java
@@ -5,6 +5,7 @@ import gherkin.ast.Feature;
 import gherkin.pickles.PickleTag;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +27,7 @@ import static io.qameta.allure.util.ResultsUtils.createTagLabel;
 /**
  * Scenario labels and links builder.
  */
+@SuppressWarnings("CyclomaticComplexity")
 class LabelBuilder {
     private static final Logger LOGGER = LoggerFactory.getLogger(LabelBuilder.class);
     private static final String COMPOSITE_TAG_DELIMITER = "=";
@@ -51,8 +53,14 @@ class LabelBuilder {
 
             if (tagString.contains(COMPOSITE_TAG_DELIMITER)) {
 
-                final String tagKey = tagString.split(COMPOSITE_TAG_DELIMITER)[0].toUpperCase();
-                final String tagValue = tagString.split(COMPOSITE_TAG_DELIMITER)[1];
+                final String[] tagParts = tagString.split(COMPOSITE_TAG_DELIMITER, 2);
+                if (StringUtils.isEmpty(tagParts[1])) {
+                    // skip empty tags, e.g. '@tmsLink=', to avoid formatter errors
+                    continue;
+                }
+
+                final String tagKey = tagParts[0].toUpperCase();
+                final String tagValue = tagParts[1];
 
                 // Handle composite named links
                 if (tagKey.startsWith(PLAIN_LINK + ".")) {

--- a/allure-cucumber2-jvm/src/test/resources/features/test.feature
+++ b/allure-cucumber2-jvm/src/test/resources/features/test.feature
@@ -11,6 +11,13 @@ Feature: Test Simple Scenarios
     When I add a to b
     Then result is 15
 
+  @good @tmsLink= @tmsLink=ISSUE=12345
+  Scenario: Scenario with empty tag and tag with more than one =
+    Given a is 5
+    And b is 10
+    When I add a to b
+    Then result is 15
+
   @bad
   Scenario: Wrong add a to b
     Given a is 5


### PR DESCRIPTION
Skip composite tags with empty value part to avoid errors in formatters (both Cucumber JVM 1.x and 2.x)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

Right now if we have composite tags with empty value part (e.g. `@tmsLink=` or `@issue=`) LabelBuilder will throw exception, and result file won't be saved.

I suggest to ignore and skip such invalid tags

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2