### PR TITLE
Curl '-d' for HttpRequestAttachment has been fixed

### DIFF
--- a/allure-attachments/src/main/java/io.qameta.allure.attachment/http/HttpRequestAttachment.java
+++ b/allure-attachments/src/main/java/io.qameta.allure.attachment/http/HttpRequestAttachment.java
@@ -147,7 +147,7 @@ public class HttpRequestAttachment implements AttachmentData {
             cookies.forEach((key, value) -> appendCookie(builder, key, value));
 
             if (Objects.nonNull(body)) {
-                builder.append(" -d '").append(builder).append('\'');
+                builder.append(" -d '").append(body).append('\'');
             }
             return builder.toString();
         }


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)
Removed wrong duplication of "curl" in -d option for HttpRequestAttachment. Previously: curl ... -d 'curl... body', after: curl ... -d 'body'
![verticals_ _backend_ _autoru_api](https://user-images.githubusercontent.com/20776437/35805269-3897a938-0a8c-11e8-9504-ba7675d5c16e.jpg)


#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
