### PR TITLE
Bump jsonUnitVersion from 2.35.0 to 2.38.0

### DIFF
--- a/allure-jsonunit/build.gradle.kts
+++ b/allure-jsonunit/build.gradle.kts
@@ -1,6 +1,6 @@
 description = "Allure JsonUnit Integration"
 
-val jsonUnitVersion = "2.35.0"
+val jsonUnitVersion = "2.38.0"
 
 dependencies {
     api(project(":allure-attachments"))


### PR DESCRIPTION

### Context
Update json unit version from 2.35.0 to 2.38.0
[release notes](https://github.com/lukas-krecan/JsonUnit#release-notes)

 - **2.38.0 (2023-05-22)**
Support for NumberComparator
Dependency updates
 - **2.37.0 (2023-03-23)**
[Make custom matcher regexp DOTALL](https://github.com/lukas-krecan/JsonUnit/pull/617) 
Dependency updates
 - **2.36.1 (2023-01-29)**
[Fix slf4j dependency](https://github.com/lukas-krecan/JsonUnit/issues/595)
Dependency updates
 - **2.36.0 (2022-10-05)**
[Support for node method in JsonMapAssert](https://github.com/lukas-krecan/JsonUnit/issues/560) 
Fixed number parsing in Jackson, so it works as [intended](https://github.com/lukas-krecan/JsonUnit#numbers) (see https://github.com/lukas-krecan/JsonUnit/issues/564 for details)
Dependency updates

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
