### PR TITLE
Extract step value from param method call

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/util/NamingUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/NamingUtils.java
@@ -88,7 +88,14 @@ public final class NamingUtils {
                         .map(child -> extractProperties(child, parts, index))
                         .collect(JOINER);
             }
-            final Object child = on(object).get(parts[index]);
+            String part = parts[index];
+            boolean isMethod = part.endsWith("()");
+            final Object child;
+            if (isMethod) {
+                child = on(object).call(part.replaceAll("\\(\\)", ""));
+            } else {
+                child = on(object).get(part);
+            }
             return extractProperties(child, parts, index + 1);
         }
         return ObjectUtils.toString(object);


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with isses use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->
**Problem**: When we pass an object to step, for example `Response` class from `rest-assured` library, like this:
```
@Step("Response : [{0}]")
public void method(Response response) {
 // do smt
}
```
It will call `toString()` method by default, and in report will be unredable information, smt like `Response@12349` since method is not overrided.


**What we want:** To be able to call a specific method on param. For `Response` it would be `asString()`, then we would get a readeble report.
```
@Step("Response : [{0.asString()}]")
public void method(Response response) {
 // do smt
}
```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
