### PR TITLE
Fix common Java code problems

### DIFF
--- a/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpResponseAttachment.java
+++ b/allure-attachments/src/main/java/io/qameta/allure/attachment/http/HttpResponseAttachment.java
@@ -108,7 +108,6 @@ public class HttpResponseAttachment implements AttachmentData {
         }
 
         public Builder setResponseCode(final int responseCode) {
-            Objects.requireNonNull(responseCode, "Response code must not be null value");
             this.responseCode = responseCode;
             return this;
         }

--- a/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/AllureCucumberJvm.java
+++ b/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/AllureCucumberJvm.java
@@ -249,7 +249,7 @@ public class AllureCucumberJvm implements Reporter, Formatter {
             final String attachmentSource = lifecycle
                     .prepareAttachment("Data table", "text/tab-separated-values", "csv");
             lifecycle.writeAttachment(attachmentSource,
-                    new ByteArrayInputStream(dataTableCsv.toString().getBytes(Charset.forName("UTF-8"))));
+                    new ByteArrayInputStream(dataTableCsv.toString().getBytes(StandardCharsets.UTF_8)));
         }
     }
 

--- a/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/AllureCucumberJvm.java
+++ b/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/AllureCucumberJvm.java
@@ -38,15 +38,14 @@ import io.qameta.allure.model.TestResult;
 import io.qameta.allure.util.ResultsUtils;
 
 import java.io.ByteArrayInputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 

--- a/allure-cucumber2-jvm/src/main/java/io/qameta/allure/cucumber2jvm/AllureCucumber2Jvm.java
+++ b/allure-cucumber2-jvm/src/main/java/io/qameta/allure/cucumber2jvm/AllureCucumber2Jvm.java
@@ -51,7 +51,6 @@ import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
 
 import java.io.ByteArrayInputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Deque;

--- a/allure-cucumber2-jvm/src/main/java/io/qameta/allure/cucumber2jvm/AllureCucumber2Jvm.java
+++ b/allure-cucumber2-jvm/src/main/java/io/qameta/allure/cucumber2jvm/AllureCucumber2Jvm.java
@@ -328,7 +328,7 @@ public class AllureCucumber2Jvm implements Formatter {
             final String attachmentSource = lifecycle
                     .prepareAttachment("Data table", "text/tab-separated-values", "csv");
             lifecycle.writeAttachment(attachmentSource,
-                    new ByteArrayInputStream(dataTableCsv.toString().getBytes(Charset.forName("UTF-8"))));
+                    new ByteArrayInputStream(dataTableCsv.toString().getBytes(StandardCharsets.UTF_8)));
         }
     }
 

--- a/allure-cucumber3-jvm/src/main/java/io/qameta/allure/cucumber3jvm/AllureCucumber3Jvm.java
+++ b/allure-cucumber3-jvm/src/main/java/io/qameta/allure/cucumber3jvm/AllureCucumber3Jvm.java
@@ -330,7 +330,7 @@ public class AllureCucumber3Jvm implements Formatter {
             final String attachmentSource = lifecycle
                     .prepareAttachment("Data table", "text/tab-separated-values", "csv");
             lifecycle.writeAttachment(attachmentSource,
-                    new ByteArrayInputStream(dataTableCsv.toString().getBytes(Charset.forName("UTF-8"))));
+                    new ByteArrayInputStream(dataTableCsv.toString().getBytes(StandardCharsets.UTF_8)));
         }
     }
 

--- a/allure-cucumber3-jvm/src/main/java/io/qameta/allure/cucumber3jvm/AllureCucumber3Jvm.java
+++ b/allure-cucumber3-jvm/src/main/java/io/qameta/allure/cucumber3jvm/AllureCucumber3Jvm.java
@@ -51,7 +51,6 @@ import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
 
 import java.io.ByteArrayInputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Deque;

--- a/allure-java-commons/src/main/java/io/qameta/allure/aspects/AttachmentsAspects.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/aspects/AttachmentsAspects.java
@@ -39,7 +39,8 @@ import static io.qameta.allure.util.NamingUtils.processNameTemplate;
 @Aspect
 public class AttachmentsAspects {
 
-    private static final InheritableThreadLocal<AllureLifecycle> lifecycle = new InheritableThreadLocal<AllureLifecycle>() {
+    private static final InheritableThreadLocal<AllureLifecycle> LIFECYCLE =
+            new InheritableThreadLocal<AllureLifecycle>() {
         @Override
         protected AllureLifecycle initialValue() {
             return Allure.getLifecycle();
@@ -89,10 +90,10 @@ public class AttachmentsAspects {
      * @param allure allure lifecycle to set.
      */
     public static void setLifecycle(final AllureLifecycle allure) {
-        lifecycle.set(allure);
+        LIFECYCLE.set(allure);
     }
 
     public static AllureLifecycle getLifecycle() {
-        return lifecycle.get();
+        return LIFECYCLE.get();
     }
 }

--- a/allure-java-commons/src/main/java/io/qameta/allure/aspects/AttachmentsAspects.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/aspects/AttachmentsAspects.java
@@ -39,7 +39,7 @@ import static io.qameta.allure.util.NamingUtils.processNameTemplate;
 @Aspect
 public class AttachmentsAspects {
 
-    private static InheritableThreadLocal<AllureLifecycle> lifecycle = new InheritableThreadLocal<AllureLifecycle>() {
+    private static final InheritableThreadLocal<AllureLifecycle> lifecycle = new InheritableThreadLocal<AllureLifecycle>() {
         @Override
         protected AllureLifecycle initialValue() {
             return Allure.getLifecycle();

--- a/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
@@ -45,7 +45,8 @@ import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
 @Aspect
 public class StepsAspects {
 
-    private static final InheritableThreadLocal<AllureLifecycle> lifecycle = new InheritableThreadLocal<AllureLifecycle>() {
+    private static final InheritableThreadLocal<AllureLifecycle> LIFECYCLE
+            = new InheritableThreadLocal<AllureLifecycle>() {
         @Override
         protected AllureLifecycle initialValue() {
             return Allure.getLifecycle();
@@ -98,10 +99,10 @@ public class StepsAspects {
      * @param allure allure lifecycle to set.
      */
     public static void setLifecycle(final AllureLifecycle allure) {
-        lifecycle.set(allure);
+        LIFECYCLE.set(allure);
     }
 
     public static AllureLifecycle getLifecycle() {
-        return lifecycle.get();
+        return LIFECYCLE.get();
     }
 }

--- a/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
@@ -45,7 +45,7 @@ import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
 @Aspect
 public class StepsAspects {
 
-    private static InheritableThreadLocal<AllureLifecycle> lifecycle = new InheritableThreadLocal<AllureLifecycle>() {
+    private static final InheritableThreadLocal<AllureLifecycle> lifecycle = new InheritableThreadLocal<AllureLifecycle>() {
         @Override
         protected AllureLifecycle initialValue() {
             return Allure.getLifecycle();

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/PropertiesUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/PropertiesUtils.java
@@ -43,13 +43,12 @@ public final class PropertiesUtils {
     }
 
     private static void loadPropertiesFrom(final ClassLoader classLoader, final Properties properties) {
-        if (classLoader.getResource(ALLURE_PROPERTIES_FILE) != null) {
-            try (InputStream stream = classLoader.getResourceAsStream(ALLURE_PROPERTIES_FILE)) {
+        try (InputStream stream = classLoader.getResourceAsStream(ALLURE_PROPERTIES_FILE)) {
+            if (stream != null) {
                 properties.load(stream);
-            } catch (IOException e) {
-                LOGGER.error("Error while reading allure.properties file from classpath: %s", e.getMessage());
             }
+        } catch (IOException e) {
+            LOGGER.error("Error while reading allure.properties file from classpath: {}", e.getMessage());
         }
     }
-
 }

--- a/allure-spock/src/main/java/io/qameta/allure/spock/AllureSpock.java
+++ b/allure-spock/src/main/java/io/qameta/allure/spock/AllureSpock.java
@@ -91,7 +91,7 @@ public class AllureSpock extends AbstractRunListener implements IGlobalExtension
     private final ThreadLocal<String> testResults
             = InheritableThreadLocal.withInitial(() -> UUID.randomUUID().toString());
 
-    private AllureLifecycle lifecycle;
+    private final AllureLifecycle lifecycle;
 
     @SuppressWarnings("unused")
     public AllureSpock() {


### PR DESCRIPTION
Here we fix several Java code problems, namely:

- Use final modifier for proper single value initialization
- Use `StandardCharsets.UTF_8` whether it is possible
- Get rid of unnecessary null check for int
- Use single `getResourceAsStream` call to ClassLoader instead of two

## Checklist

- [x] Sign Allure CLA