### PR TITLE
Add new param annotation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Thank you so much for sending us a pull request!
 
 Make sure you have a clear name for your pull request. 
 The name should start with a capital letter and no dot is required in the end of the sentence.
-To link the request with isses use the following notation: (fixes #123, fixes #321\)
+To link the request with issues use the following notation: (fixes #123, fixes #321\)
 
 An example of good pull request names:
 * Add Cucumber integration (fixes #123\)

--- a/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
@@ -535,9 +535,62 @@ public final class Allure {
      */
     public interface StepContext {
 
+        /**
+         * Sets step's name.
+         *
+         * @param name the deserted name of step.
+         */
         void name(String name);
 
+        /**
+         * Adds parameter to a step.
+         *
+         * @param name  the name of parameter.
+         * @param value the value.
+         * @param <T>   the type of value.
+         * @return the value.
+         */
         <T> T parameter(String name, T value);
+
+        /**
+         * Adds parameter to a step.
+         *
+         * @param name     the name of parameter.
+         * @param value    the value.
+         * @param excluded true if parameter should be excluded from history key generation, false otherwise.
+         * @param <T>      the type of value.
+         * @return the value.
+         */
+        default <T> T parameter(String name, T value, Boolean excluded) {
+            throw new UnsupportedOperationException("method is not implemented");
+        }
+
+        /**
+         * Adds parameter to a step.
+         *
+         * @param name  the name of parameter.
+         * @param value the value.
+         * @param mode  the parameter's mode.
+         * @param <T>   the type of value.
+         * @return the value.
+         */
+        default <T> T parameter(String name, T value, Parameter.Mode mode) {
+            throw new UnsupportedOperationException("method is not implemented");
+        }
+
+        /**
+         * Adds parameter to a step.
+         *
+         * @param name     the name of parameter.
+         * @param value    the value.
+         * @param excluded true if parameter should be excluded from history key generation, false otherwise.
+         * @param mode     the parameter's mode.
+         * @param <T>      the type of value.
+         * @return the value.
+         */
+        default <T> T parameter(String name, T value, Boolean excluded, Parameter.Mode mode) {
+            throw new UnsupportedOperationException("method is not implemented");
+        }
 
     }
 
@@ -559,7 +612,22 @@ public final class Allure {
 
         @Override
         public <T> T parameter(final String name, final T value) {
-            final Parameter param = createParameter(name, value);
+            return parameter(name, value, null, null);
+        }
+
+        @Override
+        public <T> T parameter(final String name, final T value, final Boolean excluded) {
+            return parameter(name, value, excluded, null);
+        }
+
+        @Override
+        public <T> T parameter(final String name, final T value, final Parameter.Mode mode) {
+            return parameter(name, value, null, mode);
+        }
+
+        @Override
+        public <T> T parameter(final String name, final T value, final Boolean excluded, final Parameter.Mode mode) {
+            final Parameter param = createParameter(name, value, excluded, mode);
             getLifecycle().updateStep(uuid, stepResult -> stepResult.getParameters().add(param));
             return value;
         }

--- a/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
@@ -533,6 +533,7 @@ public final class Allure {
     /**
      * Step context.
      */
+    @SuppressWarnings("MultipleStringLiterals")
     public interface StepContext {
 
         /**

--- a/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
@@ -247,12 +247,60 @@ public final class Allure {
     /**
      * Adds parameter to current test or step (or fixture) if any. Takes no effect
      * if no test run at the moment.
+     * <p>
+     * Shortcut for {@link #parameter(String, Object, Boolean, Parameter.Mode)}.
      *
      * @param name  the name of parameter.
      * @param value the value of parameter.
      */
     public static <T> T parameter(final String name, final T value) {
-        final Parameter parameter = createParameter(name, value);
+        return parameter(name, value, null, null);
+    }
+
+    /**
+     * Adds parameter to current test or step (or fixture) if any. Takes no effect
+     * if no test run at the moment.
+     * <p>
+     * Shortcut for {@link #parameter(String, Object, Boolean, Parameter.Mode)}.
+     *
+     * @param name     the name of parameter.
+     * @param value    the value of parameter.
+     * @param excluded true if parameter should be excluded from history key calculation, false otherwise.
+     * @return the specified value.
+     */
+    public static <T> T parameter(final String name, final T value, final Boolean excluded) {
+        return parameter(name, value, excluded, null);
+    }
+
+    /**
+     * Adds parameter to current test or step (or fixture) if any. Takes no effect
+     * if no test run at the moment.
+     * <p>
+     * Shortcut for {@link #parameter(String, Object, Boolean, Parameter.Mode)}.
+     *
+     * @param name  the name of parameter.
+     * @param value the value of parameter.
+     * @param mode  the parameter mode.
+     * @return the specified value.
+     */
+    public static <T> T parameter(final String name, final T value,
+                                  final Parameter.Mode mode) {
+        return parameter(name, value, null, mode);
+    }
+
+    /**
+     * Adds parameter to current test or step (or fixture) if any. Takes no effect
+     * if no test run at the moment.
+     *
+     * @param name     the name of parameter.
+     * @param value    the value of parameter.
+     * @param excluded true if parameter should be excluded from history key calculation, false otherwise.
+     * @param mode     the parameter mode.
+     * @return the specified value.
+     */
+    public static <T> T parameter(final String name, final T value,
+                                  final Boolean excluded, final Parameter.Mode mode) {
+        final Parameter parameter = createParameter(name, value, excluded, mode);
         getLifecycle().updateTestCase(testResult -> testResult.getParameters().add(parameter));
         return value;
     }

--- a/allure-java-commons/src/main/java/io/qameta/allure/Param.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Param.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure;
+
+import io.qameta.allure.model.Parameter;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation used to add parameters to results
+ * from method parameters.
+ *
+ * @see Parameter
+ * @see Parameter.Mode
+ * @see Allure#parameter(String, Object)
+ */
+@Documented
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface Param {
+
+    /**
+     * Alias for {@link #name()}. Overrides value, specified in {@link #name()}.
+     */
+    String value() default "";
+
+    /**
+     * The name of parameter. Be careful, changing parameter's name
+     * may affect method signature and, as result, may get different
+     * test case generated.
+     * <p>
+     * If not specified, the parameter name from reflection will be used.
+     *
+     * @return the name of parameter.
+     */
+    String name() default "";
+
+    /**
+     * The parameter mode.
+     *
+     * @return the parameter mode.
+     */
+    Parameter.Mode mode() default Parameter.Mode.DEFAULT;
+
+    /**
+     * Set it to true to exclude the parameter from historyKey generation.
+     *
+     * @return true if parameter is excluded, false otherwise.
+     */
+    boolean excluded() default false;
+
+}

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ParameterUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ParameterUtils.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2021 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.util;
+
+import io.qameta.allure.Param;
+import io.qameta.allure.model.Parameter;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * @author charlie (Dmitry Baev).
+ */
+public final class ParameterUtils {
+
+    private ParameterUtils() {
+        throw new IllegalStateException("do not instance");
+    }
+
+    public static List<Parameter> createParameters(final Method method,
+                                                   final Object... args) {
+        final java.lang.reflect.Parameter[] parameters = method.getParameters();
+        return IntStream.range(0, parameters.length)
+                .mapToObj(i -> {
+                    final java.lang.reflect.Parameter parameter = parameters[i];
+                    final Object value = args[i];
+                    final Param annotation = parameter.getAnnotation(Param.class);
+                    if (Objects.isNull(annotation)) {
+                        return ResultsUtils.createParameter(parameter.getName(), value);
+                    }
+                    final String name = Stream.of(annotation.value(), annotation.name(), parameter.getName())
+                            .map(String::trim)
+                            .filter(s -> s.length() > 0)
+                            .findFirst()
+                            .orElseGet(() -> "arg" + i);
+
+                    return ResultsUtils.createParameter(
+                            name,
+                            value,
+                            annotation.excluded(),
+                            annotation.mode()
+                    );
+                })
+                .collect(Collectors.toList());
+    }
+
+}

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -64,8 +64,7 @@ import static java.util.Objects.nonNull;
         "ClassDataAbstractionCoupling",
         "PMD.ExcessiveImports",
         "PMD.TooManyMethods",
-        "PMD.GodClass",
-        "deprecation"
+        "PMD.GodClass"
 })
 public final class ResultsUtils {
 
@@ -109,7 +108,16 @@ public final class ResultsUtils {
     }
 
     public static Parameter createParameter(final String name, final Object value) {
-        return new Parameter().setName(name).setValue(ObjectUtils.toString(value));
+        return createParameter(name, value, null, null);
+    }
+
+    public static Parameter createParameter(final String name, final Object value,
+                                            final Boolean excluded, final Parameter.Mode mode) {
+        return new Parameter()
+                .setName(name)
+                .setValue(ObjectUtils.toString(value))
+                .setExcluded(excluded)
+                .setMode(mode);
     }
 
     public static Label createSuiteLabel(final String suite) {
@@ -353,7 +361,7 @@ public final class ResultsUtils {
             try {
                 cachedHost = InetAddress.getLocalHost().getHostName();
             } catch (UnknownHostException e) {
-                LOGGER.debug("Could not get host name {}", e);
+                LOGGER.debug("Could not get host name", e);
                 cachedHost = "default";
             }
         }

--- a/allure-java-commons/src/test/java/io/qameta/allure/AllureTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AllureTest.java
@@ -181,6 +181,31 @@ class AllureTest {
     }
 
     @Test
+    void shouldAddParameterWithModeAndExcluded() {
+        final Parameter first = current().nextObject(Parameter.class);
+        final Parameter second = current().nextObject(Parameter.class);
+        final Parameter third = current().nextObject(Parameter.class);
+
+        final AllureResults results = runWithinTestContext(
+                () -> {
+                    parameter(first.getName(), first.getValue(), first.getMode());
+                    parameter(second.getName(), second.getValue(), second.getExcluded());
+                    parameter(third.getName(), third.getValue(), third.getExcluded(), third.getMode());
+                },
+                Allure::setLifecycle
+        );
+
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getExcluded, Parameter::getMode)
+                .contains(
+                        tuple(first.getName(), first.getValue(), null, first.getMode()),
+                        tuple(second.getName(), second.getValue(), second.getExcluded(), null),
+                        tuple(third.getName(), third.getValue(), third.getExcluded(), third.getMode())
+                );
+    }
+
+    @Test
     void shouldAddLinks() {
         final io.qameta.allure.model.Link first = current().nextObject(Link.class);
         final io.qameta.allure.model.Link second = current().nextObject(Link.class);

--- a/allure-java-commons/src/test/java/io/qameta/allure/util/ObjectUtilsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/util/ObjectUtilsTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author charlie (Dmitry Baev).
  */
-class AspectUtilsTest {
+class ObjectUtilsTest {
 
     @Issue("191")
     @Test


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

This pull request extends parameters API. The target issues are 

1) #80 https://github.com/allure-framework/allure2/issues/342 Opportunity to exclude test parameter from history matching. By now, all the parameters are included in history id calculation. The new `excluded` flag can change the behaviour. 

2) https://github.com/allure-framework/allure2/issues/863 Hidden/Masked parameters. Sometimes, parameters may contains sensitive data. The request add's to additional modes to parameters: `HIDDEN` and `MASKED`

#### API changes



* New `Boolean excluded` field added to  `io.qameta.allure.model.Parameter`
* New `io.qameta.allure.model.Parameter.Mode` enum added. 
* New `Parameter.Mode mode` field added to  `io.qameta.allure.model.Parameter`
* New `io.qameta.allure.Param` annotation, that already can be used together with `Step`:
    ```java
    @Step("Login")
    void doLogin(@Param("Username") String user, @Param(name="Password", mode=MASKED) String pass) {
        // do something
    }
    ```
* Additional `Allure#parameter` methods to respect new parameter's fields
* Additional `StepContext#parameter` methods 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2