### PR TITLE
Added @Disabled tests handling

### DIFF
--- a/allure-junit-platform/src/main/java/io/qameta/allure/junit5/AllureJunit5.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junit5/AllureJunit5.java
@@ -37,6 +37,8 @@ public class AllureJunit5 implements TestExecutionListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(AllureJunit5.class);
 
     private static final String TAG = "tag";
+    private static final String SUITE = "suite";
+    private static final String PACKAGE = "package";
 
 
     private final ThreadLocal<String> tests
@@ -72,8 +74,8 @@ public class AllureJunit5 implements TestExecutionListener {
 
             methodSource.ifPresent(source -> {
                 result.setDescription(getDescription(source));
-                result.getLabels().add(new Label().withName("suite").withValue(getSuite(source)));
-                result.getLabels().add(new Label().withName("package").withValue(source.getClassName()));
+                result.getLabels().add(new Label().withName(SUITE).withValue(getSuite(source)));
+                result.getLabels().add(new Label().withName(PACKAGE).withValue(source.getClassName()));
             });
 
             getLifecycle().scheduleTestCase(result);
@@ -98,8 +100,8 @@ public class AllureJunit5 implements TestExecutionListener {
 
             methodSource.ifPresent(source -> {
                 result.setDescription(getDescription(source));
-                result.getLabels().add(new Label().withName("suite").withValue(getSuite(source)));
-                result.getLabels().add(new Label().withName("package").withValue(source.getClassName()));
+                result.getLabels().add(new Label().withName(SUITE).withValue(getSuite(source)));
+                result.getLabels().add(new Label().withName(PACKAGE).withValue(source.getClassName()));
             });
 
             getLifecycle().scheduleTestCase(result);

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junit5/AllureJunit5.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junit5/AllureJunit5.java
@@ -84,11 +84,8 @@ public class AllureJunit5 implements TestExecutionListener {
     }
 
     @Override
-    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+    public void executionSkipped(final TestIdentifier testIdentifier, final String reason) {
         if (testIdentifier.isTest()) {
-            final Optional<MethodSource> methodSource = testIdentifier.getSource()
-                    .filter(MethodSource.class::isInstance)
-                    .map(MethodSource.class::cast);
             final String uuid = tests.get();
             final TestResult result = new TestResult()
                     .withUuid(uuid)
@@ -98,11 +95,15 @@ public class AllureJunit5 implements TestExecutionListener {
                     .withStage(Stage.FINISHED)
                     .withStatus(SKIPPED);
 
-            methodSource.ifPresent(source -> {
-                result.setDescription(getDescription(source));
-                result.getLabels().add(new Label().withName(SUITE).withValue(getSuite(source)));
-                result.getLabels().add(new Label().withName(PACKAGE).withValue(source.getClassName()));
-            });
+            testIdentifier
+                    .getSource()
+                    .filter(MethodSource.class::isInstance)
+                    .map(MethodSource.class::cast)
+                    .ifPresent(source -> {
+                        result.setDescription(getDescription(source));
+                        result.getLabels().add(new Label().withName(SUITE).withValue(getSuite(source)));
+                        result.getLabels().add(new Label().withName(PACKAGE).withValue(source.getClassName()));
+                    });
 
             getLifecycle().scheduleTestCase(result);
             getLifecycle().startTestCase(uuid);

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junit5/AllureJunit5.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junit5/AllureJunit5.java
@@ -92,8 +92,7 @@ public class AllureJunit5 implements TestExecutionListener {
                     .withName(testIdentifier.getDisplayName())
                     .withLabels(getTags(testIdentifier))
                     .withHistoryId(getHistoryId(testIdentifier))
-                    .withStage(Stage.FINISHED)
-                    .withStatus(SKIPPED);
+                    .withStage(Stage.RUNNING);
 
             testIdentifier
                     .getSource()
@@ -107,6 +106,13 @@ public class AllureJunit5 implements TestExecutionListener {
 
             getLifecycle().scheduleTestCase(result);
             getLifecycle().startTestCase(uuid);
+
+            tests.remove();
+            getLifecycle().updateTestCase(uuid, testResult -> {
+                testResult.setStage(Stage.FINISHED);
+                testResult.setStatus(SKIPPED);
+            });
+
             getLifecycle().stopTestCase(uuid);
             getLifecycle().writeTestCase(uuid);
         }

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junit5/AllureJunit5.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junit5/AllureJunit5.java
@@ -112,7 +112,6 @@ public class AllureJunit5 implements TestExecutionListener {
                 testResult.setStage(Stage.FINISHED);
                 testResult.setStatus(SKIPPED);
             });
-
             getLifecycle().stopTestCase(uuid);
             getLifecycle().writeTestCase(uuid);
         }

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junit5/AllureJunit5Test.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junit5/AllureJunit5Test.java
@@ -251,6 +251,17 @@ public class AllureJunit5Test {
                 .contains("Test description");
     }
 
+    @Test
+    void shouldProcessDisabledTests() {
+        runClasses(DisabledTests.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1)
+                .first()
+                .hasFieldOrPropertyWithValue("status", Status.SKIPPED);
+    }
+
     private void runClasses(Class<?>... classes) {
         final ClassSelector[] classSelectors = Stream.of(classes)
                 .map(DiscoverySelectors::selectClass)

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junit5/features/DisabledTests.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junit5/features/DisabledTests.java
@@ -1,0 +1,13 @@
+package io.qameta.allure.junit5.features;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class DisabledTests {
+
+    @Test
+    @Disabled
+    void disabledByAnnotation() {
+
+    }
+}

--- a/allure-junit5/src/test/java/io/qameta/allure/junit5/AnnotationsTest.java
+++ b/allure-junit5/src/test/java/io/qameta/allure/junit5/AnnotationsTest.java
@@ -53,67 +53,67 @@ public class AnnotationsTest {
     }
 
 
-//    @Test
-//    void shouldProcessClassLabels() {
-//        runClasses(TestWithClassLabels.class);
-//        final List<TestResult> testResults = results.getTestResults();
-//        assertThat(testResults)
-//                .hasSize(1)
-//                .flatExtracting(TestResult::getLabels)
-//                .extracting(Label::getValue)
-//                .contains(
-//                        "epic1", "epic2", "epic3",
-//                        "feature1", "feature2", "feature3",
-//                        "story1", "story2", "story3",
-//                        "some-owner"
-//                );
-//    }
-//
-//    @Test
-//    void shouldProcessMethodLinks() {
-//        runClasses(TestWithMethodLinks.class);
-//        final List<TestResult> testResults = results.getTestResults();
-//        assertThat(testResults)
-//                .hasSize(1)
-//                .flatExtracting(TestResult::getLinks)
-//                .extracting(Link::getName)
-//                .contains(
-//                        "LINK-1", "LINK-2", "LINK-3",
-//                        "ISSUE-1", "ISSUE-2", "ISSUE-3",
-//                        "TMS-1", "TMS-2", "TMS-3"
-//                );
-//    }
-//
-//    @Test
-//    void shouldProcessClassLinks() {
-//        runClasses(TestWithClassLinks.class);
-//        final List<TestResult> testResults = results.getTestResults();
-//        assertThat(testResults)
-//                .hasSize(1)
-//                .flatExtracting(TestResult::getLinks)
-//                .extracting(Link::getName)
-//                .contains(
-//                        "LINK-1", "LINK-2", "LINK-3",
-//                        "ISSUE-1", "ISSUE-2", "ISSUE-3",
-//                        "TMS-1", "TMS-2", "TMS-3"
-//                );
-//    }
+    @Test
+    void shouldProcessClassLabels() {
+        runClasses(TestWithClassLabels.class);
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1)
+                .flatExtracting(TestResult::getLabels)
+                .extracting(Label::getValue)
+                .contains(
+                        "epic1", "epic2", "epic3",
+                        "feature1", "feature2", "feature3",
+                        "story1", "story2", "story3",
+                        "some-owner"
+                );
+    }
+
+    @Test
+    void shouldProcessMethodLinks() {
+        runClasses(TestWithMethodLinks.class);
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1)
+                .flatExtracting(TestResult::getLinks)
+                .extracting(Link::getName)
+                .contains(
+                        "LINK-1", "LINK-2", "LINK-3",
+                        "ISSUE-1", "ISSUE-2", "ISSUE-3",
+                        "TMS-1", "TMS-2", "TMS-3"
+                );
+    }
+
+    @Test
+    void shouldProcessClassLinks() {
+        runClasses(TestWithClassLinks.class);
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1)
+                .flatExtracting(TestResult::getLinks)
+                .extracting(Link::getName)
+                .contains(
+                        "LINK-1", "LINK-2", "LINK-3",
+                        "ISSUE-1", "ISSUE-2", "ISSUE-3",
+                        "TMS-1", "TMS-2", "TMS-3"
+                );
+    }
 
     @Test
     @Disabled("not implemented")
     void shouldProcessDynamicTestLabels() {
-//        runClasses(DynamicTests.class);
-//        final List<TestResult> testResults = results.getTestResults();
-//        assertThat(testResults)
-//                .hasSize(3)
-//                .flatExtracting(TestResult::getLabels)
-//                .extracting(Label::getValue)
-//                .contains(
-//                        "epic1", "epic2", "epic3",
-//                        "feature1", "feature2", "feature3",
-//                        "story1", "story2", "story3",
-//                        "some-owner"
-//                );
+        runClasses(DynamicTests.class);
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(3)
+                .flatExtracting(TestResult::getLabels)
+                .extracting(Label::getValue)
+                .contains(
+                        "epic1", "epic2", "epic3",
+                        "feature1", "feature2", "feature3",
+                        "story1", "story2", "story3",
+                        "some-owner"
+                );
     }
 
     @BeforeEach

--- a/allure-junit5/src/test/java/io/qameta/allure/junit5/AnnotationsTest.java
+++ b/allure-junit5/src/test/java/io/qameta/allure/junit5/AnnotationsTest.java
@@ -53,67 +53,67 @@ public class AnnotationsTest {
     }
 
 
-    @Test
-    void shouldProcessClassLabels() {
-        runClasses(TestWithClassLabels.class);
-        final List<TestResult> testResults = results.getTestResults();
-        assertThat(testResults)
-                .hasSize(1)
-                .flatExtracting(TestResult::getLabels)
-                .extracting(Label::getValue)
-                .contains(
-                        "epic1", "epic2", "epic3",
-                        "feature1", "feature2", "feature3",
-                        "story1", "story2", "story3",
-                        "some-owner"
-                );
-    }
-
-    @Test
-    void shouldProcessMethodLinks() {
-        runClasses(TestWithMethodLinks.class);
-        final List<TestResult> testResults = results.getTestResults();
-        assertThat(testResults)
-                .hasSize(1)
-                .flatExtracting(TestResult::getLinks)
-                .extracting(Link::getName)
-                .contains(
-                        "LINK-1", "LINK-2", "LINK-3",
-                        "ISSUE-1", "ISSUE-2", "ISSUE-3",
-                        "TMS-1", "TMS-2", "TMS-3"
-                );
-    }
-
-    @Test
-    void shouldProcessClassLinks() {
-        runClasses(TestWithClassLinks.class);
-        final List<TestResult> testResults = results.getTestResults();
-        assertThat(testResults)
-                .hasSize(1)
-                .flatExtracting(TestResult::getLinks)
-                .extracting(Link::getName)
-                .contains(
-                        "LINK-1", "LINK-2", "LINK-3",
-                        "ISSUE-1", "ISSUE-2", "ISSUE-3",
-                        "TMS-1", "TMS-2", "TMS-3"
-                );
-    }
+//    @Test
+//    void shouldProcessClassLabels() {
+//        runClasses(TestWithClassLabels.class);
+//        final List<TestResult> testResults = results.getTestResults();
+//        assertThat(testResults)
+//                .hasSize(1)
+//                .flatExtracting(TestResult::getLabels)
+//                .extracting(Label::getValue)
+//                .contains(
+//                        "epic1", "epic2", "epic3",
+//                        "feature1", "feature2", "feature3",
+//                        "story1", "story2", "story3",
+//                        "some-owner"
+//                );
+//    }
+//
+//    @Test
+//    void shouldProcessMethodLinks() {
+//        runClasses(TestWithMethodLinks.class);
+//        final List<TestResult> testResults = results.getTestResults();
+//        assertThat(testResults)
+//                .hasSize(1)
+//                .flatExtracting(TestResult::getLinks)
+//                .extracting(Link::getName)
+//                .contains(
+//                        "LINK-1", "LINK-2", "LINK-3",
+//                        "ISSUE-1", "ISSUE-2", "ISSUE-3",
+//                        "TMS-1", "TMS-2", "TMS-3"
+//                );
+//    }
+//
+//    @Test
+//    void shouldProcessClassLinks() {
+//        runClasses(TestWithClassLinks.class);
+//        final List<TestResult> testResults = results.getTestResults();
+//        assertThat(testResults)
+//                .hasSize(1)
+//                .flatExtracting(TestResult::getLinks)
+//                .extracting(Link::getName)
+//                .contains(
+//                        "LINK-1", "LINK-2", "LINK-3",
+//                        "ISSUE-1", "ISSUE-2", "ISSUE-3",
+//                        "TMS-1", "TMS-2", "TMS-3"
+//                );
+//    }
 
     @Test
     @Disabled("not implemented")
     void shouldProcessDynamicTestLabels() {
-        runClasses(DynamicTests.class);
-        final List<TestResult> testResults = results.getTestResults();
-        assertThat(testResults)
-                .hasSize(3)
-                .flatExtracting(TestResult::getLabels)
-                .extracting(Label::getValue)
-                .contains(
-                        "epic1", "epic2", "epic3",
-                        "feature1", "feature2", "feature3",
-                        "story1", "story2", "story3",
-                        "some-owner"
-                );
+//        runClasses(DynamicTests.class);
+//        final List<TestResult> testResults = results.getTestResults();
+//        assertThat(testResults)
+//                .hasSize(3)
+//                .flatExtracting(TestResult::getLabels)
+//                .extracting(Label::getValue)
+//                .contains(
+//                        "epic1", "epic2", "epic3",
+//                        "feature1", "feature2", "feature3",
+//                        "story1", "story2", "story3",
+//                        "some-owner"
+//                );
     }
 
     @BeforeEach


### PR DESCRIPTION

### Context
This pull request fixes problem, that tests with annotation `@Disabled` not shown in report.
Allure shows skipped test only in case of assumption.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2