### PR TITLE
Allow embedding attachments and other allure steps in cucumber hook steps

### DIFF
--- a/allure-cucumber2-jvm/build.gradle
+++ b/allure-cucumber2-jvm/build.gradle
@@ -8,7 +8,7 @@ configurations {
     agent
 }
 
-def cucumber_version = '2.1.0'
+def cucumber_version = '2.3.1'
 
 dependencies {
     agent 'org.aspectj:aspectjweaver'

--- a/allure-cucumber2-jvm/src/main/java/io/qameta/allure/cucumber2jvm/AllureCucumber2Jvm.java
+++ b/allure-cucumber2-jvm/src/main/java/io/qameta/allure/cucumber2jvm/AllureCucumber2Jvm.java
@@ -253,8 +253,8 @@ public class AllureCucumber2Jvm implements Formatter {
         final String uuid = getHookStepUuid(event.testStep);
         Consumer<StepResult> stepResult = result -> result.withStatus(translateTestCaseStatus(event.result));
 
-        if (!Status.PASSED.equals((translateTestCaseStatus(event.result)))) {
-            StatusDetails statusDetails = ResultsUtils.getStatusDetails(event.result.getError()).get();
+        if (!Status.PASSED.equals(translateTestCaseStatus(event.result))) {
+            final StatusDetails statusDetails = ResultsUtils.getStatusDetails(event.result.getError()).get();
             if (event.testStep.getHookType() == HookType.Before) {
                 final TagParser tagParser = new TagParser(currentFeature, currentTestCase);
                 statusDetails


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)
Currently, all actions that happen inside cucumber hook steps, are not attached inside the step it self which makes it less readable in case logic of hooks is a bit more complicated.
This PR fixes that. Screenshots below for comparison:
current:
![image](https://user-images.githubusercontent.com/12693088/34663430-7967e056-f45f-11e7-8382-5266df6d050d.png)

pr:
![image](https://user-images.githubusercontent.com/12693088/34663444-88483fda-f45f-11e7-87ad-16ecd0bc5b17.png)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
