### PR TITLE
JUnit5 updates: @DisplayName for test class + @Description for test method

### DIFF
--- a/allure-junit-platform/build.gradle
+++ b/allure-junit-platform/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     compile project(':allure-java-commons')
     compile('org.junit.platform:junit-platform-launcher')
+    compile('org.junit.jupiter:junit-jupiter-api')
 
     testCompile('org.slf4j:slf4j-simple')
     testCompile 'org.assertj:assertj-core'

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junit5/AllureJunit5.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junit5/AllureJunit5.java
@@ -2,15 +2,19 @@ package io.qameta.allure.junit5;
 
 import io.qameta.allure.Allure;
 import io.qameta.allure.AllureLifecycle;
+import io.qameta.allure.Description;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Stage;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.util.ResultsUtils;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
 import java.security.MessageDigest;
@@ -29,6 +33,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * @author ehborisov
  */
 public class AllureJunit5 implements TestExecutionListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AllureJunit5.class);
 
     private static final String TAG = "tag";
 
@@ -65,7 +71,8 @@ public class AllureJunit5 implements TestExecutionListener {
                     .withStage(Stage.RUNNING);
 
             methodSource.ifPresent(source -> {
-                result.getLabels().add(new Label().withName("suite").withValue(source.getClassName()));
+                result.setDescription(getDescription(source));
+                result.getLabels().add(new Label().withName("suite").withValue(getSuite(source)));
                 result.getLabels().add(new Label().withName("package").withValue(source.getClassName()));
             });
 
@@ -129,5 +136,32 @@ public class AllureJunit5 implements TestExecutionListener {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("Could not find md5 hashing algorithm", e);
         }
+    }
+
+    private String getSuite(final MethodSource source) {
+        try {
+            final DisplayName displayNameAnnotation =
+                    Class.forName(source.getClassName()).getAnnotation(DisplayName.class);
+            if (displayNameAnnotation != null && !displayNameAnnotation.value().isEmpty()) {
+                return displayNameAnnotation.value();
+            }
+        } catch (ClassNotFoundException e) {
+            LOGGER.trace(e.getMessage(), e);
+        }
+        return source.getClassName();
+    }
+
+    private String getDescription(final MethodSource source) {
+        try {
+            final Description descriptionAnnotation = Class.forName(source.getClassName())
+                    .getDeclaredMethod(source.getMethodName())
+                    .getAnnotation(Description.class);
+            if (descriptionAnnotation != null) {
+                return descriptionAnnotation.value();
+            }
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            LOGGER.trace(e.getMessage(), e);
+        }
+        return null;
     }
 }

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junit5/AllureJunit5Test.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junit5/AllureJunit5Test.java
@@ -208,6 +208,49 @@ public class AllureJunit5Test {
         softly.assertAll();
     }
 
+    @Test
+    void shouldProcessTestClassDisplayNameByAnnotation() {
+        runClasses(TestsClassWithDisplayNameAnnotation.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1);
+
+        final List<Label> testResultLabels = testResults.get(0).getLabels();
+        assertThat(testResultLabels)
+                .filteredOn(label -> "suite".equals(label.getName()))
+                .hasSize(1)
+                .flatExtracting(Label::getValue)
+                .contains("Display name of test class");
+    }
+
+    @Test
+    void shouldProcessDefaultTestClassDisplayName() {
+        runClasses(TestsClassWithoutDisplayNameAnnotation.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1);
+
+        final List<Label> testResultLabels = testResults.get(0).getLabels();
+        assertThat(testResultLabels)
+                .filteredOn(label -> "suite".equals(label.getName()))
+                .hasSize(1)
+                .flatExtracting(Label::getValue)
+                .contains("io.qameta.allure.junit5.features.TestsClassWithoutDisplayNameAnnotation");
+    }
+
+    @Test
+    void shouldProcessJunit5Description() {
+        runClasses(TestsWithDescriptions.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1)
+                .flatExtracting(TestResult::getDescription)
+                .contains("Test description");
+    }
+
     private void runClasses(Class<?>... classes) {
         final ClassSelector[] classSelectors = Stream.of(classes)
                 .map(DiscoverySelectors::selectClass)

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junit5/features/TestsClassWithDisplayNameAnnotation.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junit5/features/TestsClassWithDisplayNameAnnotation.java
@@ -1,0 +1,15 @@
+package io.qameta.allure.junit5.features;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author a.afrikanov (Andrey Afrikanov).
+ */
+@DisplayName("Display name of test class")
+public class TestsClassWithDisplayNameAnnotation {
+
+    @Test
+    void test() {
+    }
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junit5/features/TestsClassWithoutDisplayNameAnnotation.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junit5/features/TestsClassWithoutDisplayNameAnnotation.java
@@ -1,0 +1,13 @@
+package io.qameta.allure.junit5.features;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author a.afrikanov (Andrey Afrikanov).
+ */
+public class TestsClassWithoutDisplayNameAnnotation {
+
+    @Test
+    void test() {
+    }
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junit5/features/TestsWithDescriptions.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junit5/features/TestsWithDescriptions.java
@@ -1,0 +1,15 @@
+package io.qameta.allure.junit5.features;
+
+import io.qameta.allure.Description;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author a.afrikanov (Andrey Afrikanov).
+ */
+public class TestsWithDescriptions {
+
+    @Test
+    @Description("Test description")
+    void testWithDescription() {
+    }
+}


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)
Some updates for Allure 2 + JUnit 5.
Added ability to show in Allure 2 report:
- display name (label "suite") for test class (by annotation org.junit.jupiter.api.DisplayName)
- test description (by annotation io.qameta.allure.Description)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
