### PR TITLE
Reuse Selenide screenshots 

### DIFF
--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -100,7 +100,7 @@ public class AllureSelenide implements LogEventListener {
                 .orElseGet(AllureSelenide::takeNewScreenshot);
     }
 
-    private static Optional<byte[]> convertScreenshotFileToByteArray(File file) {
+    private static Optional<byte[]> convertScreenshotFileToByteArray(final File file) {
         try {
             return Optional.of(Files.readAllBytes(file.toPath()));
         } catch (IOException e) {


### PR DESCRIPTION
### Context
The idea behind it is to not take screenshot 2 times (by Selenide and by Allure) but check if Selenide has already taken one and re-use it otherwise take a new screenshot.

Selenide issue history https://github.com/selenide/selenide/issues/1002

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
