### PR TITLE
spock2: add test plan filter support

### DIFF
--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -112,7 +112,7 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         this.testPlan = new FileTestPlanSupplier().supply().orElse(new TestPlanUnknown());
     }
 
-    public AllureSpock2(final AllureLifecycle lifecycle, TestPlan plan) {
+    public AllureSpock2(final AllureLifecycle lifecycle, final TestPlan plan) {
         this.lifecycle = lifecycle;
         this.streamsCapturer.addStandardStreamsListener(this);
         this.testPlan = plan;
@@ -281,7 +281,7 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         return this.getQualifiedName(featureInfo.getSpec().getReflection().getName(), featureInfo.getName());
     }
 
-    private String getQualifiedName(String specName, String testName) {
+    private String getQualifiedName(final String specName, final String testName) {
         return specName + "." + testName;
     }
 
@@ -317,7 +317,7 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         return null;
     }
 
-    private boolean match(TestPlanV1_0.TestCase tc, String allureId, String qualifiedName) {
+    private boolean match(final TestPlanV1_0.TestCase tc, final String allureId, final String qualifiedName) {
         return Objects.equals(allureId, tc.getId()) || Objects.equals(qualifiedName, tc.getSelector());
     }
 

--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -274,11 +274,16 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
     }
 
     private String getQualifiedName(final IterationInfo iteration) {
-        return iteration.getFeature().getSpec().getReflection().getName() + "." + iteration.getName();
+        return this.getQualifiedName(iteration.getFeature().getSpec().getReflection().getName(), iteration.getName());
+
     }
 
     private String getQualifiedName(final FeatureInfo featureInfo) {
-        return featureInfo.getSpec().getReflection().getName() + "." + featureInfo.getName();
+        return this.getQualifiedName(featureInfo.getSpec().getReflection().getName(), featureInfo.getName());
+    }
+
+    private String getQualifiedName(String specName, String testName) {
+        return specName + "." + testName;
     }
 
     private String getHistoryId(final String name, final List<Parameter> parameters) {
@@ -306,7 +311,7 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
     }
 
     private String getAllureId(final FeatureInfo featureInfo) {
-        AllureId annotation = featureInfo.getFeatureMethod().getAnnotation(AllureId.class);
+        final AllureId annotation = featureInfo.getFeatureMethod().getAnnotation(AllureId.class);
         if (Objects.nonNull(annotation)) {
             return annotation.value();
         }

--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -275,7 +275,6 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
 
     private String getQualifiedName(final IterationInfo iteration) {
         return this.getQualifiedName(iteration.getFeature().getSpec().getReflection().getName(), iteration.getName());
-
     }
 
     private String getQualifiedName(final FeatureInfo featureInfo) {

--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -16,6 +16,7 @@
 package io.qameta.allure.spock2;
 
 import io.qameta.allure.Allure;
+import io.qameta.allure.AllureId;
 import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.model.FixtureResult;
 import io.qameta.allure.model.Label;
@@ -26,6 +27,10 @@ import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.model.StepResult;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
+import io.qameta.allure.testfilter.FileTestPlanSupplier;
+import io.qameta.allure.testfilter.TestPlan;
+import io.qameta.allure.testfilter.TestPlanUnknown;
+import io.qameta.allure.testfilter.TestPlanV1_0;
 import io.qameta.allure.util.AnnotationUtils;
 import io.qameta.allure.util.ExceptionUtils;
 import io.qameta.allure.util.ResultsUtils;
@@ -94,6 +99,8 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
 
     private final AllureLifecycle lifecycle;
 
+    private final TestPlan testPlan;
+
     @SuppressWarnings("unused")
     public AllureSpock2() {
         this(Allure.getLifecycle());
@@ -102,6 +109,13 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
     public AllureSpock2(final AllureLifecycle lifecycle) {
         this.lifecycle = lifecycle;
         this.streamsCapturer.addStandardStreamsListener(this);
+        this.testPlan = new FileTestPlanSupplier().supply().orElse(new TestPlanUnknown());
+    }
+
+    public AllureSpock2(final AllureLifecycle lifecycle, TestPlan plan) {
+        this.lifecycle = lifecycle;
+        this.streamsCapturer.addStandardStreamsListener(this);
+        this.testPlan = plan;
     }
 
     @Override
@@ -111,6 +125,8 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
 
     @Override
     public void visitSpec(final SpecInfo spec) {
+        spec.getAllFeatures().forEach(methodInfo -> methodInfo.setSkipped(this.isSkipped(methodInfo)));
+
         spec.addListener(this);
 
         final String specContainerUuid = UUID.randomUUID().toString();
@@ -261,6 +277,10 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         return iteration.getFeature().getSpec().getReflection().getName() + "." + iteration.getName();
     }
 
+    private String getQualifiedName(final FeatureInfo featureInfo) {
+        return featureInfo.getSpec().getReflection().getName() + "." + featureInfo.getName();
+    }
+
     private String getHistoryId(final String name, final List<Parameter> parameters) {
         final MessageDigest digest = getMd5Digest();
         digest.update(name.getBytes(UTF_8));
@@ -272,6 +292,29 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
                 });
         final byte[] bytes = digest.digest();
         return bytesToHex(bytes);
+    }
+
+    private boolean isSkipped(final FeatureInfo featureInfo) {
+        if (this.testPlan instanceof TestPlanV1_0) {
+            final TestPlanV1_0 tp = (TestPlanV1_0) testPlan;
+            return !Objects.isNull(tp.getTests()) && tp.getTests()
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .noneMatch(tc -> this.match(tc, this.getAllureId(featureInfo), this.getQualifiedName(featureInfo)));
+        }
+        return false;
+    }
+
+    private String getAllureId(final FeatureInfo featureInfo) {
+        AllureId annotation = featureInfo.getFeatureMethod().getAnnotation(AllureId.class);
+        if (Objects.nonNull(annotation)) {
+            return annotation.value();
+        }
+        return null;
+    }
+
+    private boolean match(TestPlanV1_0.TestCase tc, String allureId, String qualifiedName) {
+        return Objects.equals(allureId, tc.getId()) || Objects.equals(qualifiedName, tc.getSelector());
     }
 
     @Override

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/TestsWithIdForFilter.groovy
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/TestsWithIdForFilter.groovy
@@ -1,0 +1,60 @@
+/*
+ *  Copyright 2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.spock2.samples
+
+import spock.lang.Ignore;
+
+import io.qameta.allure.AllureId;
+import spock.lang.Specification;
+
+class TestsWithIdForFilter extends Specification {
+
+    @AllureId("1")
+    def "test 1"() {
+        expect:
+        true
+    }
+
+    @AllureId("2")
+    def "test 2"() {
+        expect:
+        true
+    }
+
+    def "test 3"() {
+        expect:
+        true
+    }
+
+    @AllureId("4")
+    def "test 4"() {
+        expect:
+        true
+    }
+
+    @Ignore
+    @AllureId("5")
+    def "test 5"() {
+        expect:
+        true
+    }
+
+    @AllureId("6")
+    def "test 6"() {
+        expect:
+        false
+    }
+}


### PR DESCRIPTION
### Context
We are using spock 2 as a test runner for one of our test automation frameworks. Recently, we've set up an integration with Allure TestOps and it appears that allure-spock2 doesn't support selective test runs yet. This contribution is aimed to add such feature.

P.S. - logic and unit tests are essentially the same as already implemented for allure-testng and allure-junit-platform integration with a few spock-specific details. 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
