### PR TITLE
allure-selenide: adding a setting to include Selenide locators as steps (default = true) 

### DIFF
--- a/allure-selenide/build.gradle.kts
+++ b/allure-selenide/build.gradle.kts
@@ -2,7 +2,7 @@ description = "Allure Selenide Integration"
 
 val agent: Configuration by configurations.creating
 
-val selenideVersion = "5.2.3"
+val selenideVersion = "5.8.0"
 
 dependencies {
     agent("org.aspectj:aspectjweaver")

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -171,7 +171,7 @@ public class AllureSelenide implements LogEventListener {
 
 
     private boolean stepsShouldBeLogged(final LogEvent event) {
-        //  other customer Loggers could be configured, they shooud be logged
+        //  other customer Loggers could be configured, they should be logged
         return includeSelenideLocatorsSteps || !(event instanceof SelenideLog);
     }
 }

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -73,8 +73,8 @@ public class AllureSelenide implements LogEventListener {
         return this;
     }
 
-    public AllureSelenide includeSelenideLocators(final boolean includeSelenideLocators) {
-        this.includeSelenideLocatorsSteps = includeSelenideLocators;
+    public AllureSelenide includeSelenideSteps(final boolean includeSelenideSteps) {
+        this.includeSelenideLocatorsSteps = includeSelenideSteps;
         return this;
     }
 

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -51,7 +51,7 @@ public class AllureSelenide implements LogEventListener {
 
     private boolean saveScreenshots = true;
     private boolean savePageHtml = true;
-    private boolean includeSelenideLocators = true;
+    private boolean includeSelenideLocatorsSteps = true;
     private final Map<LogType, Level> logTypesToSave = new HashMap<>();
     private final AllureLifecycle lifecycle;
 
@@ -73,8 +73,8 @@ public class AllureSelenide implements LogEventListener {
         return this;
     }
 
-    public AllureSelenide includeSelenideLocators(boolean includeSelenideLocators) {
-        this.includeSelenideLocators = includeSelenideLocators;
+    public AllureSelenide includeSelenideLocators(final boolean includeSelenideLocators) {
+        this.includeSelenideLocatorsSteps = includeSelenideLocators;
         return this;
     }
 
@@ -118,8 +118,8 @@ public class AllureSelenide implements LogEventListener {
 
     @Override
     public void beforeEvent(final LogEvent event) {
-        if (!includeSelenideLocators) {
-            if (event instanceof SelenideLog) return;
+        if (!includeSelenideLocatorsSteps && event instanceof SelenideLog) {
+            return;
         }
         lifecycle.getCurrentTestCaseOrStep().ifPresent(parentUuid -> {
             final String uuid = UUID.randomUUID().toString();
@@ -129,8 +129,8 @@ public class AllureSelenide implements LogEventListener {
 
     @Override
     public void afterEvent(final LogEvent event) {
-        if (!includeSelenideLocators) {
-            if (event instanceof SelenideLog) return;
+        if (!includeSelenideLocatorsSteps && event instanceof SelenideLog) {
+            return;
         }
         lifecycle.getCurrentTestCaseOrStep().ifPresent(parentUuid -> {
             switch (event.getStatus()) {

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -19,6 +19,7 @@ import com.codeborne.selenide.Selenide;
 import com.codeborne.selenide.WebDriverRunner;
 import com.codeborne.selenide.logevents.LogEvent;
 import com.codeborne.selenide.logevents.LogEventListener;
+import com.codeborne.selenide.logevents.SelenideLog;
 import io.qameta.allure.Allure;
 import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.model.Status;
@@ -50,6 +51,7 @@ public class AllureSelenide implements LogEventListener {
 
     private boolean saveScreenshots = true;
     private boolean savePageHtml = true;
+    private boolean includeSelenideLocators = true;
     private final Map<LogType, Level> logTypesToSave = new HashMap<>();
     private final AllureLifecycle lifecycle;
 
@@ -68,6 +70,11 @@ public class AllureSelenide implements LogEventListener {
 
     public AllureSelenide savePageSource(final boolean savePageHtml) {
         this.savePageHtml = savePageHtml;
+        return this;
+    }
+
+    public AllureSelenide includeSelenideLocators(boolean includeSelenideLocators) {
+        this.includeSelenideLocators = includeSelenideLocators;
         return this;
     }
 
@@ -111,6 +118,9 @@ public class AllureSelenide implements LogEventListener {
 
     @Override
     public void beforeEvent(final LogEvent event) {
+        if (!includeSelenideLocators) {
+            if (event instanceof SelenideLog) return;
+        }
         lifecycle.getCurrentTestCaseOrStep().ifPresent(parentUuid -> {
             final String uuid = UUID.randomUUID().toString();
             lifecycle.startStep(parentUuid, uuid, new StepResult().setName(event.toString()));
@@ -119,6 +129,9 @@ public class AllureSelenide implements LogEventListener {
 
     @Override
     public void afterEvent(final LogEvent event) {
+        if (!includeSelenideLocators) {
+            if (event instanceof SelenideLog) return;
+        }
         lifecycle.getCurrentTestCaseOrStep().ifPresent(parentUuid -> {
             switch (event.getStatus()) {
                 case PASS:

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -93,12 +93,12 @@ class AllureSelenideTest {
                     .screenshots(false)
                     .includeSelenideLocators(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
-            Allure.step("step1");
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
                     "dummyMethod()"
             );
             SelenideLogger.commitStep(log, LogEvent.EventStatus.PASS);
+            Allure.step("step1");
         });
 
         final StepResult selenideStep = extractStepFromResults(results);

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -39,6 +39,8 @@ import org.openqa.selenium.logging.Logs;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
 
@@ -93,17 +95,20 @@ class AllureSelenideTest {
                     .screenshots(false)
                     .includeSelenideLocators(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
+            Allure.step("step1");
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
                     "dummyMethod()"
             );
             SelenideLogger.commitStep(log, LogEvent.EventStatus.PASS);
-            Allure.step("step1");
+            Allure.step("step2");
         });
 
-        final StepResult selenideStep = extractStepFromResults(results);
-        assertThat(selenideStep.getName())
-                .isEqualTo("step1");
+        List<StepResult> steps = extractAllStepsFromResults(results);
+        assertThat(steps).hasSize(2);
+        assertThat(steps.get(0).getName()).isEqualTo("step1");
+        // no selenide steps in between
+        assertThat(steps.get(1).getName()).isEqualTo("step2");
     }
     @AllureFeatures.Steps
     @Test
@@ -341,5 +346,10 @@ class AllureSelenideTest {
         return results
                 .getTestResults().iterator().next()
                 .getSteps().iterator().next();
+    }
+    private static List<StepResult> extractAllStepsFromResults(AllureResults results) {
+        return results
+                .getTestResults().iterator().next()
+                .getSteps();
     }
 }

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -39,7 +39,6 @@ import org.openqa.selenium.logging.Logs;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -93,7 +92,7 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
                     .screenshots(false)
-                    .includeSelenideLocators(false);
+                    .includeSelenideSteps(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             Allure.step("step1");
             final SelenideLog log = SelenideLogger.beginStep(

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -86,6 +86,27 @@ class AllureSelenideTest {
 
     @AllureFeatures.Steps
     @Test
+    void shouldNotLogSelenideLocatorSteps() {
+        final AllureResults results = runWithinTestContext(() -> {
+            final AllureSelenide selenide = new AllureSelenide()
+                    .savePageSource(false)
+                    .screenshots(false)
+                    .includeSelenideLocators(false);
+            SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
+            Allure.step("step1");
+            final SelenideLog log = SelenideLogger.beginStep(
+                    "dummy source",
+                    "dummyMethod()"
+            );
+            SelenideLogger.commitStep(log, LogEvent.EventStatus.PASS);
+        });
+
+        final StepResult selenideStep = extractStepFromResults(results);
+        assertThat(selenideStep.getName())
+                .isEqualTo("step1");
+    }
+    @AllureFeatures.Steps
+    @Test
     void shouldLogStepTimings() {
         final AllureResults results = runWithinTestContext(() -> {
             final AllureSelenide selenide = new AllureSelenide()


### PR DESCRIPTION
Now you can use .includeSelenideLocators(false) to exclude logging of all of the locators as steps. Default behaviour stays as is.

### Context

allure-selenide plugin nicely handles screenshot and source code attachments, but the logging of all the locators automatically create sometimes overbloated reports.

Checklist

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
