### PR TITLE
Added customization of source file name pattern

### DIFF
--- a/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
@@ -447,6 +447,19 @@ class AllureLifecycleTest {
 
     }
 
+    @Test
+    void shouldCreateAttachmentWithCustomSource() {
+        final String sourceName = "TEST_SOURCE_NAME";
+        final String extension = "html";
+        final String sourceResult = lifecycle.prepareAttachment(
+                randomName(),
+                "text/plain",
+                extension,
+                () -> sourceName
+        );
+        assertThat(sourceResult).isEqualTo("%s.%s".formatted(sourceName, extension));
+    }
+
     private String randomStep(String parentUuid) {
         final String uuid = randomId();
         final String name = randomName();


### PR DESCRIPTION
### Context

Currently the attachment filename pattern is hardcoded in `AllureLifecycle#prepareAttachment` method. Despite it if perfectly matches `io.qameta.allure.AllureResultsWriter#write(java.lang.String, java.io.InputStream)` specification in some cases we might need to customize the value.

**For example:** we have tests with numbers of steps where all those steps return same result. We do not want to keep different files for all those attachments since it overloads storage and network. So we would like to use some logic that would evaluate the attachment name depending on the content so that same content would be stored in the same file.

I understand that current implementation of `io.qameta.allure.FileSystemResultsWriter` does not allow to use attachment files with the same name. However I keep that out of the scope of current PR since I expect that whoever addressing the use case like mine would use their own writer which would be able to overwrite existing attachment files.

#### Checklist
- [v] [Sign Allure CLA][cla]
- [v] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
