### PR TITLE
Cucumber gherkin version 15.0.2 to support cucumber 6.9.0

### DIFF
--- a/allure-cucumber6-jvm/build.gradle.kts
+++ b/allure-cucumber6-jvm/build.gradle.kts
@@ -2,8 +2,8 @@ description = "Allure CucumberJVM 6.0"
 
 val agent: Configuration by configurations.creating
 
-val cucumberVersion = "6.1.1"
-val cucumberGherkinVersion = "5.1.0"
+val cucumberVersion = "6.9.0"
+val cucumberGherkinVersion = "15.0.2"
 
 dependencies {
     agent("org.aspectj:aspectjweaver")

--- a/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/LabelBuilder.java
+++ b/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/LabelBuilder.java
@@ -15,8 +15,8 @@
  */
 package io.qameta.allure.cucumber6jvm;
 
+import io.cucumber.messages.Messages.GherkinDocument.Feature;
 import io.cucumber.plugin.event.TestCase;
-import gherkin.ast.Feature;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.util.ResultsUtils;

--- a/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/TagParser.java
+++ b/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/TagParser.java
@@ -15,7 +15,7 @@
  */
 package io.qameta.allure.cucumber6jvm;
 
-import gherkin.ast.Feature;
+import io.cucumber.messages.Messages.GherkinDocument.Feature;
 import io.cucumber.plugin.event.TestCase;
 import io.qameta.allure.SeverityLevel;
 
@@ -52,7 +52,7 @@ class TagParser {
     private boolean getStatusDetailByTag(final String tagName) {
         return scenario.getTags().stream()
                 .anyMatch(tag -> tag.equalsIgnoreCase(tagName))
-                || feature.getTags().stream()
+                || feature.getTagsList().stream()
                 .anyMatch(tag -> tag.getName().equalsIgnoreCase(tagName));
     }
 

--- a/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/testsourcemodel/TestSourcesModel.java
+++ b/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/testsourcemodel/TestSourcesModel.java
@@ -15,31 +15,41 @@
  */
 package io.qameta.allure.cucumber6jvm.testsourcemodel;
 
-import gherkin.AstBuilder;
-import gherkin.Parser;
-import gherkin.ParserException;
-import gherkin.TokenMatcher;
-import gherkin.ast.Examples;
-import gherkin.ast.Feature;
-import gherkin.ast.GherkinDocument;
-import gherkin.ast.Node;
-import gherkin.ast.ScenarioDefinition;
-import gherkin.ast.ScenarioOutline;
-import gherkin.ast.Step;
-import gherkin.ast.TableRow;
+import io.cucumber.gherkin.Gherkin;
+import io.cucumber.messages.Messages;
+import io.cucumber.messages.Messages.GherkinDocument;
+import io.cucumber.messages.Messages.GherkinDocument.Feature;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.Background;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.FeatureChild;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.FeatureChild.RuleChild;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.Scenario;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.Scenario.Examples;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.Step;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.TableRow;
+import io.cucumber.messages.internal.com.google.protobuf.GeneratedMessageV3;
 import io.cucumber.plugin.event.TestSourceRead;
+
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
-public final class TestSourcesModel {
+import static io.cucumber.gherkin.Gherkin.makeSourceEnvelope;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
+final class TestSourcesModel {
     private final Map<URI, TestSourceRead> pathToReadEventMap = new HashMap<>();
     private final Map<URI, GherkinDocument> pathToAstMap = new HashMap<>();
     private final Map<URI, Map<Integer, AstNode>> pathToNodeMap = new HashMap<>();
 
-    public static ScenarioDefinition getScenarioDefinition(final AstNode astNode) {
-        return astNode.node instanceof ScenarioDefinition ? (ScenarioDefinition) astNode.node
-                : (ScenarioDefinition) astNode.parent.parent.node;
+    public static Scenario getScenarioDefinition(final AstNode astNode) {
+        AstNode candidate = astNode;
+        while (candidate != null && !(candidate.node instanceof Scenario)) {
+            candidate = candidate.parent;
+        }
+        return candidate == null ? null : (Scenario) candidate.node;
     }
 
     public void addTestSourceReadEvent(final URI path, final TestSourceRead event) {
@@ -56,6 +66,100 @@ public final class TestSourcesModel {
         return null;
     }
 
+    private void parseGherkinSource(final URI path) {
+        if (!pathToReadEventMap.containsKey(path)) {
+            return;
+        }
+        final String source = pathToReadEventMap.get(path).getSource();
+
+        final List<Messages.Envelope> sources = singletonList(
+                makeSourceEnvelope(source, path.toString()));
+
+        final List<Messages.Envelope> envelopes = Gherkin.fromSources(
+                sources,
+                true,
+                true,
+                true,
+                () -> String.valueOf(UUID.randomUUID())).collect(toList());
+
+        final GherkinDocument gherkinDocument = envelopes.stream()
+                .filter(Messages.Envelope::hasGherkinDocument)
+                .map(Messages.Envelope::getGherkinDocument)
+                .findFirst()
+                .orElse(null);
+
+        pathToAstMap.put(path, gherkinDocument);
+        final Map<Integer, AstNode> nodeMap = new HashMap<>();
+        final AstNode currentParent = createAstNode(gherkinDocument.getFeature(), null);
+        for (FeatureChild child : gherkinDocument.getFeature().getChildrenList()) {
+            processFeatureDefinition(nodeMap, child, currentParent);
+        }
+        pathToNodeMap.put(path, nodeMap);
+
+    }
+
+    private void processFeatureDefinition(
+            final Map<Integer, AstNode> nodeMap, final FeatureChild child, final AstNode currentParent) {
+        if (child.hasBackground()) {
+            processBackgroundDefinition(nodeMap, child.getBackground(), currentParent);
+        } else if (child.hasScenario()) {
+            processScenarioDefinition(nodeMap, child.getScenario(), currentParent);
+        } else if (child.hasRule()) {
+            final AstNode childNode = createAstNode(child.getRule(), currentParent);
+            nodeMap.put(child.getRule().getLocation().getLine(), childNode);
+            for (RuleChild ruleChild : child.getRule().getChildrenList()) {
+                processRuleDefinition(nodeMap, ruleChild, childNode);
+            }
+        }
+    }
+
+    private void processBackgroundDefinition(
+            final Map<Integer, AstNode> nodeMap, final Background background, final AstNode currentParent
+    ) {
+        final AstNode childNode = createAstNode(background, currentParent);
+        nodeMap.put(background.getLocation().getLine(), childNode);
+        for (Step step : background.getStepsList()) {
+            nodeMap.put(step.getLocation().getLine(), createAstNode(step, childNode));
+        }
+    }
+
+    private void processScenarioDefinition(
+            final Map<Integer, AstNode> nodeMap, final Scenario child, final AstNode currentParent) {
+        final AstNode childNode = createAstNode(child, currentParent);
+        nodeMap.put(child.getLocation().getLine(), childNode);
+        for (Step step : child.getStepsList()) {
+            nodeMap.put(step.getLocation().getLine(), createAstNode(step, childNode));
+        }
+        if (child.getExamplesCount() > 0) {
+            processScenarioOutlineExamples(nodeMap, child, childNode);
+        }
+    }
+
+    private void processRuleDefinition(
+            final Map<Integer, AstNode> nodeMap, final RuleChild child, final AstNode currentParent) {
+        if (child.hasBackground()) {
+            processBackgroundDefinition(nodeMap, child.getBackground(), currentParent);
+        } else if (child.hasScenario()) {
+            processScenarioDefinition(nodeMap, child.getScenario(), currentParent);
+        }
+    }
+
+    private void processScenarioOutlineExamples(
+            final Map<Integer, AstNode> nodeMap, final Scenario scenarioOutline, final AstNode parent
+    ) {
+        for (Examples examples : scenarioOutline.getExamplesList()) {
+            final AstNode examplesNode = createAstNode(examples, parent);
+            final TableRow headerRow = examples.getTableHeader();
+            final AstNode headerNode = createAstNode(headerRow, examplesNode);
+            nodeMap.put(headerRow.getLocation().getLine(), headerNode);
+            for (int i = 0; i < examples.getTableBodyCount(); ++i) {
+                final TableRow examplesRow = examples.getTableBody(i);
+                final AstNode expandedScenarioNode = createAstNode(examplesRow, examplesNode);
+                nodeMap.put(examplesRow.getLocation().getLine(), expandedScenarioNode);
+            }
+        }
+    }
+
     public AstNode getAstNode(final URI path, final int line) {
         if (!pathToNodeMap.containsKey(path)) {
             parseGherkinSource(path);
@@ -66,92 +170,15 @@ public final class TestSourcesModel {
         return null;
     }
 
-    private void parseGherkinSource(final URI path) {
-        if (!pathToReadEventMap.containsKey(path)) {
-            return;
-        }
-        final Parser<GherkinDocument> parser = new Parser<>(new AstBuilder());
-        final TokenMatcher matcher = new TokenMatcher();
-        try {
-            final GherkinDocument gherkinDocument = parser.parse(pathToReadEventMap.get(path).getSource(),
-                    matcher);
-            pathToAstMap.put(path, gherkinDocument);
-            final Map<Integer, AstNode> nodeMap = new HashMap<>();
-            final AstNode currentParent = new AstNode(gherkinDocument.getFeature(), null);
-            for (ScenarioDefinition child : gherkinDocument.getFeature().getChildren()) {
-                processScenarioDefinition(nodeMap, child, currentParent);
-            }
-            pathToNodeMap.put(path, nodeMap);
-        } catch (ParserException e) {
-            throw new IllegalStateException("You are using a plugin that only supports till Gherkin 5.\n"
-                    + "Please check if the Gherkin provided follows the standard of Gherkin 5\n", e
-            );
-        }
+    private AstNode createAstNode(final GeneratedMessageV3 node, final AstNode astNode) {
+        return createAstNode(node, astNode);
     }
 
-    private void processScenarioDefinition(final Map<Integer, AstNode> nodeMap, final ScenarioDefinition child,
-                                           final AstNode currentParent) {
-        final AstNode childNode = new AstNode(child, currentParent);
-        nodeMap.put(child.getLocation().getLine(), childNode);
-        for (Step step : child.getSteps()) {
-            nodeMap.put(step.getLocation().getLine(), createAstNode(step, childNode));
-        }
-        if (child instanceof ScenarioOutline) {
-            processScenarioOutlineExamples(nodeMap, (ScenarioOutline) child, childNode);
-        }
-    }
-
-    private void processScenarioOutlineExamples(final Map<Integer, AstNode> nodeMap,
-                                                final ScenarioOutline scenarioOutline,
-                                                final AstNode childNode) {
-        for (Examples examples : scenarioOutline.getExamples()) {
-            final AstNode examplesNode = createAstNode(examples, childNode);
-            final TableRow headerRow = examples.getTableHeader();
-            final AstNode headerNode = createAstNode(headerRow, examplesNode);
-            nodeMap.put(headerRow.getLocation().getLine(), headerNode);
-            for (int i = 0; i < examples.getTableBody().size(); ++i) {
-                final TableRow examplesRow = examples.getTableBody().get(i);
-                final Node rowNode = createExamplesRowWrapperNode(examplesRow, i);
-                final AstNode expandedScenarioNode = createAstNode(rowNode, examplesNode);
-                nodeMap.put(examplesRow.getLocation().getLine(), expandedScenarioNode);
-            }
-        }
-    }
-
-    private static ExamplesRowWrapperNode createExamplesRowWrapperNode(final Node examplesRow, final int bodyRowIndex) {
-        return new ExamplesRowWrapperNode(examplesRow, bodyRowIndex);
-    }
-
-    private static AstNode createAstNode(final Node node, final AstNode astNode) {
-        return new AstNode(node, astNode);
-    }
-
-    static class ExamplesRowWrapperNode extends Node {
-        private final int bodyRowIndex;
-
-        public int getBodyRowIndex() {
-            return bodyRowIndex;
-        }
-
-        ExamplesRowWrapperNode(final Node examplesRow, final int bodyRowIndex) {
-            super(examplesRow.getLocation());
-            this.bodyRowIndex = bodyRowIndex;
-        }
-    }
-
-    static class AstNode {
-        private final Node node;
+    private static class AstNode {
+        private final GeneratedMessageV3 node;
         private final AstNode parent;
 
-        public Node getNode() {
-            return node;
-        }
-
-        public AstNode getParent() {
-            return parent;
-        }
-
-        AstNode(final Node node, final AstNode parent) {
+        AstNode(final GeneratedMessageV3 node, final AstNode parent) {
             this.node = node;
             this.parent = parent;
         }

--- a/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/testsourcemodel/TestSourcesModelProxy.java
+++ b/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/testsourcemodel/TestSourcesModelProxy.java
@@ -15,10 +15,10 @@
  */
 package io.qameta.allure.cucumber6jvm.testsourcemodel;
 
-import gherkin.GherkinDialect;
-import gherkin.GherkinDialectProvider;
-import gherkin.ast.Feature;
-import gherkin.ast.ScenarioDefinition;
+import io.cucumber.gherkin.GherkinDialect;
+import io.cucumber.gherkin.GherkinDialectProvider;
+import io.cucumber.messages.Messages.GherkinDocument.Feature;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.Scenario;
 import io.cucumber.plugin.event.TestSourceRead;
 
 import java.net.URI;
@@ -43,8 +43,8 @@ public class TestSourcesModelProxy {
         return testSources.getFeature(path);
     }
 
-    public ScenarioDefinition getScenarioDefinition(final URI path, final int line) {
-        return testSources.getScenarioDefinition(testSources.getAstNode(path, line));
+    public Scenario getScenarioDefinition(final URI path, final int line) {
+        return TestSourcesModel.getScenarioDefinition(testSources.getAstNode(path, line));
     }
 
     public String getKeywordFromSource(final URI uri, final int stepLine) {

--- a/allure-cucumber6-jvm/src/test/java/io/qameta/allure/cucumber6jvm/AllureCucumber6JvmTest.java
+++ b/allure-cucumber6-jvm/src/test/java/io/qameta/allure/cucumber6jvm/AllureCucumber6JvmTest.java
@@ -504,16 +504,16 @@ class AllureCucumber6JvmTest {
         assertThat(testResults)
                 .extracting(TestResult::getName, TestResult::getStatus)
                 .containsExactlyInAnyOrder(
-                        tuple("Add a to b", Status.SKIPPED)
+                        tuple("Add a to b", Status.PASSED)
                 );
 
         assertThat(testResults.get(0).getSteps())
                 .extracting(StepResult::getName, StepResult::getStatus)
                 .containsExactlyInAnyOrder(
-                        tuple("Given  a is 5", Status.SKIPPED),
-                        tuple("And  b is 10", Status.SKIPPED),
-                        tuple("When  I add a to b", Status.SKIPPED),
-                        tuple("Then  result is 15", Status.SKIPPED)
+                        tuple("Given  a is 5", Status.PASSED),
+                        tuple("And  b is 10", Status.PASSED),
+                        tuple("When  I add a to b", Status.PASSED),
+                        tuple("Then  result is 15", Status.PASSED)
                 );
     }
 
@@ -529,28 +529,28 @@ class AllureCucumber6JvmTest {
         assertThat(testResults)
                 .extracting(TestResult::getName, TestResult::getStatus)
                 .startsWith(
-                        tuple("Simple scenario with Before and After hooks", Status.SKIPPED)
+                        tuple("Simple scenario with Before and After hooks", Status.PASSED)
                 );
 
         assertThat(writer.getTestResultContainers().get(0).getBefores())
                 .extracting(FixtureResult::getName, FixtureResult::getStatus)
                 .containsExactlyInAnyOrder(
-                        tuple("io.qameta.allure.cucumber6jvm.samples.HookSteps.beforeHook()", Status.SKIPPED)
+                        tuple("io.qameta.allure.cucumber6jvm.samples.HookSteps.beforeHook()", Status.PASSED)
                 );
 
         assertThat(writer.getTestResultContainers().get(0).getAfters())
                 .extracting(FixtureResult::getName, FixtureResult::getStatus)
                 .containsExactlyInAnyOrder(
-                        tuple("io.qameta.allure.cucumber6jvm.samples.HookSteps.afterHook()", Status.SKIPPED)
+                        tuple("io.qameta.allure.cucumber6jvm.samples.HookSteps.afterHook()", Status.PASSED)
                 );
 
         assertThat(testResults.get(0).getSteps())
                 .extracting(StepResult::getName, StepResult::getStatus)
                 .containsExactlyInAnyOrder(
-                        tuple("Given  a is 7", Status.SKIPPED),
-                        tuple("And  b is 8", Status.SKIPPED),
-                        tuple("When  I add a to b", Status.SKIPPED),
-                        tuple("Then  result is 15", Status.SKIPPED)
+                        tuple("Given  a is 7", Status.PASSED),
+                        tuple("And  b is 8", Status.PASSED),
+                        tuple("When  I add a to b", Status.PASSED),
+                        tuple("Then  result is 15", Status.PASSED)
                 );
     }
 


### PR DESCRIPTION
* Cucumber gherkin version 15.0.2 to support cucumber 6.9.0
* AllureCucumber6Jvm corresponding update
* Dry-run steps result changed to PASSED due to cucumber 6 behavior change: https://github.com/cucumber/cucumber-jvm/pull/2109

### Context
AllureCucumber6Jvm is incompatible with cucomber-jvm-6.9.0. 
It uses io.cucumber:gherkin-5.0.1 while cucumber-jvm-6.9.0 uses 15.x.x.
io.cucumber:gherkin apis are too different to force 5.0.1 for cucumber-jvm-6.9.0 and vice-versa.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
