### PR TITLE
Add request and response time to HttpResponseAttachment/HttpRequestAttachment

### DIFF
--- a/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpRequestAttachment.java
+++ b/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpRequestAttachment.java
@@ -17,7 +17,8 @@ package io.qameta.allure.attachment.http;
 
 import io.qameta.allure.attachment.AttachmentData;
 
-import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -37,7 +38,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
     private final String curl;
 
-    private final LocalDateTime requestTime;
+    private final ZonedDateTime requestTime;
 
     private final Map<String, String> headers;
 
@@ -45,7 +46,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
     @SuppressWarnings("checkstyle:ParameterNumber")
     public HttpRequestAttachment(final String name, final String url, final String method,
-                                 final String body, final String curl, final LocalDateTime requestTime,
+                                 final String body, final String curl, final ZonedDateTime requestTime,
                                  final Map<String, String> headers,
                                  final Map<String, String> cookies) {
         this.name = name;
@@ -82,7 +83,7 @@ public class HttpRequestAttachment implements AttachmentData {
         return curl;
     }
 
-    public LocalDateTime getRequestTime() {
+    public ZonedDateTime getRequestTime() {
         return requestTime;
     }
 
@@ -105,7 +106,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
         private String body;
 
-        private LocalDateTime requestTime;
+        private ZonedDateTime requestTime;
 
         private final Map<String, String> headers = new HashMap<>();
 
@@ -123,7 +124,7 @@ public class HttpRequestAttachment implements AttachmentData {
         }
 
         public Builder setRequestTime() {
-            this.requestTime = LocalDateTime.now();
+            this.requestTime = ZonedDateTime.now(ZoneId.systemDefault()) ;
             return this;
         }
 

--- a/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpRequestAttachment.java
+++ b/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpRequestAttachment.java
@@ -17,6 +17,7 @@ package io.qameta.allure.attachment.http;
 
 import io.qameta.allure.attachment.AttachmentData;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -36,18 +37,23 @@ public class HttpRequestAttachment implements AttachmentData {
 
     private final String curl;
 
+    private final LocalDateTime time;
+
     private final Map<String, String> headers;
 
     private final Map<String, String> cookies;
 
+    @SuppressWarnings("checkstyle:ParameterNumber")
     public HttpRequestAttachment(final String name, final String url, final String method,
-                                 final String body, final String curl, final Map<String, String> headers,
+                                 final String body, final String curl, final LocalDateTime time,
+                                 final Map<String, String> headers,
                                  final Map<String, String> cookies) {
         this.name = name;
         this.url = url;
         this.method = method;
         this.body = body;
         this.curl = curl;
+        this.time = time;
         this.headers = headers;
         this.cookies = cookies;
     }
@@ -76,6 +82,10 @@ public class HttpRequestAttachment implements AttachmentData {
         return curl;
     }
 
+    public LocalDateTime getTime() {
+        return time;
+    }
+
     @Override
     public String getName() {
         return name;
@@ -95,6 +105,8 @@ public class HttpRequestAttachment implements AttachmentData {
 
         private String body;
 
+        private LocalDateTime time;
+
         private final Map<String, String> headers = new HashMap<>();
 
         private final Map<String, String> cookies = new HashMap<>();
@@ -108,6 +120,11 @@ public class HttpRequestAttachment implements AttachmentData {
 
         public static Builder create(final String attachmentName, final String url) {
             return new Builder(attachmentName, url);
+        }
+
+        public Builder setRequestTime() {
+            this.time = LocalDateTime.now();
+            return this;
         }
 
         public Builder setMethod(final String method) {
@@ -150,6 +167,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
         /**
          * Use setter method instead.
+         *
          * @deprecated scheduled for removal in 3.0 release
          */
         @Deprecated
@@ -159,6 +177,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
         /**
          * Use setter method instead.
+         *
          * @deprecated scheduled for removal in 3.0 release
          */
         @Deprecated
@@ -168,6 +187,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
         /**
          * Use setter method instead.
+         *
          * @deprecated scheduled for removal in 3.0 release
          */
         @Deprecated
@@ -177,6 +197,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
         /**
          * Use setter method instead.
+         *
          * @deprecated scheduled for removal in 3.0 release
          */
         @Deprecated
@@ -186,6 +207,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
         /**
          * Use setter method instead.
+         *
          * @deprecated scheduled for removal in 3.0 release
          */
         @Deprecated
@@ -195,6 +217,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
         /**
          * Use setter method instead.
+         *
          * @deprecated scheduled for removal in 3.0 release
          */
         @Deprecated
@@ -203,7 +226,7 @@ public class HttpRequestAttachment implements AttachmentData {
         }
 
         public HttpRequestAttachment build() {
-            return new HttpRequestAttachment(name, url, method, body, getCurl(), headers, cookies);
+            return new HttpRequestAttachment(name, url, method, body, getCurl(), time, headers, cookies);
         }
 
         private String getCurl() {

--- a/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpRequestAttachment.java
+++ b/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpRequestAttachment.java
@@ -124,7 +124,7 @@ public class HttpRequestAttachment implements AttachmentData {
         }
 
         public Builder setRequestTime() {
-            this.requestTime = ZonedDateTime.now(ZoneId.systemDefault()) ;
+            this.requestTime = ZonedDateTime.now(ZoneId.systemDefault());
             return this;
         }
 

--- a/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpRequestAttachment.java
+++ b/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpRequestAttachment.java
@@ -37,7 +37,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
     private final String curl;
 
-    private final LocalDateTime time;
+    private final LocalDateTime requestTime;
 
     private final Map<String, String> headers;
 
@@ -45,7 +45,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
     @SuppressWarnings("checkstyle:ParameterNumber")
     public HttpRequestAttachment(final String name, final String url, final String method,
-                                 final String body, final String curl, final LocalDateTime time,
+                                 final String body, final String curl, final LocalDateTime requestTime,
                                  final Map<String, String> headers,
                                  final Map<String, String> cookies) {
         this.name = name;
@@ -53,7 +53,7 @@ public class HttpRequestAttachment implements AttachmentData {
         this.method = method;
         this.body = body;
         this.curl = curl;
-        this.time = time;
+        this.requestTime = requestTime;
         this.headers = headers;
         this.cookies = cookies;
     }
@@ -82,8 +82,8 @@ public class HttpRequestAttachment implements AttachmentData {
         return curl;
     }
 
-    public LocalDateTime getTime() {
-        return time;
+    public LocalDateTime getRequestTime() {
+        return requestTime;
     }
 
     @Override
@@ -105,7 +105,7 @@ public class HttpRequestAttachment implements AttachmentData {
 
         private String body;
 
-        private LocalDateTime time;
+        private LocalDateTime requestTime;
 
         private final Map<String, String> headers = new HashMap<>();
 
@@ -123,7 +123,7 @@ public class HttpRequestAttachment implements AttachmentData {
         }
 
         public Builder setRequestTime() {
-            this.time = LocalDateTime.now();
+            this.requestTime = LocalDateTime.now();
             return this;
         }
 
@@ -226,7 +226,7 @@ public class HttpRequestAttachment implements AttachmentData {
         }
 
         public HttpRequestAttachment build() {
-            return new HttpRequestAttachment(name, url, method, body, getCurl(), time, headers, cookies);
+            return new HttpRequestAttachment(name, url, method, body, getCurl(), requestTime, headers, cookies);
         }
 
         private String getCurl() {

--- a/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpResponseAttachment.java
+++ b/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpResponseAttachment.java
@@ -17,6 +17,7 @@ package io.qameta.allure.attachment.http;
 
 import io.qameta.allure.attachment.AttachmentData;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -34,17 +35,20 @@ public class HttpResponseAttachment implements AttachmentData {
 
     private final int responseCode;
 
+    private final LocalDateTime responseTime;
+
     private final Map<String, String> headers;
 
     private final Map<String, String> cookies;
 
     public HttpResponseAttachment(final String name, final String url,
-                                  final String body, final int responseCode,
+                                  final String body, final int responseCode, final LocalDateTime responseTime,
                                   final Map<String, String> headers, final Map<String, String> cookies) {
         this.name = name;
         this.url = url;
         this.body = body;
         this.responseCode = responseCode;
+        this.responseTime = responseTime;
         this.headers = headers;
         this.cookies = cookies;
     }
@@ -64,6 +68,10 @@ public class HttpResponseAttachment implements AttachmentData {
 
     public int getResponseCode() {
         return responseCode;
+    }
+
+    public LocalDateTime getResponseTime() {
+        return responseTime;
     }
 
     public Map<String, String> getHeaders() {
@@ -86,6 +94,8 @@ public class HttpResponseAttachment implements AttachmentData {
 
         private int responseCode;
 
+        private LocalDateTime responseTime;
+
         private String body;
 
         private final Map<String, String> headers = new HashMap<>();
@@ -99,6 +109,11 @@ public class HttpResponseAttachment implements AttachmentData {
 
         public static Builder create(final String attachmentName) {
             return new Builder(attachmentName);
+        }
+
+        public Builder setResponseTime() {
+            this.responseTime = LocalDateTime.now();
+            return this;
         }
 
         public Builder setUrl(final String url) {
@@ -209,7 +224,7 @@ public class HttpResponseAttachment implements AttachmentData {
         }
 
         public HttpResponseAttachment build() {
-            return new HttpResponseAttachment(name, url, body, responseCode, headers, cookies);
+            return new HttpResponseAttachment(name, url, body, responseCode, responseTime, headers, cookies);
         }
     }
 }

--- a/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpResponseAttachment.java
+++ b/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpResponseAttachment.java
@@ -17,7 +17,9 @@ package io.qameta.allure.attachment.http;
 
 import io.qameta.allure.attachment.AttachmentData;
 
-import java.time.LocalDateTime;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -35,14 +37,14 @@ public class HttpResponseAttachment implements AttachmentData {
 
     private final int responseCode;
 
-    private final LocalDateTime responseTime;
+    private final ZonedDateTime responseTime;
 
     private final Map<String, String> headers;
 
     private final Map<String, String> cookies;
 
     public HttpResponseAttachment(final String name, final String url,
-                                  final String body, final int responseCode, final LocalDateTime responseTime,
+                                  final String body, final int responseCode, final ZonedDateTime responseTime,
                                   final Map<String, String> headers, final Map<String, String> cookies) {
         this.name = name;
         this.url = url;
@@ -70,7 +72,7 @@ public class HttpResponseAttachment implements AttachmentData {
         return responseCode;
     }
 
-    public LocalDateTime getResponseTime() {
+    public ZonedDateTime getResponseTime() {
         return responseTime;
     }
 
@@ -94,7 +96,7 @@ public class HttpResponseAttachment implements AttachmentData {
 
         private int responseCode;
 
-        private LocalDateTime responseTime;
+        private ZonedDateTime responseTime;
 
         private String body;
 
@@ -112,7 +114,7 @@ public class HttpResponseAttachment implements AttachmentData {
         }
 
         public Builder setResponseTime() {
-            this.responseTime = LocalDateTime.now();
+            this.responseTime = ZonedDateTime.now(ZoneId.systemDefault());
             return this;
         }
 

--- a/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpResponseAttachment.java
+++ b/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpResponseAttachment.java
@@ -17,7 +17,6 @@ package io.qameta.allure.attachment.http;
 
 import io.qameta.allure.attachment.AttachmentData;
 
-
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.HashMap;

--- a/allure-attachments/src/main/resources/tpl/http-request.ftl
+++ b/allure-attachments/src/main/resources/tpl/http-request.ftl
@@ -2,10 +2,10 @@
 <#-- @ftlvariable name="data" type="io.qameta.allure.attachment.http.HttpRequestAttachment" -->
 <div><#if data.method??>${data.method}<#else>GET</#if> to <#if data.url??>${data.url}<#else>Unknown</#if></div>
 
-<#if data.time??>
+<#if data.requestTime??>
     <h4>Request time</h4>
     <div>
-        ${data.time}
+        ${data.requestTime}
     </div>
 </#if>
 

--- a/allure-attachments/src/main/resources/tpl/http-request.ftl
+++ b/allure-attachments/src/main/resources/tpl/http-request.ftl
@@ -2,6 +2,13 @@
 <#-- @ftlvariable name="data" type="io.qameta.allure.attachment.http.HttpRequestAttachment" -->
 <div><#if data.method??>${data.method}<#else>GET</#if> to <#if data.url??>${data.url}<#else>Unknown</#if></div>
 
+<#if data.time??>
+    <h4>Request time</h4>
+    <div>
+        ${data.time}
+    </div>
+</#if>
+
 <#if data.body??>
 <h4>Body</h4>
 <div>

--- a/allure-attachments/src/main/resources/tpl/http-response.ftl
+++ b/allure-attachments/src/main/resources/tpl/http-response.ftl
@@ -3,6 +3,13 @@
 <div>Status code <#if data.responseCode??>${data.responseCode} <#else>Unknown</#if></div>
 <#if data.url??><div>${data.url}</div></#if>
 
+<#if data.responseTime??>
+    <h4>Response time</h4>
+    <div>
+        ${data.responseTime}
+    </div>
+</#if>
+
 <#if data.body??>
 <h4>Body</h4>
 <div>

--- a/allure-attachments/src/test/java/io/qameta/allure/attachment/FreemarkerAttachmentRendererTest.java
+++ b/allure-attachments/src/test/java/io/qameta/allure/attachment/FreemarkerAttachmentRendererTest.java
@@ -16,10 +16,12 @@
 package io.qameta.allure.attachment;
 
 import io.qameta.allure.attachment.http.HttpRequestAttachment;
+import io.qameta.allure.attachment.http.HttpResponseAttachment;
 import io.qameta.allure.test.AllureFeatures;
 import org.junit.jupiter.api.Test;
 
 import static io.qameta.allure.attachment.testdata.TestData.randomHttpRequestAttachment;
+import static io.qameta.allure.attachment.testdata.TestData.randomHttpResponseAttachment;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -40,6 +42,7 @@ class FreemarkerAttachmentRendererTest {
                 .hasFieldOrProperty("content");
     }
 
+    @AllureFeatures.Attachments
     @Test
     void shouldRenderRequestTimeAttachment() {
         final HttpRequestAttachment data = randomHttpRequestAttachment();
@@ -47,6 +50,16 @@ class FreemarkerAttachmentRendererTest {
                 .render(data);
 
         assertThat(content.getContent()).contains("Request time");
+    }
+
+    @AllureFeatures.Attachments
+    @Test
+    void shouldRenderResponseTimeAttachment() {
+        final HttpResponseAttachment data = randomHttpResponseAttachment();
+        final DefaultAttachmentContent content = new FreemarkerAttachmentRenderer("http-response.ftl")
+                .render(data);
+
+        assertThat(content.getContent()).contains("Response time");
     }
 
     @AllureFeatures.Attachments

--- a/allure-attachments/src/test/java/io/qameta/allure/attachment/FreemarkerAttachmentRendererTest.java
+++ b/allure-attachments/src/test/java/io/qameta/allure/attachment/FreemarkerAttachmentRendererTest.java
@@ -40,6 +40,15 @@ class FreemarkerAttachmentRendererTest {
                 .hasFieldOrProperty("content");
     }
 
+    @Test
+    void shouldRenderRequestTimeAttachment() {
+        final HttpRequestAttachment data = randomHttpRequestAttachment();
+        final DefaultAttachmentContent content = new FreemarkerAttachmentRenderer("http-request.ftl")
+                .render(data);
+
+        assertThat(content.getContent()).contains("Request time");
+    }
+
     @AllureFeatures.Attachments
     @Test
     void shouldRenderResponseAttachment() {

--- a/allure-attachments/src/test/java/io/qameta/allure/attachment/testdata/TestData.java
+++ b/allure-attachments/src/test/java/io/qameta/allure/attachment/testdata/TestData.java
@@ -21,7 +21,8 @@ import io.qameta.allure.attachment.http.HttpRequestAttachment;
 import io.qameta.allure.attachment.http.HttpResponseAttachment;
 import org.apache.commons.lang3.RandomStringUtils;
 
-import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -46,7 +47,7 @@ public final class TestData {
                 randomString(),
                 randomString(),
                 randomString(),
-                LocalDateTime.now(),
+                ZonedDateTime.now(ZoneId.systemDefault()),
                 randomMap(),
                 randomMap()
         );
@@ -58,7 +59,7 @@ public final class TestData {
                 randomString(),
                 randomString(),
                 ThreadLocalRandom.current().nextInt(),
-                LocalDateTime.now(),
+                ZonedDateTime.now(ZoneId.systemDefault()),
                 randomMap(),
                 randomMap()
         );

--- a/allure-attachments/src/test/java/io/qameta/allure/attachment/testdata/TestData.java
+++ b/allure-attachments/src/test/java/io/qameta/allure/attachment/testdata/TestData.java
@@ -21,6 +21,7 @@ import io.qameta.allure.attachment.http.HttpRequestAttachment;
 import io.qameta.allure.attachment.http.HttpResponseAttachment;
 import org.apache.commons.lang3.RandomStringUtils;
 
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -45,6 +46,7 @@ public final class TestData {
                 randomString(),
                 randomString(),
                 randomString(),
+                LocalDateTime.now(),
                 randomMap(),
                 randomMap()
         );

--- a/allure-attachments/src/test/java/io/qameta/allure/attachment/testdata/TestData.java
+++ b/allure-attachments/src/test/java/io/qameta/allure/attachment/testdata/TestData.java
@@ -58,6 +58,7 @@ public final class TestData {
                 randomString(),
                 randomString(),
                 ThreadLocalRandom.current().nextInt(),
+                LocalDateTime.now(),
                 randomMap(),
                 randomMap()
         );

--- a/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
+++ b/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
@@ -96,6 +96,7 @@ public class AllureRestAssured implements OrderedFilter {
 
         final Response response = filterContext.next(requestSpec, responseSpec);
         final HttpResponseAttachment responseAttachment = create(response.getStatusLine())
+                .setResponseTime()
                 .setResponseCode(response.getStatusCode())
                 .setHeaders(toMapConverter(response.getHeaders()))
                 .setBody(prettifier.getPrettifiedBodyIfPossible(response, response.getBody()))

--- a/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
+++ b/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
@@ -78,6 +78,7 @@ public class AllureRestAssured implements OrderedFilter {
 
 
         final HttpRequestAttachment.Builder requestAttachmentBuilder = create("Request", requestSpec.getURI())
+                .setRequestTime()
                 .setMethod(requestSpec.getMethod())
                 .setHeaders(toMapConverter(requestSpec.getHeaders()))
                 .setCookies(toMapConverter(requestSpec.getCookies()));


### PR DESCRIPTION
### Context

When QAs check Allure reports, they want to see the time in the attachment when HTTP requests or responses made. I clearly understand that they could check Jenkin's log, but it's not useful and has time-consuming.
For that reason, I added a request/response time to HTTP attachment. Look like:

![image](https://user-images.githubusercontent.com/8410018/66849998-99ff2b80-ef80-11e9-9567-8bf37faf199e.png)




#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
