### PR TITLE
Bump selenide version from 6.11.2 to 6.17.1

### DIFF
--- a/allure-selenide/build.gradle.kts
+++ b/allure-selenide/build.gradle.kts
@@ -1,6 +1,6 @@
 description = "Allure Selenide Integration"
 
-val selenideVersion = "6.11.2"
+val selenideVersion = "6.17.1"
 
 dependencies {
     api(project(":allure-java-commons"))


### PR DESCRIPTION
Hi there!
Would like to bump a selenide version to the latest (6.17.1)
Useful features:
1. Banners support
2. New method $.cached()
3. New method inNewBrowser for running a code snippet in a new browser
4. Replaced WebDriverManager by SeleniumManager

changelog: https://selenide.org/blog.html

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
