### PR TITLE
Add support for provided labels for CucumberJVM integrations

### DIFF
--- a/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/LabelBuilder.java
+++ b/allure-cucumber-jvm/src/main/java/io/qameta/allure/cucumberjvm/LabelBuilder.java
@@ -112,6 +112,7 @@ class LabelBuilder {
             }
         }
 
+        getScenarioLabels().addAll(ResultsUtils.getProvidedLabels());
         getScenarioLabels().addAll(Arrays.asList(
                 createHostLabel(),
                 createThreadLabel(),

--- a/allure-cucumber2-jvm/src/main/java/io/qameta/allure/cucumber2jvm/LabelBuilder.java
+++ b/allure-cucumber2-jvm/src/main/java/io/qameta/allure/cucumber2jvm/LabelBuilder.java
@@ -20,6 +20,7 @@ import gherkin.ast.Feature;
 import gherkin.pickles.PickleTag;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
+import io.qameta.allure.util.ResultsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,6 +115,7 @@ class LabelBuilder {
             }
         }
 
+        getScenarioLabels().addAll(ResultsUtils.getProvidedLabels());
         getScenarioLabels().addAll(Arrays.asList(
                 createHostLabel(),
                 createThreadLabel(),

--- a/allure-cucumber3-jvm/src/main/java/io/qameta/allure/cucumber3jvm/LabelBuilder.java
+++ b/allure-cucumber3-jvm/src/main/java/io/qameta/allure/cucumber3jvm/LabelBuilder.java
@@ -20,6 +20,7 @@ import gherkin.ast.Feature;
 import gherkin.pickles.PickleTag;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
+import io.qameta.allure.util.ResultsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,6 +115,7 @@ class LabelBuilder {
             }
         }
 
+        getScenarioLabels().addAll(ResultsUtils.getProvidedLabels());
         getScenarioLabels().addAll(Arrays.asList(
                 createHostLabel(),
                 createThreadLabel(),

--- a/allure-cucumber3-jvm/src/test/java/io/qameta/allure/cucumber3jvm/AllureCucumber3JvmTest.java
+++ b/allure-cucumber3-jvm/src/test/java/io/qameta/allure/cucumber3jvm/AllureCucumber3JvmTest.java
@@ -45,6 +45,7 @@ import io.qameta.allure.test.AllureResultsWriterStub;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,6 +62,8 @@ import static java.lang.Thread.currentThread;
 import static java.util.Objects.nonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
 
 /**
  * @author charlie (Dmitry Baev).
@@ -566,6 +569,22 @@ class AllureCucumber3JvmTest {
         assertThat(results.getTestResults())
                 .extracting(TestResult::getStatus)
                 .containsExactlyInAnyOrder(Status.FAILED);
+    }
+
+    @ResourceLock(value = SYSTEM_PROPERTIES, mode = READ_WRITE)
+    @SystemProperty(name = "allure.label.x-provided", value = "cucumberjvm3-test-provided")
+    @Test
+    void shouldSupportProvidedLabels() {
+        final AllureResults results = runFeature("features/simple.feature");
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1)
+                .flatExtracting(TestResult::getLabels)
+                .extracting(Label::getName, Label::getValue)
+                .contains(
+                        tuple("x-provided", "cucumberjvm3-test-provided")
+                );
     }
 
     private String readResource(final String resourceName) {

--- a/allure-cucumber4-jvm/src/main/java/io/qameta/allure/cucumber4jvm/LabelBuilder.java
+++ b/allure-cucumber4-jvm/src/main/java/io/qameta/allure/cucumber4jvm/LabelBuilder.java
@@ -115,6 +115,7 @@ class LabelBuilder {
         final String featureName = feature.getName();
         final String uri = scenario.getUri();
 
+        getScenarioLabels().addAll(ResultsUtils.getProvidedLabels());
         getScenarioLabels().addAll(Arrays.asList(
                 createHostLabel(),
                 createThreadLabel(),

--- a/allure-cucumber5-jvm/src/main/java/io/qameta/allure/cucumber5jvm/LabelBuilder.java
+++ b/allure-cucumber5-jvm/src/main/java/io/qameta/allure/cucumber5jvm/LabelBuilder.java
@@ -112,6 +112,7 @@ class LabelBuilder {
         final String featureName = feature.getName();
         final URI uri = scenario.getUri();
 
+        getScenarioLabels().addAll(ResultsUtils.getProvidedLabels());
         getScenarioLabels().addAll(Arrays.asList(
                 createHostLabel(),
                 createThreadLabel(),

--- a/allure-cucumber5-jvm/src/test/java/io/qameta/allure/cucumber5jvm/AllureCucumber5JvmTest.java
+++ b/allure-cucumber5-jvm/src/test/java/io/qameta/allure/cucumber5jvm/AllureCucumber5JvmTest.java
@@ -41,6 +41,7 @@ import io.qameta.allure.test.AllureFeatures;
 import io.qameta.allure.test.AllureResultsWriterStub;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
@@ -55,6 +56,8 @@ import static io.qameta.allure.util.ResultsUtils.TEST_CLASS_LABEL_NAME;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
 
 /**
  * @author charlie (Dmitry Baev).
@@ -710,6 +713,23 @@ class AllureCucumber5JvmTest {
                 .containsExactly(
                         tuple("When  ambigious step present", null),
                         tuple("Then  something bad should happen", Status.SKIPPED)
+                );
+    }
+
+    @ResourceLock(value = SYSTEM_PROPERTIES, mode = READ_WRITE)
+    @SystemProperty(name = "allure.label.x-provided", value = "cucumberjvm5-test-provided")
+    @Test
+    void shouldSupportProvidedLabels() {
+        final AllureResultsWriterStub results = new AllureResultsWriterStub();
+        runFeature(results, "features/simple.feature");
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1)
+                .flatExtracting(TestResult::getLabels)
+                .extracting(Label::getName, Label::getValue)
+                .contains(
+                        tuple("x-provided", "cucumberjvm5-test-provided")
                 );
     }
 

--- a/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/LabelBuilder.java
+++ b/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/LabelBuilder.java
@@ -112,6 +112,7 @@ class LabelBuilder {
         final String featureName = feature.getName();
         final URI uri = scenario.getUri();
 
+        getScenarioLabels().addAll(ResultsUtils.getProvidedLabels());
         getScenarioLabels().addAll(Arrays.asList(
                 createHostLabel(),
                 createThreadLabel(),

--- a/allure-cucumber6-jvm/src/test/java/io/qameta/allure/cucumber6jvm/AllureCucumber6JvmTest.java
+++ b/allure-cucumber6-jvm/src/test/java/io/qameta/allure/cucumber6jvm/AllureCucumber6JvmTest.java
@@ -41,6 +41,7 @@ import io.qameta.allure.test.AllureFeatures;
 import io.qameta.allure.test.AllureResultsWriterStub;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
@@ -55,6 +56,8 @@ import static io.qameta.allure.util.ResultsUtils.TEST_CLASS_LABEL_NAME;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
+import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
 
 /**
  * @author charlie (Dmitry Baev).
@@ -710,6 +713,23 @@ class AllureCucumber6JvmTest {
                 .containsExactly(
                         tuple("When  ambigious step present", null),
                         tuple("Then  something bad should happen", Status.SKIPPED)
+                );
+    }
+
+    @ResourceLock(value = SYSTEM_PROPERTIES, mode = READ_WRITE)
+    @SystemProperty(name = "allure.label.x-provided", value = "cucumberjvm6-test-provided")
+    @Test
+    void shouldSupportProvidedLabels() {
+        final AllureResultsWriterStub results = new AllureResultsWriterStub();
+        runFeature(results, "features/simple.feature");
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1)
+                .flatExtracting(TestResult::getLabels)
+                .extracting(Label::getName, Label::getValue)
+                .contains(
+                        tuple("x-provided", "cucumberjvm6-test-provided")
                 );
     }
 


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure has *provded labels* feature. It allows users to provide report metadata using system properties (or allure.properties):

```properties
#allure.properties
allure.label.<key>=<value>
```

The pull request adds support for such feature to all the CucumberJVM integrations 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2