### PR TITLE
Awaitility support

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,20 @@ JsonPatchMatcher is extension of JsonUnit matcher, that generates pretty html at
    <version>$LATEST_VERSION</version>
 </dependency>
 ```
+
+## Awaitility
+Extended logging for poling and ignored exceptions for [awaitility](https://github.com/awaitility/awaitility). For 
+more usage example look into module `allure-awaitility`
+
+```xml
+<dependency>
+   <groupId>io.qameta.allure</groupId>
+   <artifactId>allure-awaitility</artifactId>
+   <version>$LATEST_VERSION</version>
+</dependency>
+```
+
+Usage example:
+```
+Awaitility.setDefaultConditionEvaluationListener(new AllureAwaitilityListener());
+```

--- a/allure-awaitility/build.gradle.kts
+++ b/allure-awaitility/build.gradle.kts
@@ -1,15 +1,19 @@
 description = "Allure Awaitlity Integration"
 
+val agent: Configuration by configurations.creating
+
 val awaitilityVersion = "4.2.0"
 
 dependencies {
+    agent("org.aspectj:aspectjweaver")
     api(project(":allure-java-commons"))
     implementation("org.awaitility:awaitility:$awaitilityVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testImplementation("javax.annotation:javax.annotation-api")
     testImplementation("org.assertj:assertj-core")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.slf4j:slf4j-simple")
     testImplementation(project(":allure-java-commons-test"))
+    testImplementation(project(":allure-junit-platform"))
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 

--- a/allure-awaitility/build.gradle.kts
+++ b/allure-awaitility/build.gradle.kts
@@ -1,0 +1,26 @@
+description = "Allure Awaitlity Integration"
+
+val awaitilityVersion = "4.2.0"
+
+dependencies {
+    api(project(":allure-java-commons"))
+    implementation("org.awaitility:awaitility:$awaitilityVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
+    testImplementation("org.assertj:assertj-core")
+    testImplementation("org.slf4j:slf4j-simple")
+    testImplementation(project(":allure-java-commons-test"))
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+}
+
+tasks.jar {
+    manifest {
+        attributes(mapOf(
+                "Automatic-Module-Name" to "io.qameta.allure.awaitility"
+        ))
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/allure-awaitility/readme.md
+++ b/allure-awaitility/readme.md
@@ -1,0 +1,66 @@
+## Allure-awaitility
+Extended logging for poling and ignored exceptions for [awaitility](https://github.com/awaitility/awaitility)
+
+
+## Wiki
+For more information about awaitility highly recommended look into [awaitility usage guide](https://github.com/awaitility/awaitility/wiki/Usage)
+
+
+### Configuration examples
+Single line for all awaitility conditions in project
+```java
+Awaitility.setDefaultConditionEvaluationListener(new AllureAwaitilityListener());
+```
+
+Moreover, it's possible logging only few unstable conditions with method `.conditionEvaluationListener()`
+```java
+final AtomicInteger atomicInteger = new AtomicInteger(0);
+await().with()
+        .conditionEvaluationListener(new AllureAwaitilityListener())
+        .alias("Checking that important counter reached value around 3")
+        .atMost(Duration.of(1000, ChronoUnit.MILLIS))
+        .pollInterval(Duration.of(50, ChronoUnit.MILLIS))
+        .until(atomicInteger::getAndIncrement, is(3));
+```
+
+How it looks like:
+1. Top-level step with condition evaluation definition such as alias or default information.
+2. Second-level steps with poling process information
+3. Optional second-level step with timeout information
+4. Optional second-level steps with ignored information
+
+
+### TimeUnit
+Most awaitility users count time as milliseconds, but you can feel free to change print poll information.
+```java
+Awaitility.setDefaultConditionEvaluationListener(new AllureAwaitilityListener().setUnit(TimeUnit.SECONDS));
+```
+
+
+### Exceptions handling
+By default, it's not possible to handle and log any exceptions, but you can try to 
+[ignore](https://github.com/awaitility/awaitility/wiki/Usage#ignoring-exceptions) and log ignored exceptions. 
+
+```java
+final AtomicInteger atomicInteger = new AtomicInteger(0);
+await().with()
+        .ignoreExceptions() //required
+        .atMost(Duration.of(1000, ChronoUnit.MILLIS))
+        .pollInterval(Duration.of(500, ChronoUnit.MILLIS))
+        .until(() -> {
+            if (atomicInteger.getAndIncrement() != 3) {
+                //this exception will be ignored by awaitility, but logged into Allure
+                throw new RuntimeException("Something wrong happens");
+            } else {
+                return true;
+            }
+        });
+```
+
+Then, if you are not impressed with the large volume of logged exceptions, there is the way to disable logging for 
+ignored exceptions globally.
+
+```java
+Awaitility.ignoreExceptionsByDefault();
+Awaitility.setDefaultConditionEvaluationListener(new AllureAwaitilityListener().setLogIgnoredExceptions(false));
+```

--- a/allure-awaitility/src/main/java/io/qameta/allure/awaitility/AllureAwaitilityListener.java
+++ b/allure-awaitility/src/main/java/io/qameta/allure/awaitility/AllureAwaitilityListener.java
@@ -111,7 +111,7 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
                 new StepResult()
                         .setName(stepName)
                         .setDescription("Awaitility condition started")
-                        .setStatus(Status.PASSED)
+                        .setStatus(Status.FAILED)
         );
     }
 
@@ -128,8 +128,8 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
                             .setStatus(Status.BROKEN)
             );
             getLifecycle().stopStep(currentTimeoutStepUUID);
-            awaitilityCondition.setStatus(Status.FAILED);
         });
+        getLifecycle().stopStep(currentConditionStepUUID);
     }
 
     @Override
@@ -163,6 +163,7 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
             getLifecycle().stopStep(lastAwaitStepUUID);
             if (condition.isSatisfied()) {
                 awaitilityCondition.setStatus(Status.PASSED);
+                getLifecycle().stopStep(currentConditionStepUUID);
             }
         });
     }

--- a/allure-awaitility/src/main/java/io/qameta/allure/awaitility/AllureAwaitilityListener.java
+++ b/allure-awaitility/src/main/java/io/qameta/allure/awaitility/AllureAwaitilityListener.java
@@ -1,0 +1,224 @@
+/*
+ *  Copyright 2022 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.awaitility;
+
+import io.qameta.allure.Allure;
+import io.qameta.allure.AllureLifecycle;
+import io.qameta.allure.model.Status;
+import io.qameta.allure.model.StepResult;
+import org.awaitility.core.ConditionEvaluationListener;
+import org.awaitility.core.EvaluatedCondition;
+import org.awaitility.core.IgnoredException;
+import org.awaitility.core.StartEvaluationEvent;
+import org.awaitility.core.TimeoutEvent;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * <p>
+ * Class implements Awaitility condition listener to log all awaiting and polls as {@link io.qameta.allure.Step}.
+ * </p>
+ * <p>
+ * Usage with single condition
+ * <pre>
+ * <code>
+ *     public AllureLifecycle getLifecycle() {
+ *         Awaitility.await()
+ *                 .conditionEvaluationListener(new AllureAwaitilityListener())
+ *                 .until(() -> somethingHappen());
+ * </code>
+ * </pre>
+ * </p>
+ * <p>
+ * Usage globally for all conditions
+ * <pre>
+ * <code>
+ *     Awaitility.setDefaultConditionEvaluationListener(new AllureAwaitilityListener());
+ * </code>
+ * </pre>
+ * </p>
+ *
+ *
+ * @author a-simeshin (Simeshin Artem)
+ * @see org.awaitility.core.ConditionEvaluationListener
+ */
+@SuppressWarnings("unused")
+public class AllureAwaitilityListener implements ConditionEvaluationListener<Object> {
+
+    private TimeUnit unit;
+    private boolean attachExceptions;
+    private final String onStartStepTextPattern;
+    private final String onSatisfiedStepTextPattern;
+    private final String onAwaitStepTextPattern;
+    private final String onTimeoutStepTextPattern;
+    private final String onExceptionStepTextPattern;
+    private String currentConditionUUID;
+    private String lastAwaitStepUUID;
+
+    private static InheritableThreadLocal<AllureLifecycle> lifecycle = new InheritableThreadLocal<AllureLifecycle>() {
+        @Override
+        protected AllureLifecycle initialValue() {
+            return Allure.getLifecycle();
+        }
+    };
+
+    public static AllureLifecycle getLifecycle() {
+        return lifecycle.get();
+    }
+
+    /**
+     * Default all args constructor with default params.
+     */
+    public AllureAwaitilityListener() {
+        this.unit = MILLISECONDS;
+        this.attachExceptions = false;
+        this.onStartStepTextPattern = "Awaitility: %s";
+        this.onSatisfiedStepTextPattern = "%s after %d %s (remaining time %d %s, last poll interval was %s)";
+        this.onAwaitStepTextPattern = "%s (elapsed time %d %s, remaining time %d %s (last poll interval was %s))";
+        this.onTimeoutStepTextPattern = "Condition timeout. %s";
+        this.onExceptionStepTextPattern = "Exception %s has been ignored";
+    }
+
+    /**
+     * Set default timeunit used in awaitility in project for properly printing.
+     *
+     * @param unit default timeunit in project
+     * @return this factory
+     */
+    public AllureAwaitilityListener setUnit(final TimeUnit unit) {
+        this.unit = unit;
+        return this;
+    }
+
+    /**
+     * Setter to enable logging for ignored exceptions.
+     *
+     * @param logExceptions log or not
+     * @return this factory
+     */
+    public AllureAwaitilityListener setEnableLogExceptions(final boolean logExceptions) {
+        this.attachExceptions = logExceptions;
+        return this;
+    }
+
+    @Override
+    public void beforeEvaluation(final StartEvaluationEvent<Object> startEvaluationEvent) {
+        currentConditionUUID = UUID.randomUUID().toString();
+        getLifecycle().startStep(
+                currentConditionUUID,
+                new StepResult()
+                        .setName(String.format(onStartStepTextPattern, startEvaluationEvent.getDescription()))
+                        .setDescription("Awaitility condition started")
+                        .setStatus(Status.PASSED)
+        );
+    }
+
+    @Override
+    public void exceptionIgnored(final IgnoredException ignoredException) {
+        if (attachExceptions) {
+            getLifecycle().updateStep(awaitilityCondition -> {
+                lastAwaitStepUUID = UUID.randomUUID().toString();
+                final String message = String.format(
+                        onExceptionStepTextPattern, ignoredException.getThrowable().getMessage());
+                final StringWriter stringWriter = new StringWriter();
+                ignoredException.getThrowable().printStackTrace(new PrintWriter(stringWriter));
+                final String stackTrace = stringWriter.toString();
+                getLifecycle().startStep(
+                        currentConditionUUID,
+                        lastAwaitStepUUID,
+                        new StepResult()
+                                .setName(message)
+                                .setDescription("Exception occurred and ignored, but awaiting still in progress")
+                                .setStatus(Status.PASSED)
+                );
+                getLifecycle().addAttachment(
+                        message, "text/plain", ".txt", stackTrace.getBytes(StandardCharsets.UTF_8));
+                getLifecycle().stopStep(lastAwaitStepUUID);
+            });
+        }
+    }
+
+    @Override
+    public void onTimeout(final TimeoutEvent timeoutEvent) {
+        getLifecycle().updateStep(awaitilityCondition -> {
+            final String currentTimeoutStepUUID = UUID.randomUUID().toString();
+            getLifecycle().startStep(
+                    currentConditionUUID,
+                    currentTimeoutStepUUID,
+                    new StepResult()
+                            .setName(String.format(onTimeoutStepTextPattern, timeoutEvent.getDescription()))
+                            .setDescription("Awaitility condition timeout")
+                            .setStatus(Status.BROKEN)
+            );
+            getLifecycle().stopStep(currentTimeoutStepUUID);
+            awaitilityCondition.setStatus(Status.FAILED);
+        });
+        getLifecycle().stopStep(currentConditionUUID);
+    }
+
+    @Override
+    public void conditionEvaluated(final EvaluatedCondition<Object> condition) {
+        final String description = condition.getDescription();
+        final long elapsedTime = unit.convert(condition.getElapsedTimeInMS(), MILLISECONDS);
+        final long remainingTime = unit.convert(condition.getRemainingTimeInMS(), MILLISECONDS);
+        final String unitAsString = unit.toString().toLowerCase();
+
+        final AtomicReference<String> message = new AtomicReference<>();
+        if (condition.isSatisfied()) {
+            message.set(
+                    String.format(onSatisfiedStepTextPattern, description, elapsedTime, unitAsString, remainingTime,
+                            unitAsString, new TemporalDuration(condition.getPollInterval())));
+        } else {
+            message.set(
+                    String.format(onAwaitStepTextPattern, description, elapsedTime, unitAsString, remainingTime,
+                            unitAsString, new TemporalDuration(condition.getPollInterval())));
+        }
+
+        getLifecycle().updateStep(awaitilityCondition -> {
+            lastAwaitStepUUID = UUID.randomUUID().toString();
+            getLifecycle().startStep(
+                    currentConditionUUID,
+                    lastAwaitStepUUID,
+                    new StepResult()
+                            .setName(message.get())
+                            .setDescription("Awaitility condition satisfied or not, but awaiting still in progress")
+                            .setStatus(Status.PASSED)
+            );
+            getLifecycle().stopStep(lastAwaitStepUUID);
+            if (condition.isSatisfied()) {
+                awaitilityCondition.setStatus(Status.PASSED);
+                getLifecycle().stopStep(currentConditionUUID);
+            }
+        });
+    }
+
+    /**
+     * For tests only.
+     *
+     * @param allure allure lifecycle to set
+     */
+    public static void setLifecycle(final AllureLifecycle allure) {
+        lifecycle.set(allure);
+    }
+
+}

--- a/allure-awaitility/src/main/java/io/qameta/allure/awaitility/TemporalDuration.java
+++ b/allure-awaitility/src/main/java/io/qameta/allure/awaitility/TemporalDuration.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2022 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.awaitility;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalField;
+import java.time.temporal.UnsupportedTemporalTypeException;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MILLI_OF_SECOND;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.YEAR;
+
+/**
+ * Class helper for Duration printing purposes.
+ */
+public class TemporalDuration implements TemporalAccessor {
+    private static final Temporal BASE = LocalDateTime.of(0, 1, 1, 0, 0, 0, 0);
+
+    private static final DateTimeFormatter DTF = new DateTimeFormatterBuilder().optionalStart()
+            .appendValue(YEAR)
+            .appendLiteral(" years ").optionalEnd()
+            .optionalStart().appendLiteral(' ').appendValue(MONTH_OF_YEAR).appendLiteral(" months ").optionalEnd()
+            .optionalStart().appendLiteral(' ').appendValue(DAY_OF_MONTH).appendLiteral(" days ").optionalEnd()
+            .optionalStart().appendLiteral(' ').appendValue(HOUR_OF_DAY).appendLiteral(" hours ").optionalEnd()
+            .optionalStart().appendLiteral(' ').appendValue(MINUTE_OF_HOUR).appendLiteral(" minutes ").optionalEnd()
+            .optionalStart().appendLiteral(' ').appendValue(SECOND_OF_MINUTE).appendLiteral(" seconds").optionalEnd()
+            .optionalStart().appendLiteral(' ').appendValue(MILLI_OF_SECOND).appendLiteral(" milliseconds")
+            .optionalEnd()
+            .toFormatter();
+
+    private final Duration duration;
+    private final Temporal temporal;
+
+    TemporalDuration(final Duration duration) {
+        this.duration = duration;
+        this.temporal = duration.addTo(BASE);
+    }
+
+    @Override
+    public boolean isSupported(final TemporalField field) {
+        if (!temporal.isSupported(field)) {
+            return false;
+        }
+        return temporal.getLong(field) - BASE.getLong(field) != 0L;
+    }
+
+    @Override
+    public long getLong(final TemporalField temporalField) {
+        if (!isSupported(temporalField)) {
+            throw new UnsupportedTemporalTypeException(temporalField.toString());
+        }
+        return temporal.getLong(temporalField) - BASE.getLong(temporalField);
+    }
+
+    @Override
+    public String toString() {
+        if (duration.compareTo(Duration.ofMillis(1)) < 0) {
+            return duration.toNanos() + " nanoseconds";
+        } else {
+            return DTF.format(this).trim();
+        }
+    }
+
+}

--- a/allure-awaitility/src/test/java/io/qameta/allure/awaitility/ConditionListenersPositiveTest.java
+++ b/allure-awaitility/src/test/java/io/qameta/allure/awaitility/ConditionListenersPositiveTest.java
@@ -15,7 +15,6 @@
  */
 package io.qameta.allure.awaitility;
 
-import io.qameta.allure.awaitility.AllureAwaitilityListener;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.TestResult;
 import org.junit.jupiter.api.Test;

--- a/allure-awaitility/src/test/java/io/qameta/allure/awaitility/ConditionListenersPositiveTest.java
+++ b/allure-awaitility/src/test/java/io/qameta/allure/awaitility/ConditionListenersPositiveTest.java
@@ -1,0 +1,167 @@
+/*
+ *  Copyright 2022 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.awaitility;
+
+import io.qameta.allure.awaitility.AllureAwaitilityListener;
+import io.qameta.allure.model.Status;
+import io.qameta.allure.model.TestResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.qameta.allure.test.RunUtils.runWithinTestContext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class ConditionListenersPositiveTest {
+
+    /**
+     * Positive test to check proper allure steps generation.
+     * <p>
+     * Precondition: listener into condition declaration, await without alias
+     * <p>
+     * Test should check that:
+     * <li>1. Allure has exactly 1 top-level step for 1 await condition</li>
+     * <li>2. Top level step has passed status</li>
+     * <li>3. Top level step has default name</li>
+     */
+    @Test
+    void globalSettingsAwaitWoAliasCheckTopLevelPassedStep() {
+        final List<TestResult> testResult = runWithinTestContext(() -> {
+                    final AtomicInteger atomicInteger = new AtomicInteger(0);
+                    await().with()
+                            .conditionEvaluationListener(new AllureAwaitilityListener())
+                            .atMost(Duration.of(1000, ChronoUnit.MILLIS))
+                            .pollInterval(Duration.of(50, ChronoUnit.MILLIS))
+                            .until(atomicInteger::getAndIncrement, is(3));
+                },
+                AllureAwaitilityListener::setLifecycle
+        ).getTestResults();
+        assertAll(
+                () -> assertEquals(
+                        1, testResult.get(0).getSteps().size(),
+                        "Exactly 1 top level step for 1 awaitility condition"
+                ),
+                () -> assertEquals(
+                        Status.PASSED, testResult.get(0).getSteps().get(0).getStatus(),
+                        "Top level step has passed status"
+                ),
+                () -> assertEquals(
+                        "Awaitility: Starting evaluation",
+                        testResult.get(0).getSteps().get(0).getName(),
+                        "Top level step has default name because await() wo alias"
+                )
+        );
+    }
+
+    /**
+     * Positive test to check proper allure steps generation.
+     * <p>
+     * Precondition: listener into condition declaration, await with alias
+     * <p>
+     * Test should check that:
+     * <li>1. Top level step has name with alias from await('alias')</li>
+     */
+    @Test
+    void globalSettingsAwaitWithAliasCheckTopLevelPassedStep() {
+        final List<TestResult> testResult = runWithinTestContext(() -> {
+                    final AtomicInteger atomicInteger = new AtomicInteger(0);
+                    await("Counter should be at least 3").with()
+                            .conditionEvaluationListener(new AllureAwaitilityListener())
+                            .atMost(Duration.of(1000, ChronoUnit.MILLIS))
+                            .pollInterval(Duration.of(50, ChronoUnit.MILLIS))
+                            .until(atomicInteger::getAndIncrement, is(3));
+                },
+                AllureAwaitilityListener::setLifecycle
+        ).getTestResults();
+        assertEquals(
+                "Awaitility: Counter should be at least 3",
+                testResult.get(0).getSteps().get(0).getName(),
+                "Top level step has name with alias"
+        );
+    }
+
+    /**
+     * Positive test to check proper allure steps generation.
+     * <p>
+     * Precondition: listener into condition declaration, await without alias
+     * <p>
+     * Test should check that:
+     * <li>1. Allure has exactly 4 second-level steps for condition with 4 polls iteration</li>
+     * <li>2. All second-level steps should have passed status for successful condition evaluation</li>
+     * <li>3. All second-level steps should have information about polling intervals and evaluation</li>
+     */
+    @Test
+    void globalSettingsCheckAwaitWoAliasSecondLevelPassedSteps() {
+        final List<TestResult> testResult = runWithinTestContext(() -> {
+                    final AtomicInteger atomicInteger = new AtomicInteger(0);
+                    await().with()
+                            .conditionEvaluationListener(new AllureAwaitilityListener())
+                            .atMost(Duration.of(1000, ChronoUnit.MILLIS))
+                            .pollInterval(Duration.of(50, ChronoUnit.MILLIS))
+                            .until(atomicInteger::getAndIncrement, is(3));
+                },
+                AllureAwaitilityListener::setLifecycle
+        ).getTestResults();
+        assertAll(
+                () -> assertEquals(
+                        4, testResult.get(0).getSteps().get(0).getSteps().size(),
+                        "Exactly 4 second level steps for 4 polling iterations"
+                ),
+                () -> assertEquals(
+                        4, (int) testResult.get(0).getSteps().get(0).getSteps().stream()
+                                .filter(x -> x.getStatus().equals(Status.PASSED)).count(),
+                        "All second level steps has passed statuses"
+                ),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(0).getName())
+                        .contains("Lambda expression in io.qameta.allure.awaitility.ConditionListenersPositiveTest")
+                        .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
+                        .contains("expected <3> but was <0>")
+                        .contains("elapsed time")
+                        .contains("remaining time")
+                        .contains("last poll interval was"),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(1).getName())
+                        .contains("Lambda expression in io.qameta.allure.awaitility.ConditionListenersPositiveTest")
+                        .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
+                        .contains("expected <3> but was <1>")
+                        .contains("elapsed time")
+                        .contains("remaining time")
+                        .contains("last poll interval was"),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(2).getName())
+                        .contains("Lambda expression in io.qameta.allure.awaitility.ConditionListenersPositiveTest")
+                        .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
+                        .contains("expected <3> but was <2>")
+                        .contains("elapsed time")
+                        .contains("remaining time")
+                        .contains("last poll interval was"),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(3).getName())
+                        .contains("Lambda expression in io.qameta.allure.awaitility.ConditionListenersPositiveTest")
+                        .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
+                        .contains("reached its end value of <3> after")
+                        .contains("remaining time")
+                        .contains("last poll interval was")
+        );
+    }
+
+}

--- a/allure-awaitility/src/test/java/io/qameta/allure/awaitility/GlobalSettingsNegativeTest.java
+++ b/allure-awaitility/src/test/java/io/qameta/allure/awaitility/GlobalSettingsNegativeTest.java
@@ -15,7 +15,6 @@
  */
 package io.qameta.allure.awaitility;
 
-import io.qameta.allure.awaitility.AllureAwaitilityListener;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.TestResult;
 import org.awaitility.Awaitility;

--- a/allure-awaitility/src/test/java/io/qameta/allure/awaitility/GlobalSettingsNegativeTest.java
+++ b/allure-awaitility/src/test/java/io/qameta/allure/awaitility/GlobalSettingsNegativeTest.java
@@ -1,0 +1,121 @@
+/*
+ *  Copyright 2022 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.awaitility;
+
+import io.qameta.allure.awaitility.AllureAwaitilityListener;
+import io.qameta.allure.model.Status;
+import io.qameta.allure.model.TestResult;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.qameta.allure.test.RunUtils.runWithinTestContext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class GlobalSettingsNegativeTest {
+
+    @AfterEach
+    void reset() {
+        Awaitility.reset();
+    }
+
+    @BeforeEach
+    void setup() {
+        Awaitility.setDefaultConditionEvaluationListener(new AllureAwaitilityListener());
+    }
+
+    /**
+     * Negative test to check proper allure steps generation.
+     * <p>
+     * Precondition: static settings, await without alias
+     * <p>
+     * Test should check that:
+     * <li>1. Top level step has broken status</li>
+     */
+    @Test
+    void globalSettingsAwaitWoAliasCheckTopLevelBrokenStep() {
+        final List<TestResult> testResult = runWithinTestContext(() -> {
+                    final AtomicInteger atomicInteger = new AtomicInteger(0);
+                    await().with()
+                            .atMost(Duration.of(1000, ChronoUnit.MILLIS))
+                            .pollInterval(Duration.of(500, ChronoUnit.MILLIS))
+                            .until(atomicInteger::getAndIncrement, is(3));
+                },
+                AllureAwaitilityListener::setLifecycle
+        ).getTestResults();
+        assertEquals(
+                Status.FAILED, testResult.get(0).getSteps().get(0).getStatus(),
+                "Top level step has broken status"
+        );
+    }
+
+    /**
+     * Positive test to check proper allure steps generation.
+     * <p>
+     * Precondition: static settings, await without alias
+     * <p>
+     * Test should check that:
+     * <li>1. Allure has exactly 2 second-level steps for condition with 2 polls iteration</li>
+     * <li>2. All second-level steps should have passed or broken status for successful and timeout evaluations</li>
+     * <li>3. All second-level steps should have information about polling intervals and evaluation</li>
+     */
+    @Test
+    void globalSettingsCheckAwaitWoAliasSecondLevelTimeoutStep() {
+        final List<TestResult> testResult = runWithinTestContext(() -> {
+                    final AtomicInteger atomicInteger = new AtomicInteger(0);
+                    await().with()
+                            .atMost(Duration.of(1000, ChronoUnit.MILLIS))
+                            .pollInterval(Duration.of(500, ChronoUnit.MILLIS))
+                            .until(atomicInteger::getAndIncrement, is(3));
+                },
+                AllureAwaitilityListener::setLifecycle
+        ).getTestResults();
+        assertAll(
+                () -> assertEquals(
+                        2, testResult.get(0).getSteps().get(0).getSteps().size(),
+                        "Exactly 2 second level steps for 2 polling iterations"
+                ),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(0).getName())
+                        .contains("Lambda expression in io.qameta.allure.awaitility.GlobalSettingsNegativeTest")
+                        .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
+                        .contains("expected <3> but was <0>")
+                        .contains("elapsed time")
+                        .contains("remaining time")
+                        .contains("last poll interval was"),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(0).getStatus())
+                        .isEqualTo(Status.PASSED),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(1).getName())
+                        .contains("Condition timeout.")
+                        .contains("Lambda expression in io.qameta.allure.awaitility.GlobalSettingsNegativeTest")
+                        .contains("expected <3> but was <0> within 1 seconds"),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(1).getStatus())
+                        .isEqualTo(Status.BROKEN)
+        );
+    }
+
+}

--- a/allure-awaitility/src/test/java/io/qameta/allure/awaitility/GlobalSettingsPositiveTest.java
+++ b/allure-awaitility/src/test/java/io/qameta/allure/awaitility/GlobalSettingsPositiveTest.java
@@ -15,7 +15,6 @@
  */
 package io.qameta.allure.awaitility;
 
-import io.qameta.allure.awaitility.AllureAwaitilityListener;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.TestResult;
 import org.awaitility.Awaitility;

--- a/allure-awaitility/src/test/java/io/qameta/allure/awaitility/GlobalSettingsPositiveTest.java
+++ b/allure-awaitility/src/test/java/io/qameta/allure/awaitility/GlobalSettingsPositiveTest.java
@@ -13,7 +13,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.awaitility.examples;
+package io.qameta.allure.awaitility;
 
 import io.qameta.allure.awaitility.AllureAwaitilityListener;
 import io.qameta.allure.model.Status;
@@ -145,28 +145,28 @@ class GlobalSettingsPositiveTest {
                         "All second level steps has passed statuses"
                 ),
                 () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(0).getName())
-                        .contains("Lambda expression in io.qameta.allure.awaitility.examples.GlobalSettingsPositiveTest")
+                        .contains("Lambda expression in io.qameta.allure.awaitility.GlobalSettingsPositiveTest")
                         .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
                         .contains("expected <3> but was <0>")
                         .contains("elapsed time")
                         .contains("remaining time")
                         .contains("last poll interval was"),
                 () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(1).getName())
-                        .contains("Lambda expression in io.qameta.allure.awaitility.examples.GlobalSettingsPositiveTest")
+                        .contains("Lambda expression in io.qameta.allure.awaitility.GlobalSettingsPositiveTest")
                         .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
                         .contains("expected <3> but was <1>")
                         .contains("elapsed time")
                         .contains("remaining time")
                         .contains("last poll interval was"),
                 () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(2).getName())
-                        .contains("Lambda expression in io.qameta.allure.awaitility.examples.GlobalSettingsPositiveTest")
+                        .contains("Lambda expression in io.qameta.allure.awaitility.GlobalSettingsPositiveTest")
                         .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
                         .contains("expected <3> but was <2>")
                         .contains("elapsed time")
                         .contains("remaining time")
                         .contains("last poll interval was"),
                 () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(3).getName())
-                        .contains("Lambda expression in io.qameta.allure.awaitility.examples.GlobalSettingsPositiveTest")
+                        .contains("Lambda expression in io.qameta.allure.awaitility.GlobalSettingsPositiveTest")
                         .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
                         .contains("reached its end value of <3> after")
                         .contains("remaining time")

--- a/allure-awaitility/src/test/java/io/qameta/allure/awaitility/examples/GlobalSettingsPositiveTest.java
+++ b/allure-awaitility/src/test/java/io/qameta/allure/awaitility/examples/GlobalSettingsPositiveTest.java
@@ -1,0 +1,177 @@
+/*
+ *  Copyright 2022 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.awaitility.examples;
+
+import io.qameta.allure.awaitility.AllureAwaitilityListener;
+import io.qameta.allure.model.Status;
+import io.qameta.allure.model.TestResult;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.qameta.allure.test.RunUtils.runWithinTestContext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class GlobalSettingsPositiveTest {
+
+    @AfterEach
+    void reset() {
+        Awaitility.reset();
+    }
+
+    @BeforeEach
+    void setup() {
+        Awaitility.setDefaultConditionEvaluationListener(new AllureAwaitilityListener());
+    }
+
+    /**
+     * Positive test to check proper allure steps generation.
+     * <p>
+     * Precondition: static settings, await without alias
+     * <p>
+     * Test should check that:
+     * <li>1. Allure has exactly 1 top-level step for 1 await condition</li>
+     * <li>2. Top level step has passed status</li>
+     * <li>3. Top level step has default name</li>
+     */
+    @Test
+    void globalSettingsAwaitWoAliasCheckTopLevelPassedStep() {
+        final List<TestResult> testResult = runWithinTestContext(() -> {
+                    final AtomicInteger atomicInteger = new AtomicInteger(0);
+                    await().with()
+                            .atMost(Duration.of(1000, ChronoUnit.MILLIS))
+                            .pollInterval(Duration.of(50, ChronoUnit.MILLIS))
+                            .until(atomicInteger::getAndIncrement, is(3));
+                },
+                AllureAwaitilityListener::setLifecycle
+        ).getTestResults();
+        assertAll(
+                () -> assertEquals(
+                        1, testResult.get(0).getSteps().size(),
+                        "Exactly 1 top level step for 1 awaitility condition"
+                ),
+                () -> assertEquals(
+                        Status.PASSED, testResult.get(0).getSteps().get(0).getStatus(),
+                        "Top level step has passed status"
+                ),
+                () -> assertEquals(
+                        "Awaitility: Starting evaluation",
+                        testResult.get(0).getSteps().get(0).getName(),
+                        "Top level step has default name because await() wo alias"
+                )
+        );
+    }
+
+    /**
+     * Positive test to check proper allure steps generation.
+     * <p>
+     * Precondition: static settings, await with alias
+     * <p>
+     * Test should check that:
+     * <li>1. Top level step has name with alias from await('alias')</li>
+     */
+    @Test
+    void globalSettingsAwaitWithAliasCheckTopLevelPassedStep() {
+        final List<TestResult> testResult = runWithinTestContext(() -> {
+                    final AtomicInteger atomicInteger = new AtomicInteger(0);
+                    await("Counter should be at least 3").with()
+                            .atMost(Duration.of(1000, ChronoUnit.MILLIS))
+                            .pollInterval(Duration.of(50, ChronoUnit.MILLIS))
+                            .until(atomicInteger::getAndIncrement, is(3));
+                },
+                AllureAwaitilityListener::setLifecycle
+        ).getTestResults();
+        assertEquals(
+                "Awaitility: Counter should be at least 3",
+                testResult.get(0).getSteps().get(0).getName(),
+                "Top level step has name with alias"
+        );
+    }
+
+    /**
+     * Positive test to check proper allure steps generation.
+     * <p>
+     * Precondition: static settings, await without alias
+     * <p>
+     * Test should check that:
+     * <li>1. Allure has exactly 4 second-level steps for condition with 4 polls iteration</li>
+     * <li>2. All second-level steps should have passed status for successful condition evaluation</li>
+     * <li>3. All second-level steps should have information about polling intervals and evaluation</li>
+     */
+    @Test
+    void globalSettingsCheckAwaitWoAliasSecondLevelPassedSteps() {
+        final List<TestResult> testResult = runWithinTestContext(() -> {
+                    final AtomicInteger atomicInteger = new AtomicInteger(0);
+                    await().with()
+                            .atMost(Duration.of(1000, ChronoUnit.MILLIS))
+                            .pollInterval(Duration.of(50, ChronoUnit.MILLIS))
+                            .until(atomicInteger::getAndIncrement, is(3));
+                },
+                AllureAwaitilityListener::setLifecycle
+        ).getTestResults();
+        assertAll(
+                () -> assertEquals(
+                        4, testResult.get(0).getSteps().get(0).getSteps().size(),
+                        "Exactly 4 second level steps for 4 polling iterations"
+                ),
+                () -> assertEquals(
+                        4, (int) testResult.get(0).getSteps().get(0).getSteps().stream()
+                                .filter(x -> x.getStatus().equals(Status.PASSED)).count(),
+                        "All second level steps has passed statuses"
+                ),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(0).getName())
+                        .contains("Lambda expression in io.qameta.allure.awaitility.examples.GlobalSettingsPositiveTest")
+                        .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
+                        .contains("expected <3> but was <0>")
+                        .contains("elapsed time")
+                        .contains("remaining time")
+                        .contains("last poll interval was"),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(1).getName())
+                        .contains("Lambda expression in io.qameta.allure.awaitility.examples.GlobalSettingsPositiveTest")
+                        .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
+                        .contains("expected <3> but was <1>")
+                        .contains("elapsed time")
+                        .contains("remaining time")
+                        .contains("last poll interval was"),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(2).getName())
+                        .contains("Lambda expression in io.qameta.allure.awaitility.examples.GlobalSettingsPositiveTest")
+                        .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
+                        .contains("expected <3> but was <2>")
+                        .contains("elapsed time")
+                        .contains("remaining time")
+                        .contains("last poll interval was"),
+                () -> assertThat(testResult.get(0).getSteps().get(0).getSteps().get(3).getName())
+                        .contains("Lambda expression in io.qameta.allure.awaitility.examples.GlobalSettingsPositiveTest")
+                        .contains("that uses java.util.concurrent.atomic.AtomicInteger:")
+                        .contains("reached its end value of <3> after")
+                        .contains("remaining time")
+                        .contains("last poll interval was")
+        );
+    }
+
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "allure-java"
 
 include("allure-assertj")
 include("allure-attachments")
+include("allure-awaitility")
 include("allure-bom")
 include("allure-citrus")
 include("allure-cucumber-jvm")


### PR DESCRIPTION
### Context
Add allure integration for **[awaitility](https://github.com/awaitility/awaitility)**.

Few words about awaitility:
- Free to use any conditions or runnables, hamcrest integration, great for use in any test frameworks
- Java, Groovy, Scala, Kotlin support
- Included to spring-boot-parent from **[2.2.0.RC1](https://github.com/spring-projects/spring-boot/releases/tag/v2.2.0.RC1)**
- Stable and highly customized with polls, failfast, thread-executors, exceptions handlers, etc, but not Allure 😢 Lets fix it

Test example with manual cycle boilerplate and logging to Allure:
```java
    @Test
    @SneakyThrows
    void justPositiveAwaitWoAwaitility() {
        final AtomicInteger atomicInteger = new AtomicInteger(0);
        final long maxAwait = 1000L;
        final long sleepBetweenPolls = 50L;
        boolean happens = false;
        final long start = System.currentTimeMillis();
        for (long i = start; i < start + maxAwait; i = System.currentTimeMillis()) {
            try {
                if (atomicInteger.getAndIncrement() == 3) {
                    //log to allure satisfied polling result
                    happens = true;
                    break;
                } else {
                    //log to allure unsatisfied polling iteration
                    Thread.sleep(sleepBetweenPolls);
                }
            } catch (Exception e) {
                //log to allure exceptions boilerplate
            }
        }
        if (!happens) {
            //fail test or timeout exception boilerplate
        }
    }
```

Probably should be rewrited to `CompletableFuture` and `CountDownLatch`, but just look at the same code with awaitility and proposed allure integration:
```java
    @Test
    void justPositiveAwait() {
        final AtomicInteger atomicInteger = new AtomicInteger(0);
        await("Counter should be at least 3").with()
                .conditionEvaluationListener(new AllureAwaitilityListener())
                .atMost(Duration.of(1000, ChronoUnit.MILLIS))
                .pollInterval(Duration.of(50, ChronoUnit.MILLIS))
                .until(atomicInteger::getAndIncrement, is(3));
    }
```

Result
![image](https://user-images.githubusercontent.com/89605031/194747918-f1ce5b88-f72c-40e6-8dd1-494e5fd1a31e.png)


For projects that already used awaitility shoud be the way how to integrate this library with cheap update, for exampe:
```java
    @BeforeAll
    static void setup() {
        Awaitility.setDefaultConditionEvaluationListener(new AllureAwaitilityListener());
    }
```

#### Feature checklist
- [x] Class AllureAwaitilityListener creates step tree for polling process
- [x] AllureAwaitilityListener could be set for all conditions in project with one line, or for any single condition
- [x] TimeUnits customization for project that count time not in milliseconds
- [x] Ignored exceptions optional handling and attaching to Allure 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests
- [x] Readme 

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
