### PR TITLE
Description processing fix for inner class param type

### DIFF
--- a/allure-descriptions-javadoc/src/main/java/io/qameta/allure/descriptions/DescriptionsProcessor.java
+++ b/allure-descriptions-javadoc/src/main/java/io/qameta/allure/descriptions/DescriptionsProcessor.java
@@ -54,7 +54,19 @@ public class DescriptionsProcessor extends AbstractProcessor {
             }
             final String docs = elementUtils.getDocComment(el);
             final List<String> typeParams = ((ExecutableElement) el).getParameters().stream()
-                    .map(param -> param.asType().toString()).collect(Collectors.toList());
+                    .map(param -> {
+                        final String parameterTypeAsString = param.asType().toString();
+                        final Element methodSymbol = param.getEnclosingElement();
+                        final Element typeOrPackage = methodSymbol.getEnclosingElement();
+                        if (typeOrPackage instanceof TypeElement) {
+                            final int indexOfInnerClassSeparator = parameterTypeAsString.lastIndexOf('.');
+                            final StringBuilder stringBuilder = new StringBuilder(parameterTypeAsString);
+                            stringBuilder.replace(indexOfInnerClassSeparator, indexOfInnerClassSeparator + 1, "$");
+                            return stringBuilder.toString();
+                        } else {
+                            return parameterTypeAsString;
+                        }
+                    }).collect(Collectors.toList());
             final String name = el.getSimpleName().toString();
 
             final String hash = generateMethodSignatureHash(el.getEnclosingElement().toString(), name, typeParams);

--- a/allure-descriptions-javadoc/src/test/java/io/qameta/allure/descriptions/test/ProcessDescriptionsTest.java
+++ b/allure-descriptions-javadoc/src/test/java/io/qameta/allure/descriptions/test/ProcessDescriptionsTest.java
@@ -1,5 +1,6 @@
 package io.qameta.allure.descriptions.test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
@@ -11,6 +12,7 @@ import javax.tools.StandardLocation;
 
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
+import static io.qameta.allure.util.ResultsUtils.generateMethodSignatureHash;
 
 /**
  * @author Egor Borisov ehborisov@gmail.com
@@ -46,4 +48,50 @@ public class ProcessDescriptionsTest {
         assertThat(compilation).generatedFile(StandardLocation.CLASS_OUTPUT,
                 ALLURE_PACKAGE_NAME, expectedMethodSignatureHash);
     }
+
+    @Test
+    public void descriptionOfTestWithParameterTypeAsInnerClass() {
+        final String expectedMethodSignatureHash = generateMethodSignatureHash(
+                "io.qameta.allure.descriptions.test.DescriptionSample",
+                "sampleTest",
+                ImmutableList.of("io.qameta.allure.descriptions.test.DescriptionSample$Inner"));
+
+        JavaFileObject source = JavaFileObjects
+                .forSourceString("io.qameta.allure.descriptions.test.DescriptionSample",
+                        "package io.qameta.allure.descriptions.test;\n" +
+                                "\n" +
+                                "import io.qameta.allure.Description;\n" +
+                                "import org.testng.annotations.DataProvider;\n" +
+                                "import org.testng.annotations.Test;\n" +
+                                "\n" +
+                                "public class DescriptionSample {\n" +
+                                "\n" +
+                                "    /**\n" +
+                                "     * Captured javadoc fixture description\n" +
+                                "     */\n" +
+                                "    @Description(useJavaDoc = true)\n" +
+                                "    @DataProvider(name = \"dataProvider\")\n" +
+                                "    public Object[][] getTestData() {\n" +
+                                "        return new Inner[][]{\n" +
+                                "                {new Inner()}\n" +
+                                "        };\n" +
+                                "    }\n" +
+                                "\n" +
+                                "    /**\n" +
+                                "     * Captured javadoc test description\n" +
+                                "     */\n" +
+                                "    @Test(dataProvider = \"dataProvider\")\n" +
+                                "    @Description(useJavaDoc = true)\n" +
+                                "    public void sampleTest(Inner dataProvider) {\n" +
+                                "    }\n" +
+                                "\n" +
+                                "    class Inner {}\n" +
+                                "\n" +
+                                "}");
+        Compiler compiler = javac().withProcessors(new DescriptionsProcessor());
+        Compilation compilation = compiler.compile(source);
+        assertThat(compilation)
+                .generatedFile(StandardLocation.CLASS_OUTPUT, ALLURE_PACKAGE_NAME, expectedMethodSignatureHash);
+    }
+
 }

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -283,6 +283,9 @@ public final class ResultsUtils {
 
     private static Optional<String> readResource(final ClassLoader classLoader, final String resourceName) {
         try (InputStream is = classLoader.getResourceAsStream(resourceName)) {
+            if (is == null) {
+                throw new IOException();
+            }
             final byte[] bytes = IOUtils.toByteArray(is);
             return Optional.of(new String(bytes, StandardCharsets.UTF_8));
         } catch (IOException e) {

--- a/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
@@ -1,14 +1,13 @@
 package io.qameta.allure;
 
+import io.qameta.allure.model.ExecutableItem;
+import io.qameta.allure.util.ResultsUtils;
 import org.junit.Test;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 
-import static io.qameta.allure.util.ResultsUtils.ISSUE_LINK_TYPE;
-import static io.qameta.allure.util.ResultsUtils.TMS_LINK_TYPE;
-import static io.qameta.allure.util.ResultsUtils.createIssueLink;
-import static io.qameta.allure.util.ResultsUtils.createLink;
-import static io.qameta.allure.util.ResultsUtils.createTmsLink;
+import static io.qameta.allure.util.ResultsUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -120,4 +119,24 @@ public class ResultsUtilsTest {
                 .hasFieldOrPropertyWithValue("url", null)
                 .hasFieldOrPropertyWithValue("type", TMS_LINK_TYPE);
     }
+
+    /**
+     * Javadoc description is needed for proper checking of {@link ResultsUtils#processDescription}
+     */
+    @Description(useJavaDoc = true)
+    @Test
+    public void shouldNotThrowExceptionIfAllureDescriptionDoesNotExist() throws NoSuchMethodException {
+        ExecutableItem mockedExecutableItem = new ExecutableItem() {};
+        Method thisTestMethod = getClass().getMethod("shouldNotThrowExceptionIfAllureDescriptionDoesNotExist", (Class<?>[]) null);
+
+        Exception actualException = null;
+        try {
+            processDescription(getClass().getClassLoader(), thisTestMethod, mockedExecutableItem);
+        } catch (Exception e) {
+            actualException = e;
+        }
+        assertThat(actualException)
+                .isNull();
+    }
+
 }


### PR DESCRIPTION
While using allure-testng for parameterized test methods with inner class type parameters, NPE occured with following stacktrace

`java.lang.NullPointerException
    at org.apache.tika.io.IOUtils.copyLarge(IOUtils.java:937)
    at org.apache.tika.io.IOUtils.copy(IOUtils.java:911)
    at org.apache.tika.io.IOUtils.toByteArray(IOUtils.java:200)
    at io.qameta.allure.util.ResultsUtils.readResource(ResultsUtils.java:286)
    at io.qameta.allure.util.ResultsUtils.processDescription(ResultsUtils.java:274)
    at io.qameta.allure.testng.AllureTestNg.onTestStart(AllureTestNg.java:229)
    at org.testng.internal.Invoker.runTestListeners(Invoker.java:1700)
    at org.testng.internal.Invoker.runTestListeners(Invoker.java:1675)
    at org.testng.internal.Invoker.invokeMethod(Invoker.java:619)
    at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:820)
    at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1128)
    at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
    at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)`

It happened because of annotation processor uses dot separator for inner class type, while reflection uses $. But that wasn't supposed fail the whole test. The reason was in java.lang.ClassLoader#getResourceAsStream method which returns null instead of throwing IOException.

[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
