### PR TITLE
fix(descriptions-javadoc): put descriptions in META-INF folder

### DIFF
--- a/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
+++ b/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
@@ -16,7 +16,6 @@
 package io.qameta.allure.description;
 
 import io.qameta.allure.Description;
-import io.qameta.allure.util.ResultsUtils;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;

--- a/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
+++ b/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
@@ -16,6 +16,7 @@
 package io.qameta.allure.description;
 
 import io.qameta.allure.Description;
+import io.qameta.allure.util.ResultsUtils;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
@@ -85,8 +86,8 @@ public class JavaDocDescriptionsProcessor extends AbstractProcessor {
 
             final String hash = generateMethodSignatureHash(el.getEnclosingElement().toString(), name, typeParams);
             try {
-                final FileObject file = filer.createResource(StandardLocation.CLASS_OUTPUT,
-                        "allureDescriptions", hash);
+                final FileObject file = filer.createResource(StandardLocation.CLASS_OUTPUT, "",
+                        ResultsUtils.ALLURE_DESCRIPTIONS_FOLDER + hash);
                 try (Writer writer = file.openWriter()) {
                     writer.write(docs);
                 }

--- a/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
+++ b/allure-descriptions-javadoc/src/main/java/io/qameta/allure/description/JavaDocDescriptionsProcessor.java
@@ -47,6 +47,8 @@ import static io.qameta.allure.util.ResultsUtils.generateMethodSignatureHash;
 @SupportedAnnotationTypes("io.qameta.allure.Description")
 public class JavaDocDescriptionsProcessor extends AbstractProcessor {
 
+    private static final String ALLURE_DESCRIPTIONS_FOLDER = "META-INF/allureDescriptions/";
+
     private Filer filer;
     private Elements elementUtils;
     private Messager messager;
@@ -87,7 +89,7 @@ public class JavaDocDescriptionsProcessor extends AbstractProcessor {
             final String hash = generateMethodSignatureHash(el.getEnclosingElement().toString(), name, typeParams);
             try {
                 final FileObject file = filer.createResource(StandardLocation.CLASS_OUTPUT, "",
-                        ResultsUtils.ALLURE_DESCRIPTIONS_FOLDER + hash);
+                        ALLURE_DESCRIPTIONS_FOLDER + hash);
                 try (Writer writer = file.openWriter()) {
                     writer.write(docs);
                 }

--- a/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
+++ b/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
@@ -18,7 +18,6 @@ package io.qameta.allure.description;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
-import io.qameta.allure.util.ResultsUtils;
 import org.junit.jupiter.api.Test;
 
 import javax.tools.JavaFileObject;

--- a/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
+++ b/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
@@ -31,6 +31,9 @@ import static com.google.testing.compile.Compiler.javac;
  * @author Egor Borisov ehborisov@gmail.com
  */
 class ProcessDescriptionsTest {
+
+    private static final String ALLURE_DESCRIPTIONS_FOLDER = "META-INF/allureDescriptions/";
+
     @Test
     void captureDescriptionTest() {
         final String expectedMethodSignatureHash = "4e7f896021ef2fce7c1deb7f5b9e38fb";
@@ -57,7 +60,7 @@ class ProcessDescriptionsTest {
         assertThat(compilation).generatedFile(
                 StandardLocation.CLASS_OUTPUT,
                 "",
-                ResultsUtils.ALLURE_DESCRIPTIONS_FOLDER + expectedMethodSignatureHash
+                ALLURE_DESCRIPTIONS_FOLDER + expectedMethodSignatureHash
         );
     }
 
@@ -120,7 +123,7 @@ class ProcessDescriptionsTest {
         assertThat(compilation).generatedFile(
                 StandardLocation.CLASS_OUTPUT,
                 "",
-                ResultsUtils.ALLURE_DESCRIPTIONS_FOLDER + expectedMethodSignatureHash
+                ALLURE_DESCRIPTIONS_FOLDER + expectedMethodSignatureHash
         );
     }
 
@@ -153,7 +156,7 @@ class ProcessDescriptionsTest {
         assertThat(compilation).generatedFile(
                 StandardLocation.CLASS_OUTPUT,
                 "",
-                ResultsUtils.ALLURE_DESCRIPTIONS_FOLDER + expectedMethodSignatureHash
+                ALLURE_DESCRIPTIONS_FOLDER + expectedMethodSignatureHash
         );
     }
 }

--- a/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
+++ b/allure-descriptions-javadoc/src/test/java/io/qameta/allure/description/ProcessDescriptionsTest.java
@@ -18,6 +18,7 @@ package io.qameta.allure.description;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
+import io.qameta.allure.util.ResultsUtils;
 import org.junit.jupiter.api.Test;
 
 import javax.tools.JavaFileObject;
@@ -30,9 +31,6 @@ import static com.google.testing.compile.Compiler.javac;
  * @author Egor Borisov ehborisov@gmail.com
  */
 class ProcessDescriptionsTest {
-
-    private static final String ALLURE_PACKAGE_NAME = "allureDescriptions";
-
     @Test
     void captureDescriptionTest() {
         final String expectedMethodSignatureHash = "4e7f896021ef2fce7c1deb7f5b9e38fb";
@@ -58,8 +56,8 @@ class ProcessDescriptionsTest {
         Compilation compilation = compiler.compile(source);
         assertThat(compilation).generatedFile(
                 StandardLocation.CLASS_OUTPUT,
-                ALLURE_PACKAGE_NAME,
-                expectedMethodSignatureHash
+                "",
+                ResultsUtils.ALLURE_DESCRIPTIONS_FOLDER + expectedMethodSignatureHash
         );
     }
 
@@ -121,8 +119,8 @@ class ProcessDescriptionsTest {
         Compilation compilation = compiler.compile(source);
         assertThat(compilation).generatedFile(
                 StandardLocation.CLASS_OUTPUT,
-                ALLURE_PACKAGE_NAME,
-                expectedMethodSignatureHash
+                "",
+                ResultsUtils.ALLURE_DESCRIPTIONS_FOLDER + expectedMethodSignatureHash
         );
     }
 
@@ -154,8 +152,8 @@ class ProcessDescriptionsTest {
         Compilation compilation = compiler.compile(source);
         assertThat(compilation).generatedFile(
                 StandardLocation.CLASS_OUTPUT,
-                ALLURE_PACKAGE_NAME,
-                expectedMethodSignatureHash
+                "",
+                ResultsUtils.ALLURE_DESCRIPTIONS_FOLDER + expectedMethodSignatureHash
         );
     }
 }

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -95,9 +95,9 @@ public final class ResultsUtils {
     public static final String PACKAGE_LABEL_NAME = "package";
     public static final String FRAMEWORK_LABEL_NAME = "framework";
     public static final String LANGUAGE_LABEL_NAME = "language";
-    public static final String ALLURE_DESCRIPTIONS_FOLDER = "META-INF/allureDescriptions/";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResultsUtils.class);
+    private static final String ALLURE_DESCRIPTIONS_FOLDER = "META-INF/allureDescriptions/";
     private static final String MD_5 = "MD5";
 
     private static String cachedHost;

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -95,9 +95,9 @@ public final class ResultsUtils {
     public static final String PACKAGE_LABEL_NAME = "package";
     public static final String FRAMEWORK_LABEL_NAME = "framework";
     public static final String LANGUAGE_LABEL_NAME = "language";
+    public static final String ALLURE_DESCRIPTIONS_FOLDER = "META-INF/allureDescriptions/";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResultsUtils.class);
-    private static final String ALLURE_DESCRIPTIONS_PACKAGE = "allureDescriptions/";
     private static final String MD_5 = "MD5";
 
     private static String cachedHost;
@@ -305,7 +305,7 @@ public final class ResultsUtils {
                 name,
                 parameterTypes);
 
-        return readResource(classLoader, ALLURE_DESCRIPTIONS_PACKAGE + signatureHash)
+        return readResource(classLoader, ALLURE_DESCRIPTIONS_FOLDER + signatureHash)
                 .map(desc -> separateLines() ? desc.replace("\n", "<br />") : desc);
     }
 


### PR DESCRIPTION
### Context

We have a multi module project, where we have a "commons-junit" maven module.
The "commons-junit" module provides some basic tests in an abstract class, that other modules can can (re)use.
Now we want to add module-infos in all our modules and we come across the problem, that `allure-descriptions-javadoc` puts the descriptions in the folder `allureDescriptions`. 

As this looks like a package, we get the jpms split package situation and get the error
```
Package allureDescriptions in both module A and module B
```
This PR changes the destination from `allureDescriptions` to `META-INF/allureDescriptions` as suggested here
https://stackoverflow.com/questions/69526033/how-to-add-resources-to-two-modular-jars-in-same-named-folders 

This will solve our problem, but I cannot estimate, if there are thirdParty frameworks, that rely on the folder location

### Example use case

Content of the "commons-junit" module
```java
public abstract class BasicArchitectureTest {
	/**
	 * Tests for correct test class names (uses com.tngtech.archunit).
	 */
	@Test
	@Description(useJavaDoc = true)
	public void testTestClassNames() {
		testClasses()
				.should()
				.haveSimpleNameEndingWith("Test")
				.orShould()
				.haveSimpleNameEndingWith("IT") // covers also UIT
				.check(SRC_TEST_JAVA);
	}
}
```
Content of other module (depends on commons-junit)
```java
public class CoreCommonsJunitArchitectureTest extends BasicArchitectureTest {
        // execute all tests in this module provided by BasicArchitectureTest 

    	/**
	 * module specific architecture tests
	 */
	@Test
	@Description(useJavaDoc = true)
	public void testFoo() {
            ...
        }
}
```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests (unit tests are adjusted)

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
