### PR TITLE
Update selenide plugin related to latest selenide changes:

### DIFF
--- a/allure-selenide/build.gradle.kts
+++ b/allure-selenide/build.gradle.kts
@@ -1,6 +1,6 @@
 description = "Allure Selenide Integration"
 
-val selenideVersion = "5.1.0"
+val selenideVersion = "5.2.3"
 
 dependencies {
     api(project(":allure-java-commons"))


### PR DESCRIPTION
Changes:
* Split `onEvent` to `beforeEvent` and `afterEvent` blocks
* Start step in `beforeEvent` block
* Update and stop step in `afterEvent` block
* Remove `lifecycle.getCurrentTestCase` wrap because `uuid` is not used

[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
