### PR TITLE
Rft testng params processing

### DIFF
--- a/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
+++ b/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
@@ -660,14 +660,17 @@ public class AllureTestNg implements
                     .map(java.lang.reflect.Parameter::getName)
                     .toArray(String[]::new);
 
+            int skippedCount = 0;
             for (int i = 0; i < parameterTypes.length; i++) {
                 final Class<?> parameterType = parameterTypes[i];
                 if (INJECTED_TYPES.contains(parameterType)) {
+                    skippedCount++;
                     continue;
                 }
 
-                if (i < providedNames.length) {
-                    result.put(providedNames[i], ObjectUtils.toString(parameters[i]));
+                final int indexFromAnnotation = i - skippedCount;
+                if (indexFromAnnotation < providedNames.length) {
+                    result.put(providedNames[indexFromAnnotation], ObjectUtils.toString(parameters[i]));
                     continue;
                 }
 

--- a/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
+++ b/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
@@ -45,16 +45,17 @@ import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
+import org.testng.annotations.Parameters;
 import org.testng.internal.ConstructorOrMethod;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
 import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -84,11 +85,9 @@ import static io.qameta.allure.util.ResultsUtils.getMd5Digest;
 import static io.qameta.allure.util.ResultsUtils.getProvidedLabels;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
 import static io.qameta.allure.util.ResultsUtils.processDescription;
-import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.nonNull;
-import static java.util.stream.IntStream.range;
 
 /**
  * Allure TestNG listener.
@@ -128,6 +127,10 @@ public class AllureTestNg implements
      */
     private final Map<ITestClass, String> classContainerUuidStorage = new ConcurrentHashMap<>();
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+    private static final List<Class<?>> INJECTED_TYPES = Arrays.asList(
+            ITestContext.class, ITestResult.class, XmlTest.class, Method.class, Object[].class
+    );
 
     private final AllureLifecycle lifecycle;
 
@@ -638,24 +641,45 @@ public class AllureTestNg implements
     private List<Parameter> getParameters(final ITestContext context,
                                           final ITestNGMethod method,
                                           final Object... parameters) {
-        final Stream<Parameter> tagsParameters = context
-                .getCurrentXmlTest().getAllParameters().entrySet()
-                .stream()
-                .map(entry -> createParameter(entry.getKey(), entry.getValue()));
-        final String[] parameterNames = getMethod(method)
-                .map(Executable::getParameters)
-                .map(Stream::of)
-                .orElseGet(Stream::empty)
-                .map(java.lang.reflect.Parameter::getName)
-                .toArray(String[]::new);
-        final String[] parameterValues = nonNull(parameters)
-                ? Stream.of(parameters)
-                .map(ObjectUtils::toString)
-                .toArray(String[]::new)
-                : new String[]{};
-        final Stream<Parameter> methodParameters = range(0, min(parameterNames.length, parameterValues.length))
-                .mapToObj(i -> createParameter(parameterNames[i], parameterValues[i]));
-        return Stream.concat(tagsParameters, methodParameters)
+        final Map<String, String> result = new HashMap<>(
+                context.getCurrentXmlTest().getAllParameters()
+        );
+
+        getMethod(method).ifPresent(m -> {
+            final Class<?>[] parameterTypes = m.getParameterTypes();
+
+            if (parameterTypes.length != parameters.length) {
+                return;
+            }
+
+            final String[] providedNames = Optional.ofNullable(m.getAnnotation(Parameters.class))
+                    .map(Parameters::value)
+                    .orElse(new String[]{});
+
+            final String[] reflectionNames = Stream.of(m.getParameters())
+                    .map(java.lang.reflect.Parameter::getName)
+                    .toArray(String[]::new);
+
+            for (int i = 0; i < parameterTypes.length; i++) {
+                final Class<?> parameterType = parameterTypes[i];
+                if (INJECTED_TYPES.contains(parameterType)) {
+                    continue;
+                }
+
+                if (i < providedNames.length) {
+                    result.put(providedNames[i], ObjectUtils.toString(parameters[i]));
+                    continue;
+                }
+
+                if (i < reflectionNames.length) {
+                    result.put(reflectionNames[i], ObjectUtils.toString(parameters[i]));
+                }
+            }
+
+        });
+
+        return result.entrySet().stream()
+                .map(entry -> createParameter(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
     }
 

--- a/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
@@ -1019,8 +1019,8 @@ public class AllureTestNgTest {
         assertThat(results.getTestResults())
                 .flatExtracting(TestResult::getParameters)
                 .extracting(Parameter::getName, Parameter::getValue)
-                .containsExactly(
-                        tuple("arg0", "null")
+                .containsExactlyInAnyOrder(
+                        tuple("param", "null")
                 );
     }
 
@@ -1034,10 +1034,10 @@ public class AllureTestNgTest {
         assertThat(results.getTestResults())
                 .flatExtracting(TestResult::getParameters)
                 .extracting(Parameter::getName, Parameter::getValue)
-                .containsExactly(
-                        tuple("arg0", "a"),
-                        tuple("arg1", "false"),
-                        tuple("arg2", "[1, 2, 3]")
+                .containsExactlyInAnyOrder(
+                        tuple("first", "a"),
+                        tuple("second", "false"),
+                        tuple("third", "[1, 2, 3]")
                 );
     }
 
@@ -1064,6 +1064,21 @@ public class AllureTestNgTest {
                 .extracting(StepResult::getName)
                 .containsExactly(
                         "first", "second"
+                );
+    }
+
+    @SuppressWarnings("unchecked")
+    @AllureFeatures.Parameters
+    @Test
+    public void shouldOverrideParameters() {
+        final AllureResults results = runTestNgSuites("suites/parameters-override.xml");
+
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue)
+                .containsExactlyInAnyOrder(
+                        tuple("first", "first-test"),
+                        tuple("second", "second-test")
                 );
     }
 

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/TestWithParameters.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/TestWithParameters.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author charlie (Dmitry Baev).
+ */
+public class TestWithParameters {
+
+    @Parameters({"first", "second"})
+    @Test
+    public void test(final String first, final String s, final Method method) {
+    }
+}

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/TestWithParameters.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/TestWithParameters.java
@@ -15,6 +15,7 @@
  */
 package io.qameta.allure.testng.samples;
 
+import org.testng.ITestContext;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
@@ -27,6 +28,9 @@ public class TestWithParameters {
 
     @Parameters({"first", "second"})
     @Test
-    public void test(final String first, final String s, final Method method) {
+    public void test(final Method method,
+                     final String first,
+                     final ITestContext context,
+                     final String s) {
     }
 }

--- a/allure-testng/src/test/resources/suites/parameters-override.xml
+++ b/allure-testng/src/test/resources/suites/parameters-override.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Github Issues">
+    <parameter name="first" value="first-suite"/>
+    <parameter name="second" value="second-suite"/>
+    <test name="gh-219">
+        <parameter name="first" value="first-test"/>
+        <parameter name="second" value="second-test"/>
+        <classes>
+            <class name="io.qameta.allure.testng.samples.TestWithParameters"/>
+        </classes>
+    </test>
+</suite>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,6 +108,11 @@ configure(subprojects) {
         }
     }
 
+    tasks.withType(JavaCompile::class) {
+        options.encoding = "UTF-8"
+        options.compilerArgs.add("-parameters")
+    }
+
     tasks.named<Jar>("jar") {
         manifest {
             attributes(mapOf(


### PR DESCRIPTION
* Exclude injected types from parameters
* Add support for TestNG `@Parameters` annotation
* Remove duplicate params if any