### PR TITLE
Fix NPEs when using @Parameter with private or uninitialized fields

### DIFF
--- a/allure-java-migration/src/main/java/io/qameta/allure/aspects/Allure1Annotations.java
+++ b/allure-java-migration/src/main/java/io/qameta/allure/aspects/Allure1Annotations.java
@@ -111,9 +111,10 @@ final class Allure1Annotations {
         final List<Field> fields = FieldUtils.getFieldsListWithAnnotation(getType(),
                 ru.yandex.qatools.allure.annotations.Parameter.class);
 
-        return fields.stream().collect(
-                Collectors.toMap(Allure1Utils::getParameterName, f -> Allure1Utils.getParameterValue(f, target))
-        );
+        return fields
+                .stream()
+                .filter(f -> Allure1Utils.getParameterValue(f, target) != null)
+                .collect(Collectors.toMap(Allure1Utils::getParameterName, f -> Allure1Utils.getParameterValue(f, target)));
     }
 
     private Class<?> getType() {

--- a/allure-java-migration/src/main/java/io/qameta/allure/aspects/Allure1Annotations.java
+++ b/allure-java-migration/src/main/java/io/qameta/allure/aspects/Allure1Annotations.java
@@ -114,7 +114,9 @@ final class Allure1Annotations {
         return fields
                 .stream()
                 .filter(f -> Allure1Utils.getParameterValue(f, target) != null)
-                .collect(Collectors.toMap(Allure1Utils::getParameterName, f -> Allure1Utils.getParameterValue(f, target)));
+                .collect(
+                        Collectors.toMap(Allure1Utils::getParameterName, f -> Allure1Utils.getParameterValue(f, target))
+                );
     }
 
     private Class<?> getType() {

--- a/allure-java-migration/src/main/java/io/qameta/allure/aspects/Allure1Utils.java
+++ b/allure-java-migration/src/main/java/io/qameta/allure/aspects/Allure1Utils.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -172,7 +173,12 @@ final class Allure1Utils {
 
     public static String getParameterValue(final Field field, final Object target) {
         try {
-            return field.get(target).toString();
+            field.setAccessible(true);
+
+            return Optional
+                    .ofNullable(field.get(target))
+                    .map(String::valueOf)
+                    .orElse(null);
         } catch (IllegalAccessException e) {
             return null;
         }

--- a/allure-java-migration/src/test/java/io/qameta/allure/aspects/Allure1TestCaseAspectsTest.java
+++ b/allure-java-migration/src/test/java/io/qameta/allure/aspects/Allure1TestCaseAspectsTest.java
@@ -5,14 +5,19 @@ import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.test.AllureResultsWriterStub;
+
+import org.assertj.core.api.Condition;
+import org.assertj.core.data.Index;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Issue;
 import ru.yandex.qatools.allure.annotations.Issues;
+import ru.yandex.qatools.allure.annotations.Parameter;
 import ru.yandex.qatools.allure.annotations.Severity;
 import ru.yandex.qatools.allure.annotations.Stories;
 import ru.yandex.qatools.allure.annotations.TestCaseId;
@@ -24,6 +29,7 @@ import java.util.Collection;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Index.atIndex;
 
 /**
  * eroshenkoam
@@ -124,6 +130,16 @@ public class Allure1TestCaseAspectsTest {
 
     }
 
+    @Test
+    public void shouldProcessParameterAnnotation() {
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getParameters)
+                .has(new Condition<>(p -> p.getName().equals("parameterWithoutName") && p.getValue().equals("testValue1"), ""), atIndex(0))
+                .has(new Condition<>(p -> p.getName().equals("customParameterName") && p.getValue().equals("testValue2"), ""), atIndex(1))
+                .extracting(io.qameta.allure.model.Parameter::getName)
+                .doesNotContain("uninitializedParameter");
+    }
+
     public interface SimpleTest {
 
         void testSomething();
@@ -137,6 +153,15 @@ public class Allure1TestCaseAspectsTest {
     @Features("feature1")
     public static class TestNgTest implements SimpleTest {
 
+        @Parameter
+        private String parameterWithoutName;
+
+        @Parameter("customParameterName")
+        private String parameterWithName;
+
+        @Parameter
+        private String uninitializedParameter;
+
         @Title("testcase")
         @Description("testcase description")
         @Issue("ISSUE-2")
@@ -147,7 +172,8 @@ public class Allure1TestCaseAspectsTest {
         @Severity(SeverityLevel.CRITICAL)
         @org.testng.annotations.Test
         public void testSomething() {
-
+            parameterWithoutName = "testValue1";
+            parameterWithName = "testValue2";
         }
 
     }
@@ -159,6 +185,15 @@ public class Allure1TestCaseAspectsTest {
     @Features("feature1")
     public static class JunitTest implements SimpleTest {
 
+        @Parameter
+        private String parameterWithoutName;
+
+        @Parameter("customParameterName")
+        private String parameterWithName;
+
+        @Parameter
+        private String uninitializedParameter;
+
         @Title("testcase")
         @Description("testcase description")
         @Issue("ISSUE-2")
@@ -169,7 +204,8 @@ public class Allure1TestCaseAspectsTest {
         @Severity(SeverityLevel.CRITICAL)
         @org.junit.Test
         public void testSomething() {
-
+            parameterWithoutName = "testValue1";
+            parameterWithName = "testValue2";
         }
 
     }

--- a/allure-java-migration/src/test/java/io/qameta/allure/aspects/Allure1TestCaseAspectsTest.java
+++ b/allure-java-migration/src/test/java/io/qameta/allure/aspects/Allure1TestCaseAspectsTest.java
@@ -137,7 +137,7 @@ public class Allure1TestCaseAspectsTest {
                 .has(new Condition<>(p -> p.getName().equals("parameterWithoutName") && p.getValue().equals("testValue1"), ""), atIndex(0))
                 .has(new Condition<>(p -> p.getName().equals("customParameterName") && p.getValue().equals("testValue2"), ""), atIndex(1))
                 .extracting(io.qameta.allure.model.Parameter::getName)
-                .doesNotContain("uninitializedParameter");
+                .doesNotContain("parameterWithName", "uninitializedParameter");
     }
 
     public interface SimpleTest {

--- a/allure-java-migration/src/test/java/io/qameta/allure/aspects/Allure1TestCaseAspectsTest.java
+++ b/allure-java-migration/src/test/java/io/qameta/allure/aspects/Allure1TestCaseAspectsTest.java
@@ -5,14 +5,11 @@ import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.test.AllureResultsWriterStub;
-
 import org.assertj.core.api.Condition;
-import org.assertj.core.data.Index;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 import ru.yandex.qatools.allure.annotations.Description;
 import ru.yandex.qatools.allure.annotations.Features;
 import ru.yandex.qatools.allure.annotations.Issue;
@@ -29,7 +26,6 @@ import java.util.Collection;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.data.Index.atIndex;
 
 /**
  * eroshenkoam
@@ -134,8 +130,8 @@ public class Allure1TestCaseAspectsTest {
     public void shouldProcessParameterAnnotation() {
         assertThat(results.getTestResults())
                 .flatExtracting(TestResult::getParameters)
-                .has(parameterWithNameAndValue("parameterWithoutName", "testValue1"), atIndex(0))
-                .has(parameterWithNameAndValue("customParameterName", "testValue2"), atIndex(1))
+                .haveExactly(1, parameterWithNameAndValue("parameterWithoutName", "testValue1"))
+                .haveExactly(1, parameterWithNameAndValue("customParameterName", "testValue2"))
                 .extracting(io.qameta.allure.model.Parameter::getName)
                 .doesNotContain("parameterWithName", "uninitializedParameter");
     }

--- a/allure-java-migration/src/test/java/io/qameta/allure/aspects/Allure1TestCaseAspectsTest.java
+++ b/allure-java-migration/src/test/java/io/qameta/allure/aspects/Allure1TestCaseAspectsTest.java
@@ -134,8 +134,8 @@ public class Allure1TestCaseAspectsTest {
     public void shouldProcessParameterAnnotation() {
         assertThat(results.getTestResults())
                 .flatExtracting(TestResult::getParameters)
-                .has(new Condition<>(p -> p.getName().equals("parameterWithoutName") && p.getValue().equals("testValue1"), ""), atIndex(0))
-                .has(new Condition<>(p -> p.getName().equals("customParameterName") && p.getValue().equals("testValue2"), ""), atIndex(1))
+                .has(parameterWithNameAndValue("parameterWithoutName", "testValue1"), atIndex(0))
+                .has(parameterWithNameAndValue("customParameterName", "testValue2"), atIndex(1))
                 .extracting(io.qameta.allure.model.Parameter::getName)
                 .doesNotContain("parameterWithName", "uninitializedParameter");
     }
@@ -208,5 +208,11 @@ public class Allure1TestCaseAspectsTest {
             parameterWithName = "testValue2";
         }
 
+    }
+
+    private static Condition<io.qameta.allure.model.Parameter> parameterWithNameAndValue(final String name,
+                                                                                         final String value) {
+        return new Condition<>(parameter -> parameter.getName().equals(name) && parameter.getValue().equals(value),
+                "parameter with name \"%s\" and value \"%s\"", name, value);
     }
 }


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
This fixes the issues as described in #206 

**Edit:** ~Apparently it'll fix #129 too~ 
**Edit2:** Nope, it doesn‘t... That one is about method parameters.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
