### PR TITLE
Fix concurrency when running steps in parallel

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/internal/AllureStorage.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/internal/AllureStorage.java
@@ -27,6 +27,11 @@ public class AllureStorage {
         public LinkedList<String> initialValue() {
             return new LinkedList<>();
         }
+
+        @Override
+        protected LinkedList<String> childValue(LinkedList<String> strings) {
+            return new LinkedList<>(strings);
+        }
     };
 
     @SuppressWarnings("PMD.NullAssignment")

--- a/allure-java-commons/src/main/java/io/qameta/allure/internal/AllureStorage.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/internal/AllureStorage.java
@@ -29,8 +29,8 @@ public class AllureStorage {
         }
 
         @Override
-        protected LinkedList<String> childValue(LinkedList<String> strings) {
-            return new LinkedList<>(strings);
+        protected LinkedList<String> childValue(final LinkedList<String> parentStepContext) {
+            return new LinkedList<>(parentStepContext);
         }
     };
 


### PR DESCRIPTION
[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

Modified AllureStorage to work properly when steps are executed in multiple threads.

**Before:**
![screenshot from 2018-09-21 14-19-14](https://user-images.githubusercontent.com/5463696/45878348-5cde5f00-bda9-11e8-8178-0991585184e4.png)

**After:**
![screenshot from 2018-09-21 14-15-02](https://user-images.githubusercontent.com/5463696/45878306-433d1780-bda9-11e8-98b9-a3a2fefd2e20.png)


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
