### PR TITLE
fix TestNG 7.1.0 compatability.

### DIFF
--- a/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
+++ b/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
@@ -39,7 +39,7 @@ import org.testng.IAttributes;
 import org.testng.IClass;
 import org.testng.IConfigurationListener;
 import org.testng.IInvokedMethod;
-import org.testng.IInvokedMethodListener2;
+import org.testng.IInvokedMethodListener;
 import org.testng.ISuite;
 import org.testng.ISuiteListener;
 import org.testng.ITestClass;
@@ -102,7 +102,7 @@ import static java.util.Objects.nonNull;
 public class AllureTestNg implements
         ISuiteListener,
         ITestListener,
-        IInvokedMethodListener2,
+        IInvokedMethodListener,
         IConfigurationListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AllureTestNg.class);


### PR DESCRIPTION
Fixed issue which prevent testng 7.1.0 to run any tests with allure 2.13.1 integration
just replaced old deprecated interface to his base interface

