### PR TITLE
Support test retries in AllureCucumber4 (fixes #715\)

### DIFF
--- a/allure-cucumber4-jvm/src/test/java/io/qameta/allure/cucumber4jvm/AllureCucumber4JvmTest.java
+++ b/allure-cucumber4-jvm/src/test/java/io/qameta/allure/cucumber4jvm/AllureCucumber4JvmTest.java
@@ -804,7 +804,7 @@ class AllureCucumber4JvmTest {
 
     private byte runFeature(final AllureResultsWriterStub writer,
                             final String featureResource,
-                            final BiFunction<GherkinDocument, String, List<PickleEvent>> gherkinCompiler,
+                            final BiFunction<GherkinDocument, String, List<PickleEvent>> pickleCompiler,
                             final String... moreOptions) {
 
         final AllureLifecycle lifecycle = new AllureLifecycle(writer);
@@ -826,7 +826,7 @@ class AllureCucumber4JvmTest {
                 Parser<GherkinDocument> parser = new Parser<>(new AstBuilder());
                 TokenMatcher matcher = new TokenMatcher();
                 GherkinDocument gherkinDocument = parser.parse(gherkin, matcher);
-                List<PickleEvent> pickleEvents = gherkinCompiler.apply(gherkinDocument, featureResource);
+                List<PickleEvent> pickleEvents = pickleCompiler.apply(gherkinDocument, featureResource);
                 CucumberFeature feature = new CucumberFeature(gherkinDocument, URI.create(featureResource), gherkin, pickleEvents);
 
                 return Collections.singletonList(feature);

--- a/allure-cucumber4-jvm/src/test/java/io/qameta/allure/cucumber4jvm/samples/RetriesSteps.java
+++ b/allure-cucumber4-jvm/src/test/java/io/qameta/allure/cucumber4jvm/samples/RetriesSteps.java
@@ -1,0 +1,53 @@
+package io.qameta.allure.cucumber4jvm.samples;
+
+import io.cucumber.java.Before;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author hamzaan.bridle
+ */
+public class RetriesSteps {
+
+    public static AtomicInteger aFlakyTestRunCount = new AtomicInteger(0);
+    public static AtomicInteger brokenBeforeRunCount = new AtomicInteger(0);
+    public static AtomicInteger aFlakyGivenRunCount = new AtomicInteger(0);
+
+    @Before("@RetrySkipped")
+    public void brokenBefore() {
+        final int timesRun = brokenBeforeRunCount.incrementAndGet();
+        if (timesRun < 3) {
+            throw new RuntimeException("Test retries don't change skip behaviour when before is broken");
+        }
+    }
+
+    @Given("^a flaky test$")
+    public void aFlakyTest() {
+        // nothing here
+    }
+
+    @Given("^a flaky given")
+    public void aFlakyGiven() {
+        aFlakyGivenRunCount.incrementAndGet();
+        assertThat(aFlakyGivenRunCount).hasValue(3);
+    }
+
+    @When("^the test is executed$")
+    public void testIsExecuted() {
+        final int timesRun = aFlakyTestRunCount.incrementAndGet();
+        if (timesRun < 3) {
+            throw new RuntimeException("Will fail before third run");
+        }
+    }
+
+    @Then("^the test only passes on the third run.")
+    public void testOnlyPassesOnThirdRun() {
+        // nothing here
+    }
+
+}

--- a/allure-cucumber4-jvm/src/test/resources/features/retries.feature
+++ b/allure-cucumber4-jvm/src/test/resources/features/retries.feature
@@ -1,0 +1,17 @@
+Feature: Retries feature
+
+  Scenario: A flaky test that is retried
+    Given a flaky test
+    When the test is executed
+    Then the test only passes on the third run.
+
+  Scenario: A test with flaky given
+    Given a flaky given
+    When the test is executed
+    Then the test only passes on the third run.
+
+  @RetrySkipped
+  Scenario: A test with a flaky broken before
+    Given a flaky test
+    When the test is executed
+    Then the test only passes on the third run.


### PR DESCRIPTION
### Context
https://github.com/allure-framework/allure-java/issues/715

AllureCucumber4Jvm does not recognise rerun scenarios. The uuid caching of the scenario means that reruns replace the test result of the original run. This breaks the Allure "Retries" and "Flaky" features.

This change allows multiple runs of the same scenario to have unique results and produce an Allure Report with "Flaky" tests.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
