### PR TITLE
Handle Test failures with Exceptions without message

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -183,7 +183,7 @@ public final class ResultsUtils {
     public static Optional<StatusDetails> getStatusDetails(final Throwable e) {
         return Optional.ofNullable(e)
                 .map(throwable -> new StatusDetails()
-                        .withMessage(throwable.getMessage())
+                        .withMessage(Optional.ofNullable(throwable.getMessage()).orElse(throwable.getClass().getName()))
                         .withTrace(getStackTraceAsString(throwable)));
     }
 

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/FeatureCombinationsTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/FeatureCombinationsTest.java
@@ -4,6 +4,7 @@ import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.aspects.StepsAspects;
 import io.qameta.allure.junit4.samples.AssumptionFailedTest;
 import io.qameta.allure.junit4.samples.BrokenTest;
+import io.qameta.allure.junit4.samples.BrokenWithoutMessageTest;
 import io.qameta.allure.junit4.samples.FailedTest;
 import io.qameta.allure.junit4.samples.IgnoredClassTest;
 import io.qameta.allure.junit4.samples.IgnoredTests;
@@ -113,6 +114,23 @@ public class FeatureCombinationsTest {
                 .hasSize(1)
                 .extracting(TestResult::getStatus)
                 .containsExactly(Status.BROKEN);
+        assertThat(testResults.get(0).getStatusDetails())
+                .hasFieldOrPropertyWithValue("message","Hello, everybody")
+                .hasFieldOrProperty("trace");
+    }
+
+    @Test
+    @DisplayName("Broken test without message")
+    public void shouldProcessBrokenWithoutMessageTest() throws Exception {
+        core.run(Request.aClass(BrokenWithoutMessageTest.class));
+        List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1)
+                .extracting(TestResult::getStatus)
+                .containsExactly(Status.BROKEN);
+        assertThat(testResults.get(0).getStatusDetails())
+                .hasFieldOrPropertyWithValue("message","java.lang.RuntimeException")
+                .hasFieldOrProperty("trace");
     }
 
     @Test

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/BrokenWithoutMessageTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/BrokenWithoutMessageTest.java
@@ -1,0 +1,14 @@
+package io.qameta.allure.junit4.samples;
+
+import org.junit.Test;
+
+/**
+ * @author charlie (Dmitry Baev).
+ */
+public class BrokenWithoutMessageTest {
+
+    @Test
+    public void brokenWithoutMessageTest() throws Exception {
+        throw new RuntimeException();
+    }
+}

--- a/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
@@ -144,6 +144,33 @@ public class AllureTestNgTest {
                 .hasFieldOrPropertyWithValue("status", Status.BROKEN)
                 .hasFieldOrPropertyWithValue("stage", Stage.FINISHED)
                 .hasFieldOrPropertyWithValue("name", testName);
+        assertThat(testResult.get(0).getStatusDetails()).as("Test Status Details")
+                .hasFieldOrPropertyWithValue("message","Exception")
+                .hasFieldOrProperty("trace");
+        assertThat(testResult)
+                .flatExtracting(TestResult::getSteps)
+                .hasSize(2)
+                .flatExtracting(StepResult::getStatus)
+                .contains(Status.PASSED, Status.BROKEN);
+    }
+
+    @Feature("Failed tests")
+    @Story("Broken")
+    @Test(description = "Broken testng - Exception without message")
+    public void brokenTestWithOutMessage() {
+        String testName = "brokenTestWithoutMessage";
+        runTestNgSuites("suites/brokenWithoutMessage.xml");
+        List<TestResult> testResult = results.getTestResults();
+
+        assertThat(testResult).as("Test case result has not been written").hasSize(1);
+        assertThat(testResult.get(0)).as("Unexpected broken testng property")
+                .hasFieldOrPropertyWithValue("status", Status.BROKEN)
+                .hasFieldOrPropertyWithValue("stage", Stage.FINISHED)
+                .hasFieldOrPropertyWithValue("name", testName);
+        assertThat(testResult.get(0).getStatusDetails()).as("Test Status Details")
+                .hasFieldOrPropertyWithValue("message","java.lang.RuntimeException")
+                .hasFieldOrProperty("trace");
+
         assertThat(testResult)
                 .flatExtracting(TestResult::getSteps)
                 .hasSize(2)

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/TestsWithSteps.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/TestsWithSteps.java
@@ -48,8 +48,19 @@ public class TestsWithSteps {
         broken();
     }
 
+    @Test
+    public void brokenTestWithoutMessage() {
+        stepOne();
+        brokenWithoutMessage();
+    }
+
     @Step
     private void broken() {
         throw new RuntimeException("Exception");
+    }
+
+    @Step
+    private void brokenWithoutMessage() {
+        throw new RuntimeException();
     }
 }

--- a/allure-testng/src/test/resources/suites/brokenWithoutMessage.xml
+++ b/allure-testng/src/test/resources/suites/brokenWithoutMessage.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Test suite with broken tests">
+    <test name="Test Exceptions Without Message">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.TestsWithSteps">
+                <methods>
+                    <include name="brokenTestWithoutMessage"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

Whenever test execution fails with exception without message, e.g.
```
@Test
public void testMethodWithException() throws Exception {
	throw new Exception();
}
```
or when test fails with `NullPointerException`, we encounter issues with `Categories` tab showing `404 Not Found` error (https://github.com/jenkinsci/allure-plugin/issues/193) and test page in report lacking information on exception
![screen shot 2018-01-19 at 11 34 20](https://user-images.githubusercontent.com/5063579/35146978-29918396-fd0d-11e7-8271-d958ba7d50eb.png)

This pull request suggests to use Throwable class name in case of Throwable message being empty (null)

![screen shot 2018-01-19 at 11 46 55](https://user-images.githubusercontent.com/5063579/35147351-8f18eece-fd0e-11e7-9a48-82fc8b8d7076.png)

I also added new test to `allure-testng` adapter covering this case

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2