### PR TITLE
Fix of IOException in apache httpclient integration

### DIFF
--- a/allure-httpclient/src/test/java/io/qameta/allure/httpclient/AllureHttpClientTest.java
+++ b/allure-httpclient/src/test/java/io/qameta/allure/httpclient/AllureHttpClientTest.java
@@ -8,6 +8,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +33,8 @@ import static org.mockito.Mockito.verify;
  */
 public class AllureHttpClientTest {
 
+    private static final String BODY_STRING = "Hello world!";
+
     private WireMockServer server;
 
     @Before
@@ -42,7 +45,7 @@ public class AllureHttpClientTest {
 
         stubFor(get(urlEqualTo("/hello"))
                 .willReturn(aResponse()
-                        .withBody("Hello world!")));
+                        .withBody(BODY_STRING)));
     }
 
     @SuppressWarnings("unchecked")
@@ -58,6 +61,8 @@ public class AllureHttpClientTest {
             final HttpGet httpGet = new HttpGet(String.format("http://localhost:%d/hello", server.port()));
             try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
                 response.getStatusLine().getStatusCode();
+                assertThat(EntityUtils.toString(response.getEntity()))
+                        .isEqualTo(BODY_STRING);
             }
         }
 
@@ -84,6 +89,8 @@ public class AllureHttpClientTest {
             final HttpGet httpGet = new HttpGet(String.format("http://localhost:%d/hello", server.port()));
             try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
                 response.getStatusLine().getStatusCode();
+                assertThat(EntityUtils.toString(response.getEntity()))
+                        .isEqualTo(BODY_STRING);
             }
         }
 


### PR DESCRIPTION
IOException "Attempted read from closed stream" occures in case of getting access to HttpEntity, already processed with AllureHttpClientResponse interceptor. It's implies from the impossibility to consume the same ImputStream twice.

Current PR allows to dump content of http responce by providing auxilliary LoggableEntity with method getBody()