### PR TITLE
Lazy load logger in ResultUtils to supress SLF4J warings in AnnotationProcessing

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -27,7 +27,6 @@ import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
@@ -96,7 +95,9 @@ public final class ResultsUtils {
     public static final String FRAMEWORK_LABEL_NAME = "framework";
     public static final String LANGUAGE_LABEL_NAME = "language";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResultsUtils.class);
+    // We must not initialize the logger here.
+    // See: https://github.com/allure-framework/allure-java/issues/962
+    // private static final Logger LOGGER = LoggerFactory.getLogger(ResultsUtils.class);
     private static final String ALLURE_DESCRIPTIONS_PACKAGE = "allureDescriptions/";
     private static final String MD_5 = "MD5";
 
@@ -364,7 +365,7 @@ public final class ResultsUtils {
             try {
                 cachedHost = InetAddress.getLocalHost().getHostName();
             } catch (UnknownHostException e) {
-                LOGGER.debug("Could not get host name", e);
+                LoggerFactory.getLogger(ResultsUtils.class).debug("Could not get host name", e);
                 cachedHost = "default";
             }
         }
@@ -407,7 +408,7 @@ public final class ResultsUtils {
             final byte[] bytes = toBytes(is);
             return Optional.of(new String(bytes, StandardCharsets.UTF_8));
         } catch (IOException e) {
-            LOGGER.warn("Unable to process description resource file", e);
+            LoggerFactory.getLogger(ResultsUtils.class).warn("Unable to process description resource file", e);
         }
         return Optional.empty();
     }


### PR DESCRIPTION
### Context


The JavaDocDescriptionsProcessor requires the `ResultsUtils.generateMethodSignatureHash`
When the ResultsUtils class is loaded during AnnotationProcessing, it has initialized also the SLF4J framework, which leads to some SLF4J warnings while compiling.

Getting the logger only, when it is really needed will solve the issue (in theoretical more costs in performance, but this does not matter here)

See #962 for more info

#### Checklist
- [x] [Sign Allure CLA][cla]
- [!] Provide unit tests - this is difficult to unit test as it happens only, if there is no SLF4J implementation present - I've verified it manually and the warning is gone in my project with this change (maybe give me a hint how to test it)

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
