### PR TITLE
assertJ: handle interface based assertions

### DIFF
--- a/allure-assertj/src/main/java/io/qameta/allure/assertj/AllureAspectJ.java
+++ b/allure-assertj/src/main/java/io/qameta/allure/assertj/AllureAspectJ.java
@@ -55,13 +55,8 @@ public class AllureAspectJ {
         }
     };
 
-    @Pointcut("execution(public org.assertj.core.api.AbstractAssert.new(..))")
+    @Pointcut("execution(!private org.assertj.core.api.AbstractAssert.new(..))")
     public void anyAssertCreation() {
-        //pointcut body, should be empty
-    }
-
-    @Pointcut("execution(public * org.assertj.core.api.AssertionsForClassTypes.*(..))")
-    public void anyAssertCreation2() {
         //pointcut body, should be empty
     }
 
@@ -75,7 +70,7 @@ public class AllureAspectJ {
         //pointcut body, should be empty
     }
 
-    @After("anyAssertCreation() || anyAssertCreation2()")
+    @After("anyAssertCreation()")
     public void logAssertCreation(final JoinPoint joinPoint) {
         final String actual = joinPoint.getArgs().length > 0
                 ? ObjectUtils.toString(joinPoint.getArgs()[0])

--- a/allure-assertj/src/test/java/io/qameta/allure/assertj/AllureAspectJTest.java
+++ b/allure-assertj/src/test/java/io/qameta/allure/assertj/AllureAspectJTest.java
@@ -23,6 +23,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import static io.qameta.allure.test.RunUtils.runWithinTestContext;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,6 +86,23 @@ class AllureAspectJTest {
                         "describedAs 'Byte array object'",
                         "isEqualTo '<BINARY>'"
                 );
+    }
+
+    @AllureFeatures.Steps
+    @Test
+    void shouldHandleCollections() {
+        final AllureResults results = runWithinTestContext(() -> {
+            assertThat(Arrays.asList("a", "b"))
+                .containsExactly("a", "b");
+        }, AllureAspectJ::setLifecycle);
+
+        assertThat(results.getTestResults())
+            .flatExtracting(TestResult::getSteps)
+            .extracting(StepResult::getName)
+            .containsExactly(
+                "assertThat '[a, b]'",
+                "containsExactly '[a, b]'"
+            );
     }
 
     @AllureFeatures.Steps


### PR DESCRIPTION
### Context

PointCut for assertJ does not catch interfaces-based assertions (list, map, etc)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
