### PR TITLE
Fixed all NPEs in junit-runner due to missing actual class (fixes #174)

### DIFF
--- a/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
+++ b/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
@@ -194,7 +194,7 @@ public class AllureJunit4 extends RunListener {
 
     @SuppressWarnings("unchecked")
     private <T extends Annotation> List<T> extractRepeatable(final Description result, final Class<T> clazz) {
-        if (clazz.isAnnotationPresent(Repeatable.class)) {
+        if (clazz != null && clazz.isAnnotationPresent(Repeatable.class)) {
             final Repeatable repeatable = clazz.getAnnotation(Repeatable.class);
             final Class<? extends Annotation> wrapper = repeatable.value();
             final Annotation annotation = result.getAnnotation(wrapper);
@@ -214,6 +214,7 @@ public class AllureJunit4 extends RunListener {
     private <T extends Annotation> List<T> getAnnotationsOnClass(final Description result, final Class<T> clazz) {
         return Stream.of(result)
                 .map(Description::getTestClass)
+                .filter(Objects::nonNull)
                 .map(testClass -> testClass.getAnnotationsByType(clazz))
                 .flatMap(Stream::of)
                 .collect(Collectors.toList());
@@ -237,7 +238,7 @@ public class AllureJunit4 extends RunListener {
     }
 
     private String getPackage(final Class<?> testClass) {
-        return Optional.of(testClass)
+        return Optional.ofNullable(testClass)
                 .map(Class::getPackage)
                 .map(Package::getName)
                 .orElse("");
@@ -255,7 +256,8 @@ public class AllureJunit4 extends RunListener {
         final String methodName = description.getMethodName();
         final String name = Objects.nonNull(methodName) ? methodName : className;
         final String fullName = Objects.nonNull(methodName) ? String.format("%s.%s", className, methodName) : className;
-        final String suite = Optional.ofNullable(description.getTestClass().getAnnotation(DisplayName.class))
+        final String suite = Optional.ofNullable(description.getTestClass())
+                .map(it -> it.getAnnotation(DisplayName.class))
                 .map(DisplayName::value).orElse(className);
 
         final TestResult testResult = new TestResult()

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/SampleRunnerBasedOnNotClasses.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/SampleRunnerBasedOnNotClasses.java
@@ -1,0 +1,39 @@
+package io.qameta.allure.junit4;
+
+import org.junit.runner.Description;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
+
+import java.lang.annotation.Annotation;
+
+public class SampleRunnerBasedOnNotClasses extends Runner {
+    @SuppressWarnings("unused")
+    public SampleRunnerBasedOnNotClasses(Class testClass) {
+        super();
+    }
+
+    @Override
+    public Description getDescription() {
+        return Description.createTestDescription(
+            "allure junit4 runner.test for non-existing classes (would be a class in normal runner)",
+            "should correctly handle non-existing classes (would be method name in normal runner)",
+            new DisplayName() {
+                @Override
+                public String value() {
+                    return "Some human readable name";
+                }
+
+                @Override
+                public Class<? extends Annotation> annotationType() {
+                    return DisplayName.class;
+                }
+            }
+        );
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+        notifier.fireTestStarted(getDescription());
+        notifier.fireTestFinished(getDescription());
+    }
+}

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/TestBasedOnSampleRunner.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/TestBasedOnSampleRunner.java
@@ -1,0 +1,7 @@
+package io.qameta.allure.junit4;
+
+import org.junit.runner.RunWith;
+
+@RunWith(SampleRunnerBasedOnNotClasses.class)
+public class TestBasedOnSampleRunner {
+}


### PR DESCRIPTION
### Context
Not every JUnit-based framework provides actual (/real/existing) class names in `Description`, so when attempting to operate on it we get NPE.

See example in #174 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
