### PR TITLE
Added ability to hide @Step parameters

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/Step.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Step.java
@@ -14,6 +14,18 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface Step {
 
+    /**
+     * The step text.
+     *
+     * @return the step text.
+     */
     String value() default "";
+
+    /**
+     * Option for hide step parameters.
+     *
+     * @return boolean flag to disable step parameters showing.
+     */
+    boolean hideParams() default false;
 
 }

--- a/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
@@ -45,8 +45,9 @@ public class StepsAspects {
 
         final StepResult result = new StepResult()
                 .withName(name);
-        if (!step.hideParams())
+        if (!step.hideParams()) {
             result.withParameters(getParameters(methodSignature, joinPoint.getArgs()));
+        }
         getLifecycle().startStep(uuid, result);
         try {
             final Object proceed = joinPoint.proceed();

--- a/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
@@ -44,8 +44,9 @@ public class StepsAspects {
                 .orElse(methodSignature.getName());
 
         final StepResult result = new StepResult()
-                .withName(name)
-                .withParameters(getParameters(methodSignature, joinPoint.getArgs()));
+                .withName(name);
+        if (!step.hideParams())
+            result.withParameters(getParameters(methodSignature, joinPoint.getArgs()));
         getLifecycle().startStep(uuid, result);
         try {
             final Object proceed = joinPoint.proceed();

--- a/allure-java-commons/src/test/java/io/qameta/allure/StepsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/StepsTest.java
@@ -71,6 +71,17 @@ public class StepsTest {
                 );
     }
 
+    @Test
+    public void shouldSupportParametersHide() throws Exception {
+        final AllureResultsWriterStub results = runStep(() -> stepWithHiddenParams("a", "b"));
+
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getSteps)
+                .flatExtracting(ExecutableItem::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue)
+                .contains();
+    }
+
     @Step("\"{user.emails.address}\", \"{user.emails}\", \"{user.emails.attachments}\", \"{user.password}\", \"{}\"," +
             " \"{user.card.number}\", \"{missing}\", {staySignedIn}")
     private void loginWith(final DummyUser user, final boolean staySignedIn) {
@@ -82,6 +93,10 @@ public class StepsTest {
 
     @Step
     public void step(final String... parameters) {
+    }
+
+    @Step(hideParams = true)
+    public void stepWithHiddenParams(final String param1, final String param2) {
     }
 
     public static AllureResultsWriterStub runStep(final Runnable runnable) {


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

Now we can hide @Step parameters by new annotation field hideParams. Default it's false.
```
@Step(hideParams = true)

@Step(value = "Step text", hideParams = true)
```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests
- [x] Tests are passed

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
