### PR TITLE
Handle @Description(useJavadoc=true) on uncommented methods

### DIFF
--- a/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
+++ b/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
@@ -71,6 +71,12 @@ public class JavaDocDescriptionsProcessor extends AbstractProcessor {
             final List<String> typeParams = ((ExecutableElement) el).getParameters().stream()
                     .map(param -> param.asType().toString()).collect(Collectors.toList());
             final String name = el.getSimpleName().toString();
+            if (docs == null) {
+                messager.printMessage(Diagnostic.Kind.WARNING,
+                        "Unable to create resource for method " + name + typeParams
+                                + " as it does not have a docs comment");
+                return;
+            }
 
             final String hash = generateMethodSignatureHash(el.getEnclosingElement().toString(), name, typeParams);
             try {

--- a/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
+++ b/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
@@ -61,4 +61,27 @@ class ProcessDescriptionsTest {
                 expectedMethodSignatureHash
         );
     }
+
+    @Test
+    void skipUncommentedMethodTest() {
+        JavaFileObject source = JavaFileObjects.forSourceLines(
+                "io.qameta.allure.description.test.DescriptionSample",
+                "package io.qameta.allure.description.test;",
+                "import io.qameta.allure.Description;",
+                "",
+                "public class DescriptionSample {",
+                "",
+                "@Description(useJavaDoc = true)",
+                "public void sampleTestWithoutJavadocComment() {",
+                "}",
+                "}"
+        );
+
+        Compiler compiler = javac().withProcessors(new JavaDocDescriptionsProcessor());
+        Compilation compilation = compiler.compile(source);
+        assertThat(compilation).succeeded();
+        assertThat(compilation)
+                .hadWarningContaining("Unable to create resource for method "
+                        + "sampleTestWithoutJavadocComment[] as it does not have a docs comment");
+    }
 }


### PR DESCRIPTION
### Context
The current version of the descriptions-javadoc annotation processor exits with a nullpointer exception when processing a @Description(useJavadoc=true) annotation on a method that does not have a javadoc comment. This can be very confusing while writing tests in an IDE like IntellJ because all that is shown is an error like "javac exited with an error".

### Fix
This PR changes the processor slightly so that it issues a warning about the missing javadoc method before aborting.
 
#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
