### PR TITLE
Fixing issue when OkHttp request method in attachment is always GET

### DIFF
--- a/allure-okhttp3/src/main/java/io/qameta/allure/okhttp3/AllureOkHttp3.java
+++ b/allure-okhttp3/src/main/java/io/qameta/allure/okhttp3/AllureOkHttp3.java
@@ -45,7 +45,8 @@ public class AllureOkHttp3 implements Interceptor {
         final Request request = chain.request();
         final String requestUrl = request.url().toString();
         final HttpRequestAttachment.Builder requestAttachmentBuilder = HttpRequestAttachment.Builder
-                .create("Request", requestUrl).withHeaders(toMapConverter(request.headers().toMultimap()));
+                .create("Request", requestUrl).withMethod(request.method())
+                .withHeaders(toMapConverter(request.headers().toMultimap()));
 
         final RequestBody requestBody = request.body();
         if (Objects.nonNull(requestBody)) {


### PR DESCRIPTION
At the moment attachment created by this interceptor always shows default value GET defined in template: 
<#if data.method??>${data.method}<#else>GET</#if> 

because actual method value is never defined. This small fix resolves that problem.

[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
