### PR TITLE
Fix bug from PR 796 with processing primitives type in parameterized tests parameters

### DIFF
--- a/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
+++ b/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
@@ -28,6 +28,7 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
 import javax.tools.FileObject;
@@ -69,7 +70,7 @@ public class JavaDocDescriptionsProcessor extends AbstractProcessor {
             }
             final String docs = elementUtils.getDocComment(el);
             final List<String> typeParams = ((ExecutableElement) el).getParameters().stream()
-                    .map(param -> processingEnv.getTypeUtils().asElement(param.asType()).toString())
+                    .map(this::methodParameterTypeMapper)
                     .collect(Collectors.toList());
             final String name = el.getSimpleName().toString();
             if (docs == null) {
@@ -93,5 +94,10 @@ public class JavaDocDescriptionsProcessor extends AbstractProcessor {
         });
 
         return true;
+    }
+
+    private String methodParameterTypeMapper(final VariableElement parameter) {
+        final Element typeElement = processingEnv.getTypeUtils().asElement(parameter.asType());
+        return typeElement != null ? typeElement.toString() : parameter.asType().toString();
     }
 }

--- a/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
+++ b/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
@@ -124,4 +124,37 @@ class ProcessDescriptionsTest {
                 expectedMethodSignatureHash
         );
     }
+
+    @Test
+    void captureDescriptionParametrizedTestWithPrimitivesParameterTest() {
+        final String expectedMethodSignatureHash = "edeeeaa02f01218cc206e0c6ff024c7a";
+
+        JavaFileObject source = JavaFileObjects.forSourceLines(
+                "io.qameta.allure.description.test.DescriptionSample",
+                "package io.qameta.allure.description.test;",
+                "import io.qameta.allure.Description;",
+                "import org.junit.jupiter.params.ParameterizedTest;",
+                "import org.junit.jupiter.params.provider.ValueSource;",
+                "",
+                "public class DescriptionSample {",
+                "",
+                "/**",
+                "* Captured javadoc description",
+                "*/",
+                "@ParameterizedTest",
+                "@ValueSource(ints = {1, 2, 3})",
+                "@Description(useJavaDoc = true)",
+                "public void sampleParametrizedTestWithPrimitivesParameterAndJavadocComment(int someIntValue) {",
+                "}",
+                "}"
+        );
+
+        Compiler compiler = javac().withProcessors(new JavaDocDescriptionsProcessor());
+        Compilation compilation = compiler.compile(source);
+        assertThat(compilation).generatedFile(
+                StandardLocation.CLASS_OUTPUT,
+                ALLURE_PACKAGE_NAME,
+                expectedMethodSignatureHash
+        );
+    }
 }


### PR DESCRIPTION
In my previous [PR](https://github.com/allure-framework/allure-java/pull/796) I did a bug in processing primitives parameter in parameterized tests. TypeUtils from processingEnv return null if pass primitives as parameter as result we can get NPE in processing when use javadoc as description in parameterized test with primitives type parameter.

This PR fix this trouble and check for null result of parsing type with processingEnv if it's null than use raw type of parameter