### PR TITLE
Add ability to attach selenium logs in case of test failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Usage example:
 SelenideLogger.addListener("AllureSelenide", new AllureSelenide().screenshots(true).savePageSource(false));
 
 Capture selenium logs:
-SelenideLogger.addListener("AllureSelenide", new AllureSelenide().enableLogs(LogTypes.BROWSER, Level.ALL));
+SelenideLogger.addListener("AllureSelenide", new AllureSelenide().enableLogs(LogType.BROWSER, Level.ALL));
 https://github.com/SeleniumHQ/selenium/wiki/Logging
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Listener for Selenide, that logging steps for Allure:
 Usage example:
 ```
 SelenideLogger.addListener("AllureSelenide", new AllureSelenide().screenshots(true).savePageSource(false));
+
+Capture selenium logs:
+SelenideLogger.addListener("AllureSelenide", new AllureSelenide().enableLogs(LogTypes.BROWSER, Level.ALL));
+https://github.com/SeleniumHQ/selenium/wiki/Logging
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Usage example:
 ```
 SelenideLogger.addListener("AllureSelenide", new AllureSelenide().screenshots(true).savePageSource(false));
 
-Capture selenium logs: 
+Capture selenium logs:
 SelenideLogger.addListener("AllureSelenide", new AllureSelenide().enableLogs(LogType.BROWSER, Level.ALL));
 https://github.com/SeleniumHQ/selenium/wiki/Logging
 ```

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Usage example:
 ```
 SelenideLogger.addListener("AllureSelenide", new AllureSelenide().screenshots(true).savePageSource(false));
 
-Capture selenium logs:
+Capture selenium logs: 
 SelenideLogger.addListener("AllureSelenide", new AllureSelenide().enableLogs(LogType.BROWSER, Level.ALL));
 https://github.com/SeleniumHQ/selenium/wiki/Logging
 ```

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -51,7 +51,7 @@ public class AllureSelenide implements LogEventListener {
 
     private boolean saveScreenshots = true;
     private boolean savePageHtml = true;
-    private final Map<LogTypes, Level> logTypesToSave = new HashMap<>();
+    private final Map<LogType, Level> logTypesToSave = new HashMap<>();
     private final AllureLifecycle lifecycle;
 
     public AllureSelenide() {
@@ -72,13 +72,13 @@ public class AllureSelenide implements LogEventListener {
         return this;
     }
 
-    public AllureSelenide enableLogs(final LogTypes logType, final Level logLevel) {
+    public AllureSelenide enableLogs(final LogType logType, final Level logLevel) {
         logTypesToSave.put(logType, logLevel);
 
         return this;
     }
 
-    public AllureSelenide disableLogs(final LogTypes logType) {
+    public AllureSelenide disableLogs(final LogType logType) {
         logTypesToSave.remove(logType);
 
         return this;
@@ -105,7 +105,7 @@ public class AllureSelenide implements LogEventListener {
         }
     }
 
-    private static String getBrowserLogs(final LogTypes logType, final Level level) {
+    private static String getBrowserLogs(final LogType logType, final Level level) {
         return String.join("\n\n", Selenide.getWebDriverLogs(logType.toString(), level));
     }
 
@@ -137,7 +137,7 @@ public class AllureSelenide implements LogEventListener {
                         logTypesToSave
                             .forEach((logType, level) -> {
                                 final byte[] content = getBrowserLogs(logType, level).getBytes(StandardCharsets.UTF_8);
-                                lifecycle.addAttachment("Logs from: " + logType, "text/plain", ".txt", content);
+                                lifecycle.addAttachment("Logs from: " + logType, "application/json", ".txt", content);
                                 });
                     }
                     lifecycle.updateStep(stepResult -> {

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -30,7 +30,6 @@ import org.openqa.selenium.WebDriverException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -137,7 +136,7 @@ public class AllureSelenide implements LogEventListener {
                     if (!logTypesToSave.isEmpty()) {
                         logTypesToSave
                             .forEach((logType, level) -> {
-                                final byte[] content = getBrowserLogs(logType, level).getBytes(StandardCharsets.UTF_8);
+                                final byte[] content = getBrowserLogs(logType, level).getBytes(UTF_8);
                                 lifecycle.addAttachment("Logs from: " + logType, "application/json", ".txt", content);
                                 });
                     }

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -106,7 +106,7 @@ public class AllureSelenide implements LogEventListener {
     }
 
     private static String getBrowserLogs(final LogTypes logType, final Level level) {
-        return String.join("\n\n", Selenide.getWebDriverLogs(logType.name(), level));
+        return String.join("\n\n", Selenide.getWebDriverLogs(logType.toString(), level));
     }
 
     @Override

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -15,6 +15,24 @@
  */
 package io.qameta.allure.selenide;
 
+import static io.qameta.allure.util.ResultsUtils.getStatus;
+import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
+import static org.openqa.selenium.logging.LogType.BROWSER;
+import static org.openqa.selenium.logging.LogType.CLIENT;
+import static org.openqa.selenium.logging.LogType.DRIVER;
+import static org.openqa.selenium.logging.LogType.PERFORMANCE;
+import static org.openqa.selenium.logging.LogType.PROFILER;
+import static org.openqa.selenium.logging.LogType.SERVER;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Level;
+
+import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.logevents.LogEvent;
 import com.codeborne.selenide.logevents.LogEventListener;
@@ -30,13 +48,6 @@ import org.openqa.selenium.WebDriverException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Optional;
-import java.util.UUID;
-
-import static io.qameta.allure.util.ResultsUtils.getStatus;
-import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
-
 /**
  * @author Artem Eroshenko.
  */
@@ -47,6 +58,8 @@ public class AllureSelenide implements LogEventListener {
 
     private boolean saveScreenshots = true;
     private boolean savePageHtml = true;
+    private final List<String> supportedLogTypes = Arrays.asList(BROWSER, CLIENT, DRIVER, PERFORMANCE, PROFILER, SERVER);
+    private final List<String> logTypesToSave = new ArrayList<>();
 
     private final AllureLifecycle lifecycle;
 
@@ -65,6 +78,15 @@ public class AllureSelenide implements LogEventListener {
 
     public AllureSelenide savePageSource(final boolean savePageHtml) {
         this.savePageHtml = savePageHtml;
+        return this;
+    }
+
+    public AllureSelenide saveLogsFrom(String logType) {
+        if (supportedLogTypes.contains(logType)) {
+            logTypesToSave.add(logType);
+        } else {
+            LOGGER.error("Unsupported log type: {}", logType);
+        }
         return this;
     }
 
@@ -87,6 +109,10 @@ public class AllureSelenide implements LogEventListener {
             LOGGER.warn("Could not get page source", e);
             return Optional.empty();
         }
+    }
+
+    private static String getBrowserLogs(String logType) {
+        return String.join("\n\n", Selenide.getWebDriverLogs(logType, Level.ALL));
     }
 
     @Override
@@ -112,6 +138,13 @@ public class AllureSelenide implements LogEventListener {
                     if (savePageHtml) {
                         getPageSourceBytes()
                                 .ifPresent(bytes -> lifecycle.addAttachment("Page source", "text/html", "html", bytes));
+                    }
+                    if (!logTypesToSave.isEmpty()) {
+                        logTypesToSave
+                                .forEach(logType -> {
+                                    final byte[] content = getBrowserLogs(logType).getBytes(StandardCharsets.UTF_8);
+                                    lifecycle.addAttachment("Logs from: " + logType, "text/plain", ".txt", content);
+                                });
                     }
                     lifecycle.updateStep(stepResult -> {
                         stepResult.setStatus(getStatus(event.getError()).orElse(Status.BROKEN));

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -20,6 +20,7 @@ import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -50,7 +51,7 @@ public class AllureSelenide implements LogEventListener {
 
     private boolean saveScreenshots = true;
     private boolean savePageHtml = true;
-    private final HashMap<LogTypes, Level> logTypesToSave = new HashMap<>();
+    private final Map<LogTypes, Level> logTypesToSave = new HashMap<>();
     private final AllureLifecycle lifecycle;
 
     public AllureSelenide() {
@@ -71,13 +72,13 @@ public class AllureSelenide implements LogEventListener {
         return this;
     }
 
-    public AllureSelenide enableLogs(LogTypes logType, Level logLevel) {
+    public AllureSelenide enableLogs(final LogTypes logType, final Level logLevel) {
         logTypesToSave.put(logType, logLevel);
 
         return this;
     }
 
-    public AllureSelenide disableLogs(LogTypes logType) {
+    public AllureSelenide disableLogs(final LogTypes logType) {
         logTypesToSave.remove(logType);
 
         return this;
@@ -104,7 +105,7 @@ public class AllureSelenide implements LogEventListener {
         }
     }
 
-    private static String getBrowserLogs(LogTypes logType, Level level) {
+    private static String getBrowserLogs(final LogTypes logType, final Level level) {
         return String.join("\n\n", Selenide.getWebDriverLogs(logType.name(), level));
     }
 

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/LogType.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/LogType.java
@@ -15,48 +15,46 @@
  */
 package io.qameta.allure.selenide;
 
-import org.openqa.selenium.logging.LogType;
-
 /**
- * Enum wrapper of Selenium {@link LogType}.
+ * Enum wrapper of Selenium {@link org.openqa.selenium.logging.LogType}.
 
- * @author Evgeny Golyakhovsky.
+ * @author Yevhen Holiakhovskyi.
  */
-public enum LogTypes {
+public enum LogType {
 
     /**
      * This log type pertains to logs from the browser.
      */
-    BROWSER(LogType.BROWSER),
+    BROWSER(org.openqa.selenium.logging.LogType.BROWSER),
 
     /**
      * This log type pertains to logs from the client.
      */
-    CLIENT(LogType.CLIENT),
+    CLIENT(org.openqa.selenium.logging.LogType.CLIENT),
 
     /**
      * This log pertains to logs from the WebDriver implementation.
      */
-    DRIVER(LogType.DRIVER),
+    DRIVER(org.openqa.selenium.logging.LogType.DRIVER),
 
     /**
      * This log type pertains to logs relating to performance timings.
      */
-    PERFORMANCE(LogType.PERFORMANCE),
+    PERFORMANCE(org.openqa.selenium.logging.LogType.PERFORMANCE),
 
     /**
      * This log type pertains to logs relating to performance timings.
      */
-    PROFILER(LogType.PROFILER),
+    PROFILER(org.openqa.selenium.logging.LogType.PROFILER),
 
     /**
      * This log type pertains to logs from the remote server.
      */
-    SERVER(LogType.SERVER);
+    SERVER(org.openqa.selenium.logging.LogType.SERVER);
 
     private final String logType;
 
-    LogTypes(final String logType) {
+    LogType(final String logType) {
         this.logType = logType;
     }
 

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/LogTypes.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/LogTypes.java
@@ -13,7 +13,6 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 package io.qameta.allure.selenide;
 
 import org.openqa.selenium.logging.LogType;

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/LogTypes.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/LogTypes.java
@@ -54,7 +54,7 @@ public enum LogTypes {
      */
     SERVER(LogType.SERVER);
 
-    final String logType;
+    private final String logType;
 
     LogTypes(final String logType) {
         this.logType = logType;

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/LogTypes.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/LogTypes.java
@@ -1,9 +1,27 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package io.qameta.allure.selenide;
 
 import org.openqa.selenium.logging.LogType;
 
 /**
  * Enum wrapper of Selenium {@link LogType}.
+
+ * @author Evgeny Golyakhovsky.
  */
 public enum LogTypes {
 

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/LogTypes.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/LogTypes.java
@@ -1,0 +1,39 @@
+package io.qameta.allure.selenide;
+
+import org.openqa.selenium.logging.LogType;
+
+/**
+ * Enum wrapper of Selenium {@link LogType}.
+ */
+public enum LogTypes {
+
+    /**
+     * This log type pertains to logs from the browser.
+     */
+    BROWSER,
+
+    /**
+     * This log type pertains to logs from the client.
+     */
+    CLIENT,
+
+    /**
+     * This log pertains to logs from the WebDriver implementation.
+     */
+    DRIVER,
+
+    /**
+     * This log type pertains to logs relating to performance timings.
+     */
+    PERFORMANCE,
+
+    /**
+     * This log type pertains to logs relating to performance timings.
+     */
+    PROFILER,
+
+    /**
+     * This log type pertains to logs from the remote server.
+     */
+    SERVER;
+}

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/LogTypes.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/LogTypes.java
@@ -27,30 +27,41 @@ public enum LogTypes {
     /**
      * This log type pertains to logs from the browser.
      */
-    BROWSER,
+    BROWSER(LogType.BROWSER),
 
     /**
      * This log type pertains to logs from the client.
      */
-    CLIENT,
+    CLIENT(LogType.CLIENT),
 
     /**
      * This log pertains to logs from the WebDriver implementation.
      */
-    DRIVER,
+    DRIVER(LogType.DRIVER),
 
     /**
      * This log type pertains to logs relating to performance timings.
      */
-    PERFORMANCE,
+    PERFORMANCE(LogType.PERFORMANCE),
 
     /**
      * This log type pertains to logs relating to performance timings.
      */
-    PROFILER,
+    PROFILER(LogType.PROFILER),
 
     /**
      * This log type pertains to logs from the remote server.
      */
-    SERVER;
+    SERVER(LogType.SERVER);
+
+    final String logType;
+
+    LogTypes(final String logType) {
+        this.logType = logType;
+    }
+
+    @Override
+    public String toString() {
+        return logType;
+    }
 }

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -186,7 +186,6 @@ class AllureSelenideTest {
     @AllureFeatures.Attachments
     @Test
     void shouldSaveLogs() {
-        final String logType = "browser";
         final LogEntry logEntry = new LogEntry(Level.ALL, 10, "SIMPLE LOG");
         final LogEntries logEntries = new LogEntries(Collections.singletonList(logEntry));
         final ChromeDriver wdMock = mock(ChromeDriver.class);
@@ -197,10 +196,10 @@ class AllureSelenideTest {
 
         doReturn(optionsMock).when(wdMock).manage();
         doReturn(logsMock).when(optionsMock).logs();
-        doReturn(logEntries).when(logsMock).get(logType);
+        doReturn(logEntries).when(logsMock).get(LogTypes.BROWSER.name());
 
         final AllureResults results = runWithinTestContext(() -> {
-            final var selenide = new AllureSelenide().saveLogsFrom(logType);
+            final var selenide = new AllureSelenide().enableLogs(LogTypes.BROWSER, Level.ALL);
 
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
 

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -194,7 +194,7 @@ class AllureSelenideTest {
 
         doReturn(optionsMock).when(wdMock).manage();
         doReturn(logsMock).when(optionsMock).logs();
-        doReturn(logEntries).when(logsMock).get(LogTypes.BROWSER.name());
+        doReturn(logEntries).when(logsMock).get(LogTypes.BROWSER.toString());
 
         final AllureResults results = runWithinTestContext(() -> {
             final AllureSelenide selenide = new AllureSelenide().enableLogs(LogTypes.BROWSER, Level.ALL);

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -29,11 +29,9 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriver.Options;
 import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.logging.LocalLogs;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.logging.LogEntry;
 import org.openqa.selenium.logging.Logs;
-import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -197,7 +197,7 @@ class AllureSelenideTest {
         doReturn(logEntries).when(logsMock).get(LogTypes.BROWSER.name());
 
         final AllureResults results = runWithinTestContext(() -> {
-            final var selenide = new AllureSelenide().enableLogs(LogTypes.BROWSER, Level.ALL);
+            final AllureSelenide selenide = new AllureSelenide().enableLogs(LogTypes.BROWSER, Level.ALL);
 
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
 

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -194,10 +194,10 @@ class AllureSelenideTest {
 
         doReturn(optionsMock).when(wdMock).manage();
         doReturn(logsMock).when(optionsMock).logs();
-        doReturn(logEntries).when(logsMock).get(LogTypes.BROWSER.toString());
+        doReturn(logEntries).when(logsMock).get(LogType.BROWSER.toString());
 
         final AllureResults results = runWithinTestContext(() -> {
-            final AllureSelenide selenide = new AllureSelenide().enableLogs(LogTypes.BROWSER, Level.ALL);
+            final AllureSelenide selenide = new AllureSelenide().enableLogs(LogType.BROWSER, Level.ALL);
 
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
 

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -230,7 +230,10 @@ class AllureSelenideTest {
         doReturn(logEntries).when(logsMock).get(LogType.BROWSER.toString());
 
         final AllureResults results = runWithinTestContext(() -> {
-            final AllureSelenide selenide = new AllureSelenide().enableLogs(LogType.BROWSER, Level.ALL);
+            final AllureSelenide selenide = new AllureSelenide()
+                    .enableLogs(LogType.BROWSER, Level.ALL)
+                    .savePageSource(false)
+                    .screenshots(false);
 
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
 


### PR DESCRIPTION
### Context

As a test engineer I want to be able to see what messages were logged during test run. As logs source 
[getWebDriverLogs](https://selenide.org/javadoc/4.5/com/codeborne/selenide/Selenide.html#getWebDriverLogs-java.lang.String-) is used

#### Checklist
- [x] Introduce method to attach logs of different type to test attachment
- [x] Add test for browser logs

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
