### PR TITLE
allure-description-javadoc: mark all java versions as supported

### DIFF
--- a/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
+++ b/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
@@ -23,7 +23,6 @@ import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;

--- a/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
+++ b/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
@@ -45,7 +45,6 @@ import static io.qameta.allure.util.ResultsUtils.generateMethodSignatureHash;
  * @author Egor Borisov ehborisov@gmail.com
  */
 @SupportedAnnotationTypes("io.qameta.allure.Description")
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class JavaDocDescriptionsProcessor extends AbstractProcessor {
 
     private Filer filer;
@@ -59,6 +58,11 @@ public class JavaDocDescriptionsProcessor extends AbstractProcessor {
         filer = env.getFiler();
         elementUtils = env.getElementUtils();
         messager = env.getMessager();
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latest();
     }
 
     @Override

--- a/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
+++ b/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
@@ -53,7 +53,8 @@ class ProcessDescriptionsTest {
                 "}"
         );
 
-        Compiler compiler = javac().withProcessors(new JavaDocDescriptionsProcessor());
+        Compiler compiler = javac().withProcessors(new JavaDocDescriptionsProcessor())
+                .withOptions("-Werror");
         Compilation compilation = compiler.compile(source);
         assertThat(compilation).generatedFile(
                 StandardLocation.CLASS_OUTPUT,


### PR DESCRIPTION
### Context
This change returns the version of the JDK as supported version for the annotation processor.
This avoids warings like `Supported source version 'RELEASE_8' from annotation processor ... less than -source 11` so that compiling with `-Werror` option is possible.

See #929

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests


[cla]: https://cla-assistant.io/accept/allure-framework/allure2
