### PR TITLE
Fix allure-httpclient request without body

### DIFF
--- a/allure-httpclient/src/main/java/io/qameta/allure/httpclient/AllureHttpClientResponse.java
+++ b/allure-httpclient/src/main/java/io/qameta/allure/httpclient/AllureHttpClientResponse.java
@@ -1,6 +1,10 @@
 package io.qameta.allure.httpclient;
 
-import io.qameta.allure.attachment.*;
+import io.qameta.allure.attachment.AttachmentData;
+import io.qameta.allure.attachment.AttachmentProcessor;
+import io.qameta.allure.attachment.AttachmentRenderer;
+import io.qameta.allure.attachment.DefaultAttachmentProcessor;
+import io.qameta.allure.attachment.FreemarkerAttachmentRenderer;
 import io.qameta.allure.attachment.http.HttpResponseAttachment;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;

--- a/allure-httpclient/src/main/java/io/qameta/allure/httpclient/AllureHttpClientResponse.java
+++ b/allure-httpclient/src/main/java/io/qameta/allure/httpclient/AllureHttpClientResponse.java
@@ -1,10 +1,6 @@
 package io.qameta.allure.httpclient;
 
-import io.qameta.allure.attachment.AttachmentData;
-import io.qameta.allure.attachment.AttachmentProcessor;
-import io.qameta.allure.attachment.AttachmentRenderer;
-import io.qameta.allure.attachment.DefaultAttachmentProcessor;
-import io.qameta.allure.attachment.FreemarkerAttachmentRenderer;
+import io.qameta.allure.attachment.*;
 import io.qameta.allure.attachment.http.HttpResponseAttachment;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -51,10 +47,14 @@ public class AllureHttpClientResponse implements HttpResponseInterceptor {
         Stream.of(response.getAllHeaders())
                 .forEach(header -> builder.setHeader(header.getName(), header.getValue()));
 
-        final LoggableEntity loggableEntity = new LoggableEntity(response.getEntity());
-        response.setEntity(loggableEntity);
+        if (response.getEntity() != null) {
+            final LoggableEntity loggableEntity = new LoggableEntity(response.getEntity());
+            response.setEntity(loggableEntity);
 
-        builder.setBody(loggableEntity.getBody());
+            builder.setBody(loggableEntity.getBody());
+        } else {
+            builder.setBody("No body present");
+        }
 
         final HttpResponseAttachment responseAttachment = builder.build();
         processor.addAttachment(responseAttachment, renderer);


### PR DESCRIPTION
In the case of receiving apache http response without body, exception occurs: IllegalArgumentException("Body may not be null");
But for response with 304 (Not Modified) code response body must be empty according to RFC: https://restfulapi.net/http-status-codes/ ( This status code is similar to 204 (“No Content”) in that the response body must be empty.

Current PR contains fix of that issue. In case of body absence, "No body is present" will be logged in the allure report.