### PR TITLE
Make steps and attachments fields of ExecutableItem to be thread-safe

### DIFF
--- a/allure-model/src/main/java/io/qameta/allure/model/ExecutableItem.java
+++ b/allure-model/src/main/java/io/qameta/allure/model/ExecutableItem.java
@@ -3,6 +3,7 @@ package io.qameta.allure.model;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -212,7 +213,7 @@ public abstract class ExecutableItem implements Serializable, WithAttachments,
     @Override
     public List<StepResult> getSteps() {
         if (steps == null) {
-            steps = new ArrayList<>();
+            steps = Collections.synchronizedList(new ArrayList<>());
         }
         return steps;
     }
@@ -241,7 +242,7 @@ public abstract class ExecutableItem implements Serializable, WithAttachments,
     @Override
     public List<Attachment> getAttachments() {
         if (attachments == null) {
-            attachments = new ArrayList<>();
+            attachments = Collections.synchronizedList(new ArrayList<>());
         }
         return attachments;
     }


### PR DESCRIPTION
Fix for case when single step starts another threads and some items (like, attachments, steps) may be lost due to concurrent writes to non-synchronized lists.

[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [X] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
