### PR TITLE
add support of scala 2.13 for allure-scalatest

### DIFF
--- a/allure-scalatest/build.gradle.kts
+++ b/allure-scalatest/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     agent("org.aspectj:aspectjweaver")
     api(project(":allure-java-commons"))
     implementation("org.scalatest:scalatest_$baseScalaVersion:3.1.1")
+    implementation("org.scala-lang.modules:scala-collection-compat_$baseScalaVersion:2.1.4")
     testAnnotationProcessor(project(":allure-descriptions-javadoc"))
     testImplementation("io.github.glytching:junit-extensions")
     testImplementation("org.assertj:assertj-core")

--- a/allure-scalatest/build.gradle.kts
+++ b/allure-scalatest/build.gradle.kts
@@ -4,17 +4,19 @@ description = "Allure ScalaTest Integration"
 
 apply(plugin = "scala")
 
-val availableScalaVersions = listOf("2.11", "2.12")
+val availableScalaVersions = listOf("2.11", "2.12", "2.13")
 val defaultScala211Version = "2.11.12"
 val defaultScala212Version = "2.12.8"
+val defaultScala213Version = "2.13.1"
 
-var selectedScalaVersion = defaultScala212Version
+var selectedScalaVersion = defaultScala213Version
 
 if (hasProperty("scalaVersion")) {
     val scalaVersion: String by project
     selectedScalaVersion = when (scalaVersion) {
         "2.11" -> defaultScala211Version
         "2.12" -> defaultScala212Version
+        "2.13" -> defaultScala213Version
         else -> scalaVersion
     }
 }
@@ -81,7 +83,7 @@ val agent: Configuration by configurations.creating
 dependencies {
     agent("org.aspectj:aspectjweaver")
     api(project(":allure-java-commons"))
-    implementation("org.scalatest:scalatest_$baseScalaVersion:3.0.5")
+    implementation("org.scalatest:scalatest_$baseScalaVersion:3.1.1")
     testAnnotationProcessor(project(":allure-descriptions-javadoc"))
     testImplementation("io.github.glytching:junit-extensions")
     testImplementation("org.assertj:assertj-core")

--- a/allure-scalatest/src/main/scala/io/qameta/allure/scalatest/AllureScalatest.scala
+++ b/allure-scalatest/src/main/scala/io/qameta/allure/scalatest/AllureScalatest.scala
@@ -27,7 +27,7 @@ import org.scalatest.Reporter
 import org.scalatest.events._
 import org.scalatest.exceptions.TestFailedException
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.mutable
 
 /**
@@ -185,7 +185,7 @@ class AllureScalatest(val lifecycle: AllureLifecycle) extends Reporter {
       createLanguageLabel("scala"),
       createFrameworkLabel("scalatest")
     )
-    labels ++= asScalaSet(getProvidedLabels)
+    labels ++= getProvidedLabels.asScala
 
     var links = mutable.ListBuffer[io.qameta.allure.model.Link]()
 

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/AllureScalatestTest.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/AllureScalatestTest.scala
@@ -21,10 +21,10 @@ import io.qameta.allure.scalatest.testdata._
 import io.qameta.allure.test.{AllureResults, AllureResultsWriterStub}
 import io.qameta.allure.{Allure, AllureLifecycle}
 import org.junit.jupiter.api.Test
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import org.scalatest.tools.Runner
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConverters.asScala
 import scala.collection.mutable.ListBuffer
 
 /**
@@ -35,7 +35,7 @@ class AllureScalatestTest {
   @Test
   def shouldSetName(): Unit = {
     val results = run(classOf[SimpleSpec])
-    asScalaBuffer(results.getTestResults)
+    asScala(results.getTestResults)
       .map(item => item.getName) should contain("test should be passed")
   }
 
@@ -43,7 +43,7 @@ class AllureScalatestTest {
   def shouldSetStart(): Unit = {
     val results = run(classOf[SimpleSpec])
 
-    val starts = asScalaBuffer(results.getTestResults)
+    val starts = asScala(results.getTestResults)
       .map(item => item.getStart).toList
 
     every(starts) should not be null
@@ -53,7 +53,7 @@ class AllureScalatestTest {
   def shouldSetStop(): Unit = {
     val results = run(classOf[SimpleSpec])
 
-    val stops = asScalaBuffer(results.getTestResults)
+    val stops = asScala(results.getTestResults)
       .map(item => item.getStop)
 
     every(stops) should not be null
@@ -63,7 +63,7 @@ class AllureScalatestTest {
   def shouldSetStage(): Unit = {
     val results = run(classOf[SimpleSpec])
 
-    val stages = asScalaBuffer(results.getTestResults)
+    val stages = asScala(results.getTestResults)
       .map(item => item.getStage)
 
     every(stages) shouldBe FINISHED
@@ -73,7 +73,7 @@ class AllureScalatestTest {
   def shouldSetStatus(): Unit = {
     val results = run(classOf[SimpleSpec])
 
-    val statuses = asScalaBuffer(results.getTestResults)
+    val statuses = asScala(results.getTestResults)
       .map(item => item.getStatus)
 
     every(statuses) shouldBe Status.PASSED
@@ -85,7 +85,7 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    val statuses = asScalaBuffer(results.getTestResults)
+    val statuses = asScala(results.getTestResults)
       .map(item => item.getStatus)
 
     every(statuses) shouldBe Status.FAILED
@@ -97,7 +97,7 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    val statuses = asScalaBuffer(results.getTestResults)
+    val statuses = asScala(results.getTestResults)
       .map(item => item.getStatus).toList
 
     every(statuses) should be(Status.BROKEN)
@@ -109,7 +109,7 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    val statuses = asScalaBuffer(results.getTestResults)
+    val statuses = asScala(results.getTestResults)
       .map(item => item.getStatus).toList
 
     every(statuses) should be(Status.SKIPPED)
@@ -121,8 +121,8 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    val labels = asScalaBuffer(results.getTestResults)
-      .flatMap(item => asScalaBuffer(item.getLabels))
+    val labels = asScala(results.getTestResults)
+      .flatMap(item => asScala(item.getLabels))
       .map(label => (label.getName, label.getValue))
       .toList
 
@@ -138,8 +138,8 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    val labels = asScalaBuffer(results.getTestResults)
-      .flatMap(item => asScalaBuffer(item.getLabels))
+    val labels = asScala(results.getTestResults)
+      .flatMap(item => asScala(item.getLabels))
       .map(label => (label.getName, label.getValue))
       .toList
 
@@ -152,15 +152,15 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    asScalaBuffer(results.getTestResults)
+    asScala(results.getTestResults)
       .map(item => item.getName) should contain("test should be ignored")
 
-    val statuses = asScalaBuffer(results.getTestResults)
+    val statuses = asScala(results.getTestResults)
       .map(item => item.getStatus).toList
 
     every(statuses) should be(null)
 
-    val stages = asScalaBuffer(results.getTestResults)
+    val stages = asScala(results.getTestResults)
       .map(item => item.getStage).toList
 
     every(stages) should be(Stage.FINISHED)
@@ -169,14 +169,14 @@ class AllureScalatestTest {
   @Test
   def shouldSupportJavaApi(): Unit = {
     val results = run(classOf[AllureApiSpec])
-    val steps = asScalaBuffer(results.getTestResults)
-      .flatMap(item => asScalaBuffer(item.getSteps))
+    val steps = asScala(results.getTestResults)
+      .flatMap(item => asScala(item.getSteps))
 
     steps
       .map(step => step.getName) should contain inOrder("first", "second", "third")
 
     steps.filter(step => step.getName == "second")
-      .flatMap(step => asScalaBuffer(step.getSteps))
+      .flatMap(step => asScala(step.getSteps))
       .map(step => step.getName) should contain inOrder("child1", "child2", "child3")
 
   }

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/AllureScalatestTest.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/AllureScalatestTest.scala
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test
 import org.scalatest.matchers.should.Matchers._
 import org.scalatest.tools.Runner
 
-import scala.collection.JavaConverters.asScala
 import scala.collection.mutable.ListBuffer
+import scala.jdk.CollectionConverters._
 
 /**
   * @author charlie (Dmitry Baev).
@@ -35,7 +35,7 @@ class AllureScalatestTest {
   @Test
   def shouldSetName(): Unit = {
     val results = run(classOf[SimpleSpec])
-    asScala(results.getTestResults)
+    results.getTestResults.asScala
       .map(item => item.getName) should contain("test should be passed")
   }
 
@@ -43,7 +43,7 @@ class AllureScalatestTest {
   def shouldSetStart(): Unit = {
     val results = run(classOf[SimpleSpec])
 
-    val starts = asScala(results.getTestResults)
+    val starts = results.getTestResults.asScala
       .map(item => item.getStart).toList
 
     every(starts) should not be null
@@ -53,7 +53,7 @@ class AllureScalatestTest {
   def shouldSetStop(): Unit = {
     val results = run(classOf[SimpleSpec])
 
-    val stops = asScala(results.getTestResults)
+    val stops = results.getTestResults.asScala
       .map(item => item.getStop)
 
     every(stops) should not be null
@@ -63,7 +63,7 @@ class AllureScalatestTest {
   def shouldSetStage(): Unit = {
     val results = run(classOf[SimpleSpec])
 
-    val stages = asScala(results.getTestResults)
+    val stages = results.getTestResults.asScala
       .map(item => item.getStage)
 
     every(stages) shouldBe FINISHED
@@ -73,7 +73,7 @@ class AllureScalatestTest {
   def shouldSetStatus(): Unit = {
     val results = run(classOf[SimpleSpec])
 
-    val statuses = asScala(results.getTestResults)
+    val statuses = results.getTestResults.asScala
       .map(item => item.getStatus)
 
     every(statuses) shouldBe Status.PASSED
@@ -85,7 +85,7 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    val statuses = asScala(results.getTestResults)
+    val statuses = results.getTestResults.asScala
       .map(item => item.getStatus)
 
     every(statuses) shouldBe Status.FAILED
@@ -97,7 +97,7 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    val statuses = asScala(results.getTestResults)
+    val statuses = results.getTestResults.asScala
       .map(item => item.getStatus).toList
 
     every(statuses) should be(Status.BROKEN)
@@ -109,7 +109,7 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    val statuses = asScala(results.getTestResults)
+    val statuses = results.getTestResults.asScala
       .map(item => item.getStatus).toList
 
     every(statuses) should be(Status.SKIPPED)
@@ -121,8 +121,8 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    val labels = asScala(results.getTestResults)
-      .flatMap(item => asScala(item.getLabels))
+    val labels = results.getTestResults.asScala
+      .flatMap(item => item.getLabels.asScala)
       .map(label => (label.getName, label.getValue))
       .toList
 
@@ -138,8 +138,8 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    val labels = asScala(results.getTestResults)
-      .flatMap(item => asScala(item.getLabels))
+    val labels = results.getTestResults.asScala
+      .flatMap(item => item.getLabels.asScala)
       .map(label => (label.getName, label.getValue))
       .toList
 
@@ -152,15 +152,15 @@ class AllureScalatestTest {
 
     results.getTestResults should have length 1
 
-    asScala(results.getTestResults)
+    results.getTestResults.asScala
       .map(item => item.getName) should contain("test should be ignored")
 
-    val statuses = asScala(results.getTestResults)
+    val statuses = results.getTestResults.asScala
       .map(item => item.getStatus).toList
 
     every(statuses) should be(null)
 
-    val stages = asScala(results.getTestResults)
+    val stages = results.getTestResults.asScala
       .map(item => item.getStage).toList
 
     every(stages) should be(Stage.FINISHED)
@@ -169,14 +169,14 @@ class AllureScalatestTest {
   @Test
   def shouldSupportJavaApi(): Unit = {
     val results = run(classOf[AllureApiSpec])
-    val steps = asScala(results.getTestResults)
-      .flatMap(item => asScala(item.getSteps))
+    val steps = results.getTestResults.asScala
+      .flatMap(item => item.getSteps.asScala)
 
     steps
       .map(step => step.getName) should contain inOrder("first", "second", "third")
 
     steps.filter(step => step.getName == "second")
-      .flatMap(step => asScala(step.getSteps))
+      .flatMap(step => step.getSteps.asScala)
       .map(step => step.getName) should contain inOrder("child1", "child2", "child3")
 
   }

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/AllureApiSpec.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/AllureApiSpec.scala
@@ -17,12 +17,12 @@ package io.qameta.allure.scalatest.testdata
 
 import io.qameta.allure.Allure.{StepContext, step}
 import io.qameta.allure.scalatest.AllureScalatestContext
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author charlie (Dmitry Baev).
   */
-class AllureApiSpec extends FlatSpec {
+class AllureApiSpec extends AnyFlatSpec {
 
   "test" should "be passed" in new AllureScalatestContext {
     step("first")
@@ -30,12 +30,12 @@ class AllureApiSpec extends FlatSpec {
       step("child1")
       step("child2")
       step("child3")
-      Unit
+      () =>
     })
     step("third", (context: StepContext) => {
       val a = context.parameter("a", 123L)
       val b = context.parameter("b", "hello")
-      Unit
+      () =>
     })
   }
 

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/AnnotationsOnClassSpec.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/AnnotationsOnClassSpec.scala
@@ -16,7 +16,7 @@
 package io.qameta.allure.scalatest.testdata
 
 import io.qameta.allure._
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
 /**
   * @author charlie (Dmitry Baev).
@@ -28,7 +28,7 @@ import org.scalatest.FunSuite
 @Link("https://example.org")
 @Issue("https://example.org/issue/1")
 @TmsLink("https://example.org/tms/1")
-class AnnotationsOnClassSpec extends FunSuite {
+class AnnotationsOnClassSpec extends AnyFunSuite {
 
   test("demo test") {
   }

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/BrokenSpec.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/BrokenSpec.scala
@@ -15,13 +15,13 @@
  */
 package io.qameta.allure.scalatest.testdata
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author charlie (Dmitry Baev).
   */
-class BrokenSpec extends FlatSpec {
+class BrokenSpec extends AnyFlatSpec {
 
   "test" should "be failed" in {
     throw new RuntimeException("hell no")

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/CancelledSpec.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/CancelledSpec.scala
@@ -15,13 +15,13 @@
  */
 package io.qameta.allure.scalatest.testdata
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
 
 /**
   * @author charlie (Dmitry Baev).
   */
-class CancelledSpec extends FlatSpec {
+class CancelledSpec extends AnyFlatSpec {
 
   "test" should "be cancelled" in {
     cancel("hell yes")

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/FailedSpec.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/FailedSpec.scala
@@ -15,13 +15,13 @@
  */
 package io.qameta.allure.scalatest.testdata
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
 
 /**
   * @author charlie (Dmitry Baev).
   */
-class FailedSpec extends FlatSpec {
+class FailedSpec extends AnyFlatSpec {
 
   "test" should "be failed" in {
     "hello" shouldBe "hell no"

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/IgnoredSpec.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/IgnoredSpec.scala
@@ -15,13 +15,14 @@
  */
 package io.qameta.allure.scalatest.testdata
 
-import org.scalatest.{FlatSpec, Ignore}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Ignore
 
 /**
   * @author charlie (Dmitry Baev).
   */
 @Ignore
-class IgnoredSpec extends FlatSpec {
+class IgnoredSpec extends AnyFlatSpec {
 
   "test" should "be ignored" in {
   }

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/SeveritySpec.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/SeveritySpec.scala
@@ -16,13 +16,13 @@
 package io.qameta.allure.scalatest.testdata
 
 import io.qameta.allure.{Severity, SeverityLevel}
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author charlie (Dmitry Baev).
   */
 @Severity(SeverityLevel.BLOCKER)
-class SeveritySpec extends FlatSpec {
+class SeveritySpec extends AnyFlatSpec {
 
   "test" should "be passed" in {
   }

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/SimpleSpec.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/SimpleSpec.scala
@@ -15,12 +15,12 @@
  */
 package io.qameta.allure.scalatest.testdata
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
 /**
   * @author charlie (Dmitry Baev).
   */
-class SimpleSpec extends FlatSpec {
+class SimpleSpec extends AnyFlatSpec {
 
   "test" should "be passed" in {
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ val qualityConfigsDir by extra("$gradleScriptDir/quality-configs")
 val spotlessDtr by extra("$qualityConfigsDir/spotless")
 
 tasks.withType(Wrapper::class) {
-    gradleVersion = "6.0.1"
+    gradleVersion = "6.3"
 }
 
 plugins {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with isses use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
Fixed compiling under scala 2.13, set  allure-scalatest scala 2.13 as default, fixed most of 'deprecated'

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
