### PR TITLE
fix link() method with one parameter

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
@@ -286,7 +286,7 @@ public final class Allure {
      * @param url the link's url.
      */
     public static void link(final String url) {
-        link(null, url);
+        link(url, url);
     }
 
     /**

--- a/allure-java-commons/src/test/java/io/qameta/allure/AllureTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AllureTest.java
@@ -201,7 +201,7 @@ class AllureTest {
                 .contains(
                         tuple(first.getName(), first.getType(), first.getUrl()),
                         tuple(second.getName(), null, second.getUrl()),
-                        tuple(null, null, third.getUrl())
+                        tuple(third.getUrl(), null, third.getUrl())
                 );
     }
 


### PR DESCRIPTION
<!---
Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with isses use the following notation: (fixes #123, fixes #321\)

-->

### Context
Using `link("http://ya.ru")` method with one parameter generates a link with an empty name in the Allure Report
Results *.json file contains:
```
"links":[{"url":"https://docs.qameta.io"}]}
```
And in HTML report it shows this code:
```
<a class="link" href="https://docs.qameta.io" target="_blank"></a>
```

After this fix `link()` method with one param generates a link with the same name and URL (name duplicates URL).

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Fix unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
