### PR TITLE
Add screenshots for passed steps feature for allure-java

### DIFF
--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -52,6 +52,7 @@ public class AllureSelenide implements LogEventListener {
     private boolean saveScreenshots = true;
     private boolean savePageHtml = true;
     private boolean includeSelenideLocatorsSteps = true;
+    private boolean saveScreenShotsWhenPassed = false;
     private final Map<LogType, Level> logTypesToSave = new HashMap<>();
     private final AllureLifecycle lifecycle;
 
@@ -75,6 +76,12 @@ public class AllureSelenide implements LogEventListener {
 
     public AllureSelenide includeSelenideSteps(final boolean includeSelenideSteps) {
         this.includeSelenideLocatorsSteps = includeSelenideSteps;
+        return this;
+    }
+
+    public AllureSelenide saveScreenShotsWhenPassed(final boolean saveScreenShotsWhenPassed)
+    {
+        this.saveScreenShotsWhenPassed = saveScreenShotsWhenPassed;
         return this;
     }
 
@@ -144,6 +151,15 @@ public class AllureSelenide implements LogEventListener {
                                 final byte[] content = getBrowserLogs(logType, level).getBytes(UTF_8);
                                 lifecycle.addAttachment("Logs from: " + logType, "application/json", ".txt", content);
                             });
+                }
+            });
+        } 
+        else if (event.getStatus().equals(LogEvent.EventStatus.PASS))
+        {
+            lifecycle.getCurrentTestCaseOrStep().ifPresent(parentUuid -> {
+                if (saveScreenShotsWhenPassed) {
+                    getScreenshotBytes()
+                            .ifPresent(bytes -> lifecycle.addAttachment("Screenshot", "image/png", "png", bytes));
                 }
             });
         }

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -83,7 +83,7 @@ public class AllureSelenide implements LogEventListener {
         return this;
     }
 
-    public AllureSelenide saveScreenShotsWhenPassed(final boolean saveScreenShotsWhenPassed) {
+    public AllureSelenide saveScreenShotsForPassedSteps(final boolean saveScreenShotsWhenPassed) {
         this.saveScreenShotsWhenPassed = saveScreenShotsWhenPassed;
         return this;
     }

--- a/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
+++ b/allure-selenide/src/main/java/io/qameta/allure/selenide/AllureSelenide.java
@@ -49,10 +49,14 @@ public class AllureSelenide implements LogEventListener {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AllureSelenide.class);
 
+    private static final String SCREENSHOT_NAME = "Screenshot";
+    private static final String SCREENSHOT_MIME_TYPE = "image/png";
+    private static final String SCREENSHOT_FILE_TYPE = "png";
+
     private boolean saveScreenshots = true;
     private boolean savePageHtml = true;
     private boolean includeSelenideLocatorsSteps = true;
-    private boolean saveScreenShotsWhenPassed = false;
+    private boolean saveScreenShotsWhenPassed;
     private final Map<LogType, Level> logTypesToSave = new HashMap<>();
     private final AllureLifecycle lifecycle;
 
@@ -79,8 +83,7 @@ public class AllureSelenide implements LogEventListener {
         return this;
     }
 
-    public AllureSelenide saveScreenShotsWhenPassed(final boolean saveScreenShotsWhenPassed)
-    {
+    public AllureSelenide saveScreenShotsWhenPassed(final boolean saveScreenShotsWhenPassed) {
         this.saveScreenShotsWhenPassed = saveScreenShotsWhenPassed;
         return this;
     }
@@ -138,8 +141,8 @@ public class AllureSelenide implements LogEventListener {
         if (event.getStatus().equals(LogEvent.EventStatus.FAIL)) {
             lifecycle.getCurrentTestCaseOrStep().ifPresent(parentUuid -> {
                 if (saveScreenshots) {
-                    getScreenshotBytes()
-                            .ifPresent(bytes -> lifecycle.addAttachment("Screenshot", "image/png", "png", bytes));
+                    getScreenshotBytes().ifPresent(bytes 
+                        -> lifecycle.addAttachment(SCREENSHOT_NAME, SCREENSHOT_MIME_TYPE, SCREENSHOT_FILE_TYPE, bytes));
                 }
                 if (savePageHtml) {
                     getPageSourceBytes()
@@ -153,13 +156,11 @@ public class AllureSelenide implements LogEventListener {
                             });
                 }
             });
-        } 
-        else if (event.getStatus().equals(LogEvent.EventStatus.PASS))
-        {
+        } else if (event.getStatus().equals(LogEvent.EventStatus.PASS)) {
             lifecycle.getCurrentTestCaseOrStep().ifPresent(parentUuid -> {
                 if (saveScreenShotsWhenPassed) {
-                    getScreenshotBytes()
-                            .ifPresent(bytes -> lifecycle.addAttachment("Screenshot", "image/png", "png", bytes));
+                    getScreenshotBytes().ifPresent(bytes 
+                        -> lifecycle.addAttachment(SCREENSHOT_NAME, SCREENSHOT_MIME_TYPE, SCREENSHOT_FILE_TYPE, bytes));
                 }
             });
         }

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -65,7 +65,8 @@ class AllureSelenideTest {
         final AllureResults results = runWithinTestContext(() -> {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
-                    .screenshots(false);
+                    .screenshots(false)
+                    .saveScreenShotsWhenPassed(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
@@ -92,6 +93,7 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
                     .screenshots(false)
+                    .saveScreenShotsWhenPassed(false)
                     .includeSelenideSteps(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             Allure.step("step1");
@@ -115,7 +117,8 @@ class AllureSelenideTest {
         final AllureResults results = runWithinTestContext(() -> {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
-                    .screenshots(false);
+                    .screenshots(false)
+                    .saveScreenShotsWhenPassed(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
@@ -149,7 +152,8 @@ class AllureSelenideTest {
         final AllureResults results = runWithinTestContext(() -> {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
-                    .screenshots(true);
+                    .screenshots(true)
+                    .saveScreenShotsWhenPassed(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
@@ -158,6 +162,46 @@ class AllureSelenideTest {
                     "param2"
             );
             SelenideLogger.commitStep(log, new Exception("something went wrong"));
+        });
+
+        final StepResult selenideStep = extractStepFromResults(results);
+        assertThat(selenideStep.getAttachments())
+                .hasSize(1);
+
+        final Attachment attachment = selenideStep.getAttachments().iterator().next();
+        assertThat(results.getAttachments())
+                .containsKey(attachment.getSource());
+
+        final String attachmentContent = new String(
+                results.getAttachments().get(attachment.getSource()),
+                StandardCharsets.UTF_8
+        );
+
+        assertThat(attachmentContent)
+                .isEqualTo("hello");
+    }
+
+    @AllureFeatures.Attachments
+    @Test
+    void shouldSaveScreenshotsOnPass() {
+        final ChromeDriver wdMock = mock(ChromeDriver.class);
+        WebDriverRunner.setWebDriver(wdMock);
+        doReturn("hello".getBytes(StandardCharsets.UTF_8))
+                .when(wdMock).getScreenshotAs(OutputType.BYTES);
+
+        final AllureResults results = runWithinTestContext(() -> {
+            final AllureSelenide selenide = new AllureSelenide()
+                    .savePageSource(false)
+                    .screenshots(false)
+                    .saveScreenShotsWhenPassed(true);
+            SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
+            final SelenideLog log = SelenideLogger.beginStep(
+                    "dummy source",
+                    "dummyMethod()",
+                    "param1",
+                    "param2"
+            );
+            SelenideLogger.commitStep(log, LogEvent.EventStatus.PASS);
         });
 
         final StepResult selenideStep = extractStepFromResults(results);
@@ -188,7 +232,8 @@ class AllureSelenideTest {
         final AllureResults results = runWithinTestContext(() -> {
             final AllureSelenide selenide = new AllureSelenide()
                     .screenshots(false)
-                    .savePageSource(true);
+                    .savePageSource(true)
+                    .saveScreenShotsWhenPassed(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
@@ -222,7 +267,8 @@ class AllureSelenideTest {
         final AllureResults results = runWithinTestContext(() -> {
             final AllureSelenide selenide = new AllureSelenide()
                 .savePageSource(false)
-                .screenshots(true);
+                .screenshots(true)
+                .saveScreenShotsWhenPassed(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                 "open",
@@ -258,7 +304,8 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                     .enableLogs(LogType.BROWSER, Level.ALL)
                     .savePageSource(false)
-                    .screenshots(false);
+                    .screenshots(false)
+                    .saveScreenShotsWhenPassed(false);
 
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
 
@@ -289,7 +336,8 @@ class AllureSelenideTest {
         final AllureResults results = runWithinTestContext(() -> {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
-                    .screenshots(false);
+                    .screenshots(false)
+                    .saveScreenShotsWhenPassed(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
@@ -319,7 +367,8 @@ class AllureSelenideTest {
         final AllureResults results = runWithinTestContext(() -> {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
-                    .screenshots(false);
+                    .screenshots(false)
+                    .saveScreenShotsWhenPassed(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",

--- a/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
+++ b/allure-selenide/src/test/java/io/qameta/allure/selenide/AllureSelenideTest.java
@@ -66,7 +66,7 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
                     .screenshots(false)
-                    .saveScreenShotsWhenPassed(false);
+                    .saveScreenShotsForPassedSteps(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
@@ -93,7 +93,7 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
                     .screenshots(false)
-                    .saveScreenShotsWhenPassed(false)
+                    .saveScreenShotsForPassedSteps(false)
                     .includeSelenideSteps(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             Allure.step("step1");
@@ -118,7 +118,7 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
                     .screenshots(false)
-                    .saveScreenShotsWhenPassed(false);
+                    .saveScreenShotsForPassedSteps(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
@@ -153,7 +153,7 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
                     .screenshots(true)
-                    .saveScreenShotsWhenPassed(false);
+                    .saveScreenShotsForPassedSteps(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
@@ -193,7 +193,7 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
                     .screenshots(false)
-                    .saveScreenShotsWhenPassed(true);
+                    .saveScreenShotsForPassedSteps(true);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
@@ -233,7 +233,7 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                     .screenshots(false)
                     .savePageSource(true)
-                    .saveScreenShotsWhenPassed(false);
+                    .saveScreenShotsForPassedSteps(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
@@ -268,7 +268,7 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                 .savePageSource(false)
                 .screenshots(true)
-                .saveScreenShotsWhenPassed(false);
+                .saveScreenShotsForPassedSteps(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                 "open",
@@ -305,7 +305,7 @@ class AllureSelenideTest {
                     .enableLogs(LogType.BROWSER, Level.ALL)
                     .savePageSource(false)
                     .screenshots(false)
-                    .saveScreenShotsWhenPassed(false);
+                    .saveScreenShotsForPassedSteps(false);
 
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
 
@@ -337,7 +337,7 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
                     .screenshots(false)
-                    .saveScreenShotsWhenPassed(false);
+                    .saveScreenShotsForPassedSteps(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",
@@ -368,7 +368,7 @@ class AllureSelenideTest {
             final AllureSelenide selenide = new AllureSelenide()
                     .savePageSource(false)
                     .screenshots(false)
-                    .saveScreenShotsWhenPassed(false);
+                    .saveScreenShotsForPassedSteps(false);
             SelenideLogger.addListener(UUID.randomUUID().toString(), selenide);
             final SelenideLog log = SelenideLogger.beginStep(
                     "dummy source",


### PR DESCRIPTION
### Context
A lot of our customers and users Allure requested the feature to easily create screenshots also if a Step passes.
I tried to match the style of the already available functions.
I added a unit test for this functionality and adjusted the old ones.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
