### PR TITLE
Better support for junit5 parameterised tests

### DIFF
--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
@@ -244,6 +244,7 @@ public class AllureJunitPlatform implements TestExecutionListener {
         );
     }
 
+    @SuppressWarnings({"ReturnCount"})
     private void processFixtureEvent(final TestIdentifier testIdentifier,
                                      final Map<String, String> keyValuePairs) {
         final String type = keyValuePairs.get(ALLURE_FIXTURE);
@@ -409,17 +410,16 @@ public class AllureJunitPlatform implements TestExecutionListener {
                 .map(ThreadLocal::get)
                 .flatMap(tp -> tp.getParent(testIdentifier));
 
-        final TestIdentifier parent = maybeParent.orElse(null);
-
         final TestResult result = new TestResult()
                 .setUuid(uuid)
-                .setName(testTemplate
-                        ? parent.getDisplayName() + " " + testIdentifier.getDisplayName()
+                .setName(testTemplate && maybeParent.isPresent()
+                        ? maybeParent.get().getDisplayName() + " " + testIdentifier.getDisplayName()
                         : testIdentifier.getDisplayName()
                 )
                 .setLabels(getTags(testIdentifier))
                 .setTestCaseId(testTemplate
-                        ? maybeParent.map(TestIdentifier::getUniqueId).orElse(null)
+                        ? maybeParent.map(TestIdentifier::getUniqueId)
+                        .orElseGet(testIdentifier::getUniqueId)
                         : testIdentifier.getUniqueId()
                 )
                 .setHistoryId(getHistoryId(testIdentifier))

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/ParameterisedTestsWithDisplayName.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/ParameterisedTestsWithDisplayName.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author charlie (Dmitry Baev).
+ */
+public class ParameterisedTestsWithDisplayName {
+
+    @DisplayName("Second Test")
+    @ParameterizedTest
+    @ValueSource(strings = {"a", "b"})
+    void first(String value) {
+    }
+
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/ReportEntryParameter.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/ReportEntryParameter.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import io.qameta.allure.model.Parameter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestReporter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static io.qameta.allure.junitplatform.AllureJunitPlatform.ALLURE_PARAMETER;
+import static io.qameta.allure.junitplatform.AllureJunitPlatform.ALLURE_PARAMETER_EXCLUDED_KEY;
+import static io.qameta.allure.junitplatform.AllureJunitPlatform.ALLURE_PARAMETER_MODE_KEY;
+import static io.qameta.allure.junitplatform.AllureJunitPlatform.ALLURE_PARAMETER_VALUE_KEY;
+
+/**
+ * @author charlie (Dmitry Baev).
+ */
+public class ReportEntryParameter {
+
+    @Test
+    void simpleParameterEvent(TestReporter testReporter) {
+        testReporter.publishEntry(buildEvent("some parameter name", "some parameter value"));
+    }
+
+    @Test
+    void multipleParameterEvent(TestReporter testReporter) {
+        testReporter.publishEntry(buildEvent("first name", "first value"));
+        testReporter.publishEntry(buildEvent("second name", "second value"));
+        testReporter.publishEntry(buildEvent("third name", "third value"));
+    }
+
+    @Test
+    void modeAndExcluded(TestReporter testReporter) {
+        testReporter.publishEntry(buildEvent(
+                "hidden excluded",
+                "hidden excluded value",
+                Parameter.Mode.HIDDEN,
+                true
+        ));
+        testReporter.publishEntry(buildEvent(
+                "default excluded",
+                "default excluded value",
+                Parameter.Mode.DEFAULT,
+                true
+        ));
+        testReporter.publishEntry(buildEvent(
+                "masked not excluded",
+                "masked not excluded value",
+                Parameter.Mode.MASKED,
+                false
+        ));
+    }
+
+    private Map<String, String> buildEvent(final String name,
+                                           final String value) {
+        return buildEvent(name, value, null, null);
+    }
+
+    private Map<String, String> buildEvent(final String name,
+                                           final String value,
+                                           final Parameter.Mode mode,
+                                           final Boolean excluded) {
+        final Map<String, String> data = new HashMap<>();
+        data.put(ALLURE_PARAMETER, name);
+        data.put(ALLURE_PARAMETER_VALUE_KEY, value);
+        if (Objects.nonNull(mode)) {
+            data.put(ALLURE_PARAMETER_MODE_KEY, mode.name());
+        }
+        if (Objects.nonNull(excluded)) {
+            data.put(ALLURE_PARAMETER_EXCLUDED_KEY, excluded.toString());
+        }
+
+        return data;
+    }
+
+
+}

--- a/allure-junit5/src/test/java/io/qameta/allure/junit5/AllureJunit5Test.java
+++ b/allure-junit5/src/test/java/io/qameta/allure/junit5/AllureJunit5Test.java
@@ -24,8 +24,11 @@ import io.qameta.allure.junit5.features.AfterEachFixtureFailureSupport;
 import io.qameta.allure.junit5.features.AllFixtureSupport;
 import io.qameta.allure.junit5.features.BeforeEachFixtureFailureSupport;
 import io.qameta.allure.junit5.features.EachFixtureSupport;
+import io.qameta.allure.junit5.features.ParameterisedTests;
+import io.qameta.allure.junit5.features.SkipOtherInjectables;
 import io.qameta.allure.junitplatform.AllureJunitPlatform;
 import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StepResult;
 import io.qameta.allure.model.TestResult;
@@ -53,6 +56,88 @@ import static org.assertj.core.api.Assertions.tuple;
 @AllureFeatures.Fixtures
 @SuppressWarnings("unchecked")
 class AllureJunit5Test {
+
+    @Test
+    void shouldSupportParametersForParameterisedTests() {
+        final AllureResults results = runClasses(ParameterisedTests.class);
+
+        assertThat(results.getTestResults())
+                .filteredOn("fullName", "io.qameta.allure.junit5.features.ParameterisedTests.first")
+                .filteredOn("name", "[1] value=a")
+                .flatExtracting(TestResult::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
+                .containsExactlyInAnyOrder(
+                        tuple("value", "a", null, null)
+                );
+
+        assertThat(results.getTestResults())
+                .filteredOn("fullName", "io.qameta.allure.junit5.features.ParameterisedTests.first")
+                .filteredOn("name", "[2] value=b")
+                .flatExtracting(TestResult::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
+                .containsExactlyInAnyOrder(
+                        tuple("value", "b", null, null)
+                );
+
+    }
+
+    @Test
+    void shouldSupportParamAnnotationForParameters() {
+        final AllureResults results = runClasses(ParameterisedTests.class);
+
+        assertThat(results.getTestResults())
+                .filteredOn("fullName", "io.qameta.allure.junit5.features.ParameterisedTests.third")
+                .filteredOn("name", "[1] value=a")
+                .flatExtracting(TestResult::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
+                .containsExactlyInAnyOrder(
+                        tuple("some value", "a", Parameter.Mode.DEFAULT, false)
+                );
+
+        assertThat(results.getTestResults())
+                .filteredOn("fullName", "io.qameta.allure.junit5.features.ParameterisedTests.third")
+                .filteredOn("name", "[2] value=b")
+                .flatExtracting(TestResult::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
+                .containsExactlyInAnyOrder(
+                        tuple("some value", "b", Parameter.Mode.DEFAULT, false)
+                );
+
+    }
+
+    @Test
+    void shouldSkipReportingOfTestInjectablesTestReporterForRegularTest() {
+        final AllureResults results = runClasses(SkipOtherInjectables.class);
+
+        assertThat(results.getTestResults())
+                .filteredOn("fullName", "io.qameta.allure.junit5.features.SkipOtherInjectables.regularTestWithReporterInjection")
+                .flatExtracting(TestResult::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue)
+                .isEmpty();
+    }
+
+    @Test
+    void shouldSkipReportingOfTestInjectablesTestReporterForParameterisedTest() {
+        final AllureResults results = runClasses(SkipOtherInjectables.class);
+
+        assertThat(results.getTestResults())
+                .filteredOn("fullName", "io.qameta.allure.junit5.features.SkipOtherInjectables.testReporterInjection")
+                .filteredOn("name", "[1] value=a")
+                .flatExtracting(TestResult::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
+                .containsExactlyInAnyOrder(
+                        tuple("value", "a", null, null)
+                );
+
+        assertThat(results.getTestResults())
+                .filteredOn("fullName", "io.qameta.allure.junit5.features.SkipOtherInjectables.testReporterInjection")
+                .filteredOn("name", "[2] value=b")
+                .flatExtracting(TestResult::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
+                .containsExactlyInAnyOrder(
+                        tuple("value", "b", null, null)
+                );
+    }
 
     @Test
     void shouldSupportBeforeEachFixture() {

--- a/allure-junit5/src/test/java/io/qameta/allure/junit5/AllureJunit5Test.java
+++ b/allure-junit5/src/test/java/io/qameta/allure/junit5/AllureJunit5Test.java
@@ -62,20 +62,18 @@ class AllureJunit5Test {
         final AllureResults results = runClasses(ParameterisedTests.class);
 
         assertThat(results.getTestResults())
-                .filteredOn("fullName", "io.qameta.allure.junit5.features.ParameterisedTests.first")
-                .filteredOn("name", "[1] value=a")
+                .filteredOn("name", "first(String) [1] value=a")
                 .flatExtracting(TestResult::getParameters)
                 .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
-                .containsExactlyInAnyOrder(
+                .contains(
                         tuple("value", "a", null, null)
                 );
 
         assertThat(results.getTestResults())
-                .filteredOn("fullName", "io.qameta.allure.junit5.features.ParameterisedTests.first")
-                .filteredOn("name", "[2] value=b")
+                .filteredOn("name", "first(String) [2] value=b")
                 .flatExtracting(TestResult::getParameters)
                 .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
-                .containsExactlyInAnyOrder(
+                .contains(
                         tuple("value", "b", null, null)
                 );
 
@@ -86,20 +84,18 @@ class AllureJunit5Test {
         final AllureResults results = runClasses(ParameterisedTests.class);
 
         assertThat(results.getTestResults())
-                .filteredOn("fullName", "io.qameta.allure.junit5.features.ParameterisedTests.third")
-                .filteredOn("name", "[1] value=a")
+                .filteredOn("name", "third(String) [1] value=a")
                 .flatExtracting(TestResult::getParameters)
                 .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
-                .containsExactlyInAnyOrder(
+                .contains(
                         tuple("some value", "a", Parameter.Mode.DEFAULT, false)
                 );
 
         assertThat(results.getTestResults())
-                .filteredOn("fullName", "io.qameta.allure.junit5.features.ParameterisedTests.third")
-                .filteredOn("name", "[2] value=b")
+                .filteredOn("name", "third(String) [2] value=b")
                 .flatExtracting(TestResult::getParameters)
                 .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
-                .containsExactlyInAnyOrder(
+                .contains(
                         tuple("some value", "b", Parameter.Mode.DEFAULT, false)
                 );
 
@@ -122,19 +118,19 @@ class AllureJunit5Test {
 
         assertThat(results.getTestResults())
                 .filteredOn("fullName", "io.qameta.allure.junit5.features.SkipOtherInjectables.testReporterInjection")
-                .filteredOn("name", "[1] value=a")
+                .filteredOn("name", "testReporterInjection(String, TestReporter) [1] value=a")
                 .flatExtracting(TestResult::getParameters)
                 .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
-                .containsExactlyInAnyOrder(
+                .contains(
                         tuple("value", "a", null, null)
                 );
 
         assertThat(results.getTestResults())
                 .filteredOn("fullName", "io.qameta.allure.junit5.features.SkipOtherInjectables.testReporterInjection")
-                .filteredOn("name", "[2] value=b")
+                .filteredOn("name", "testReporterInjection(String, TestReporter) [2] value=b")
                 .flatExtracting(TestResult::getParameters)
                 .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
-                .containsExactlyInAnyOrder(
+                .contains(
                         tuple("value", "b", null, null)
                 );
     }

--- a/allure-junit5/src/test/java/io/qameta/allure/junit5/features/ParameterisedTests.java
+++ b/allure-junit5/src/test/java/io/qameta/allure/junit5/features/ParameterisedTests.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit5.features;
+
+import io.qameta.allure.Param;
+import org.junit.jupiter.api.TestReporter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author charlie (Dmitry Baev).
+ */
+public class ParameterisedTests {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a", "b"})
+    void first(String value) {
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a", "b"})
+    void second(String value) {
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a", "b"})
+    void third(@Param("some value") String value) {
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a", "b"})
+    void testReporterInjection(String value, TestReporter testReporter) {
+    }
+
+}

--- a/allure-junit5/src/test/java/io/qameta/allure/junit5/features/SkipOtherInjectables.java
+++ b/allure-junit5/src/test/java/io/qameta/allure/junit5/features/SkipOtherInjectables.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit5.features;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestReporter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author charlie (Dmitry Baev).
+ */
+public class SkipOtherInjectables {
+
+    @Test
+    void regularTestWithReporterInjection(TestReporter testReporter) {
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a", "b"})
+    void testReporterInjection(String value, TestReporter testReporter) {
+    }
+
+}

--- a/gradle/quality-configs/pmd/pmd.xml
+++ b/gradle/quality-configs/pmd/pmd.xml
@@ -144,7 +144,9 @@
 
 
     <!-- Performance (https://pmd.github.io/pmd-6.0.1/pmd_rules_java_performance.html) -->
-    <rule ref="category/java/performance.xml"/>
+    <rule ref="category/java/performance.xml">
+        <exclude name="AvoidInstantiatingObjectsInLoops"/>
+    </rule>
 
 
     <!-- Security (no rules) -->


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure now detects junit test templates. For test templates test result name is set to concatenation of template's display name and invocation's display name. For example, the following test:

```java
@ParameterizedTest
@ValueSource(strings = {"some value"})
void test(ArgumentType argumentValue) {...}
```

will be displayed as `test(ArgumentType) [1] argumentValue=some value` in the report.

This also allows usage of `@DisplayName` together with `@ParameterizedTest` (fixes #500):

```java
@DisplayName("My named test")
@ParameterizedTest
@ValueSource(strings = {"some value"})
void test(ArgumentType argumentValue) {...}
```

will be displayed as `My named test [1] argumentValue=some value` in the report.

Besides that, all the parameters will be displayed correctly as well. Including support for new `@Param` annotation:


```java
@ParameterizedTest
@ValueSource(strings = {"some value"})
void test(@Param("some parameter name") ArgumentType argumentValue) {...}
```


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2