### PR TITLE
Fix signature hash for parameterised test with generic type parameter in allure-descriptions-javadoc

### DIFF
--- a/allure-descriptions-javadoc/build.gradle.kts
+++ b/allure-descriptions-javadoc/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     testImplementation("io.github.glytching:junit-extensions")
     testImplementation("org.assertj:assertj-core")
     testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
     testImplementation("org.slf4j:slf4j-simple")
     testImplementation(project(":allure-java-commons-test"))
     testImplementation(project(":allure-junit-platform"))

--- a/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
+++ b/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
@@ -69,7 +69,8 @@ public class JavaDocDescriptionsProcessor extends AbstractProcessor {
             }
             final String docs = elementUtils.getDocComment(el);
             final List<String> typeParams = ((ExecutableElement) el).getParameters().stream()
-                    .map(param -> param.asType().toString()).collect(Collectors.toList());
+                    .map(param -> processingEnv.getTypeUtils().asElement(param.asType()).toString())
+                    .collect(Collectors.toList());
             final String name = el.getSimpleName().toString();
             if (docs == null) {
                 messager.printMessage(Diagnostic.Kind.WARNING,

--- a/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
+++ b/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
@@ -35,7 +35,7 @@ class ProcessDescriptionsTest {
 
     @Test
     void captureDescriptionTest() {
-        final String expectedMethodSignatureHash = "36862acaeed19a448e8dcefa8dd6edff";
+        final String expectedMethodSignatureHash = "4e7f896021ef2fce7c1deb7f5b9e38fb";
 
         JavaFileObject source = JavaFileObjects.forSourceLines(
                 "io.qameta.allure.description.test.DescriptionSample",
@@ -48,7 +48,7 @@ class ProcessDescriptionsTest {
                 "* Captured javadoc description",
                 "*/",
                 "@Description(useJavaDoc = true)",
-                "public void sampleTest(List<String> inputList) {",
+                "public void sampleTest() {",
                 "}",
                 "}"
         );

--- a/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
+++ b/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
@@ -35,7 +35,7 @@ class ProcessDescriptionsTest {
 
     @Test
     void captureDescriptionTest() {
-        final String expectedMethodSignatureHash = "4e7f896021ef2fce7c1deb7f5b9e38fb";
+        final String expectedMethodSignatureHash = "36862acaeed19a448e8dcefa8dd6edff";
 
         JavaFileObject source = JavaFileObjects.forSourceLines(
                 "io.qameta.allure.description.test.DescriptionSample",
@@ -48,7 +48,7 @@ class ProcessDescriptionsTest {
                 "* Captured javadoc description",
                 "*/",
                 "@Description(useJavaDoc = true)",
-                "public void sampleTest() {",
+                "public void sampleTest(List<String> inputList) {",
                 "}",
                 "}"
         );
@@ -83,5 +83,45 @@ class ProcessDescriptionsTest {
         assertThat(compilation)
                 .hadWarningContaining("Unable to create resource for method "
                         + "sampleTestWithoutJavadocComment[] as it does not have a docs comment");
+    }
+
+    @Test
+    void captureDescriptionParametrizedTestWithGenericParameterTest() {
+        final String expectedMethodSignatureHash = "e90e26691bf14511db819d78624ba716";
+
+        JavaFileObject source = JavaFileObjects.forSourceLines(
+                "io.qameta.allure.description.test.DescriptionSample",
+                "package io.qameta.allure.description.test;",
+                "import io.qameta.allure.Description;",
+                "import org.junit.jupiter.params.ParameterizedTest;",
+                "import org.junit.jupiter.params.provider.MethodSource;",
+                "import java.util.Arrays;",
+                "import java.util.List;",
+                "import java.util.stream.Stream;",
+                "",
+                "public class DescriptionSample {",
+                "",
+                "/**",
+                "* Captured javadoc description",
+                "*/",
+                "@ParameterizedTest",
+                "@MethodSource(\"provideStringListParameters\")",
+                "@Description(useJavaDoc = true)",
+                "public void sampleParametrizedTestWithGenericParameterAndJavadocComment(List<String> stringList) {",
+                "}",
+                "",
+                "private static Stream<List<String>> provideStringListParameters() {",
+                "return Stream.of(Arrays.asList(\"foo\", \"bar\"));",
+                "}",
+                "}"
+        );
+
+        Compiler compiler = javac().withProcessors(new JavaDocDescriptionsProcessor());
+        Compilation compilation = compiler.compile(source);
+        assertThat(compilation).generatedFile(
+                StandardLocation.CLASS_OUTPUT,
+                ALLURE_PACKAGE_NAME,
+                expectedMethodSignatureHash
+        );
     }
 }


### PR DESCRIPTION
I found a bug in current implementation of work allure-descriptions-javadoc

In annotation processor `param.asType().toString()` return generic type without type erasure ex: `java.utils.List<java.utils.String>`, but in **ResultUtils.getJavadocDescription()** used `Class::getTypeName` for method parameters type and it have erased type like `java.utils.List`. In result for parameterised test with generic parameter type allure can not find generated javadoc description. 

In this PR I change `param.asType().toString()` to invoke util method `processingEnv.getTypeUtils().asElement(param.asType()).toString())` that return erased type for generic and now parametrised work fine.