### PR TITLE
Added loading of allure properties from context class loader

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/util/PropertiesUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/PropertiesUtils.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Objects;
 import java.util.Properties;
 
 /**
@@ -22,15 +21,20 @@ public final class PropertiesUtils {
 
     public static Properties loadAllureProperties() {
         final Properties properties = new Properties();
-        if (Objects.nonNull(ClassLoader.getSystemResource(ALLURE_PROPERTIES_FILE))) {
-            try (InputStream stream = ClassLoader.getSystemResourceAsStream(ALLURE_PROPERTIES_FILE)) {
+        loadPropertiesFrom(ClassLoader.getSystemClassLoader(), properties);
+        loadPropertiesFrom(Thread.currentThread().getContextClassLoader(), properties);
+        properties.putAll(System.getProperties());
+        return properties;
+    }
+
+    private static void loadPropertiesFrom(final ClassLoader classLoader, final Properties properties) {
+        if (classLoader.getResource(ALLURE_PROPERTIES_FILE) != null) {
+            try (InputStream stream = classLoader.getResourceAsStream(ALLURE_PROPERTIES_FILE)) {
                 properties.load(stream);
             } catch (IOException e) {
                 LOGGER.error("Error while reading allure.properties file from classpath: %s", e.getMessage());
             }
         }
-        properties.putAll(System.getProperties());
-        return properties;
     }
 
 }


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)
There is a problem with using allure.properties in build tool if it doesn't fork JVM (sbt for example) since it only tries to locate resource in system classloader which in case of non-forked jvm has no allure.properties, but has them in context classloader.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests - it is pretty hard to write one in this case, so relying on IDEAs extract method + small changes :smile: 

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
