### PR TITLE
Fix updates in Cucumber tests with fixtures (fixes #483\)

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
@@ -220,7 +220,6 @@ public class AllureLifecycle {
         storage.put(uuid, result);
         result.setStage(Stage.RUNNING);
         result.setStart(System.currentTimeMillis());
-        threadContext.clear();
         threadContext.start(uuid);
     }
 
@@ -276,7 +275,6 @@ public class AllureLifecycle {
         fixture.setStop(System.currentTimeMillis());
 
         storage.remove(uuid);
-        threadContext.clear();
 
         notifier.afterFixtureStop(fixture);
     }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with isses use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
In Cucumber (Cucumber Spring in particular) when there is CucumberContextConfiguration class with Before/After fixtures it's impossible to attach links from steps and fixtures and in case of failed test the stacktraces are not getting attached as well.

In logs there appears something like:
`ERROR io.qameta.allure.AllureLifecycle - Could not update test case: test case with uuid Example featuref213ed63-0e65-4e12-bf6a-ae5e40565d1cdummy step6 not found`

The reason for this is that in AllureLifecycle methods startFixture and stopFixture contain thread context cleanup removing the information about the root (test case uuid).

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
