### PR TITLE
Fix infinite stuck on not ok status in allure-grpc

### DIFF
--- a/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
+++ b/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
@@ -150,9 +150,13 @@ public class AllureGrpc implements ClientInterceptor {
                                     .setBody("[" + String.join(",\n", parsedResponses) + "]");
                         }
                         if (!status.isOk()) {
+                            String description = status.getDescription();
+                            if (description == null) {
+                                description = "No description provided";
+                            }
                             responseAttachmentBuilder = GrpcResponseAttachment.Builder
                                     .create(status.getCode().name())
-                                    .setStatus(status.getDescription());
+                                    .setStatus(description);
                         }
 
                         requireNonNull(responseAttachmentBuilder).setStatus(status.toString());

--- a/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
+++ b/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
@@ -149,6 +149,11 @@ public class AllureGrpc implements ClientInterceptor {
                                     .create("gRPC response (collection of elements from Server stream)")
                                     .setBody("[" + String.join(",\n", parsedResponses) + "]");
                         }
+                        if (!status.isOk()){
+                            responseAttachmentBuilder = GrpcResponseAttachment.Builder
+                                    .create(status.getCode().name())
+                                    .setStatus(status.getDescription());
+                        }
 
                         requireNonNull(responseAttachmentBuilder).setStatus(status.toString());
                         if (interceptResponseMetadata) {

--- a/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
+++ b/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
@@ -149,7 +149,7 @@ public class AllureGrpc implements ClientInterceptor {
                                     .create("gRPC response (collection of elements from Server stream)")
                                     .setBody("[" + String.join(",\n", parsedResponses) + "]");
                         }
-                        if (!status.isOk()){
+                        if (!status.isOk()) {
                             responseAttachmentBuilder = GrpcResponseAttachment.Builder
                                     .create(status.getCode().name())
                                     .setStatus(status.getDescription());


### PR DESCRIPTION
If status is not ok from the grpc service, there is an infinite stuck and test will never pass or fail.