### PR TITLE
Support AssertJ soft assertions (#19)

### DIFF
--- a/allure-assertj/build.gradle.kts
+++ b/allure-assertj/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
     testImplementation(project(":allure-java-commons-test"))
     testImplementation(project(":allure-junit-platform"))
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation("org.junit.vintage:junit-vintage-engine")
+    testImplementation("org.junit.jupiter:junit-jupiter-params")
 }
 
 tasks.jar {

--- a/allure-assertj/src/test/java/io/qameta/allure/assertj/SoftAssertionsBasicApproachesTest.java
+++ b/allure-assertj/src/test/java/io/qameta/allure/assertj/SoftAssertionsBasicApproachesTest.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.assertj;
+
+import io.qameta.allure.test.AllureFeatures;
+import org.assertj.core.api.AutoCloseableSoftAssertions;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.StandardSoftAssertionsProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.Consumer;
+
+import static io.qameta.allure.assertj.util.SoftAssertionsUtils.eraseCollectedErrors;
+
+/**
+ * @author Achitheus (Yury Yurchenko).
+ */
+public class SoftAssertionsBasicApproachesTest {
+
+    @AllureFeatures.Steps
+    @DisplayName("Check hardcoded soft assertions object")
+    @ParameterizedTest(name = "[{index}]: {arguments}")
+    @MethodSource(value = "io.qameta.allure.assertj.util.SoftAssertionsTestsProvider#softAssertionsTests")
+    void tests(String testName, Consumer<StandardSoftAssertionsProvider> test) {
+        SoftAssertions softly = new SoftAssertions();
+        test.accept(softly);
+    }
+
+    @AllureFeatures.Steps
+    @DisplayName("Check autocloseable soft assertions")
+    @ParameterizedTest(name = "[{index}]: {arguments}")
+    @MethodSource(value = "io.qameta.allure.assertj.util.SoftAssertionsTestsProvider#softAssertionsTests")
+    void autocloseableTests(String testName, Consumer<StandardSoftAssertionsProvider> test) {
+        try (AutoCloseableSoftAssertions softly = new AutoCloseableSoftAssertions()) {
+            test.accept(softly);
+            eraseCollectedErrors(softly);
+        }
+    }
+
+    @AllureFeatures.Steps
+    @DisplayName("Check SoftAssertions.assertSoftly() method")
+    @ParameterizedTest(name = "[{index}]: {arguments}")
+    @MethodSource(value = "io.qameta.allure.assertj.util.SoftAssertionsTestsProvider#softAssertionsTests")
+    void assertSoftlyMethodTests(String testName, Consumer<StandardSoftAssertionsProvider> test) {
+        SoftAssertions.assertSoftly(softly -> {
+            test.accept(softly);
+            eraseCollectedErrors(softly);
+        });
+    }
+}
+

--- a/allure-assertj/src/test/java/io/qameta/allure/assertj/SoftAssertionsJUnit4RuleTest.java
+++ b/allure-assertj/src/test/java/io/qameta/allure/assertj/SoftAssertionsJUnit4RuleTest.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.assertj;
+
+import io.qameta.allure.test.AllureFeatures;
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.assertj.core.api.StandardSoftAssertionsProvider;
+import org.junit.Rule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.Consumer;
+
+import static io.qameta.allure.assertj.util.SoftAssertionsUtils.eraseCollectedErrors;
+
+/**
+ * @author Achitheus (Yury Yurchenko).
+ */
+public class SoftAssertionsJUnit4RuleTest {
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @AllureFeatures.Steps
+    @DisplayName("Check JUnit4 Rule soft assertions")
+    @ParameterizedTest(name = "[{index}]: {arguments}")
+    @MethodSource(value = "io.qameta.allure.assertj.util.SoftAssertionsTestsProvider#softAssertionsTests")
+    public void tests(String testName, Consumer<StandardSoftAssertionsProvider> test) {
+        test.accept(softly);
+        eraseCollectedErrors(softly);
+    }
+}

--- a/allure-assertj/src/test/java/io/qameta/allure/assertj/SoftAssertionsJUnit5ExtensionTest.java
+++ b/allure-assertj/src/test/java/io/qameta/allure/assertj/SoftAssertionsJUnit5ExtensionTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.assertj;
+
+import io.qameta.allure.test.AllureFeatures;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.StandardSoftAssertionsProvider;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.function.Consumer;
+
+import static io.qameta.allure.assertj.util.SoftAssertionsUtils.eraseCollectedErrors;
+
+/**
+ * @author Achitheus (Yury Yurchenko).
+ */
+@ExtendWith(SoftAssertionsExtension.class)
+public class SoftAssertionsJUnit5ExtensionTest {
+
+    @InjectSoftAssertions
+    private SoftAssertions softly;
+
+    @AllureFeatures.Steps
+    @DisplayName("Check soft assertions obj injected as field by JUnit5 extension")
+    @ParameterizedTest(name = "[{index}]: {arguments}")
+    @MethodSource(value = "io.qameta.allure.assertj.util.SoftAssertionsTestsProvider#softAssertionsTests")
+    void fieldInjectionTests(String testName, Consumer<StandardSoftAssertionsProvider> test) {
+        test.accept(softly);
+        eraseCollectedErrors(softly);
+    }
+
+    @AllureFeatures.Steps
+    @DisplayName("Check soft assertions obj injected as parameter by JUnit5 extension")
+    @ParameterizedTest(name = "[{index}]: {arguments}")
+    @MethodSource(value = "io.qameta.allure.assertj.util.SoftAssertionsTestsProvider#softAssertionsTests")
+    void parameterInjectionTests(String testName, Consumer<StandardSoftAssertionsProvider> test, SoftAssertions softly) {
+        test.accept(softly);
+        eraseCollectedErrors(softly);
+    }
+}

--- a/allure-assertj/src/test/java/io/qameta/allure/assertj/util/ReflectionUtils.java
+++ b/allure-assertj/src/test/java/io/qameta/allure/assertj/util/ReflectionUtils.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.assertj.util;
+
+import java.lang.reflect.Method;
+import java.util.function.Consumer;
+
+public class ReflectionUtils {
+
+    public static <T> Consumer<T> staticMethodAsConsumer(Method m) {
+        return param -> {
+            try {
+                m.invoke(null, param);
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/allure-assertj/src/test/java/io/qameta/allure/assertj/util/SoftAssertionsTestsProvider.java
+++ b/allure-assertj/src/test/java/io/qameta/allure/assertj/util/SoftAssertionsTestsProvider.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.assertj.util;
+
+import io.qameta.allure.Allure;
+import io.qameta.allure.Step;
+import io.qameta.allure.aspects.StepsAspects;
+import io.qameta.allure.assertj.AllureAspectJ;
+import io.qameta.allure.model.StepResult;
+import io.qameta.allure.model.TestResult;
+import io.qameta.allure.test.AllureResults;
+import junit.framework.AssertionFailedError;
+import org.assertj.core.api.StandardSoftAssertionsProvider;
+import org.junit.jupiter.params.provider.Arguments;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static io.qameta.allure.Allure.step;
+import static io.qameta.allure.assertj.util.ReflectionUtils.staticMethodAsConsumer;
+import static io.qameta.allure.assertj.util.StringsUtils.humanReadableMethodOrClassName;
+import static io.qameta.allure.model.Status.FAILED;
+import static io.qameta.allure.model.Status.PASSED;
+import static io.qameta.allure.test.RunUtils.runWithinTestContext;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Achitheus (Yury Yurchenko).
+ */
+@SuppressWarnings("unused")
+public class SoftAssertionsTestsProvider {
+    public static final Logger LOGGER = LoggerFactory.getLogger(SoftAssertionsTestsProvider.class);
+
+    public static Stream<Arguments> softAssertionsTests() {
+        return Arrays.stream(SoftAssertionsTestsProvider.class.getDeclaredMethods())
+                .filter(method -> {
+                    Class<?>[] paramTypeArray = method.getParameterTypes();
+                    return !method.getName().contains("$")
+                            && paramTypeArray.length == 1
+                            && paramTypeArray[0] == StandardSoftAssertionsProvider.class;
+                })
+                .peek(method -> method.setAccessible(true))
+                .map(method -> Arguments.of(humanReadableMethodOrClassName(method.getName()), staticMethodAsConsumer(method)));
+    }
+
+    private static void afterAssertionErrorCollectedCallbackShouldWork(StandardSoftAssertionsProvider softly) {
+        final AllureResults results = runWithinTestContext(() -> {
+            step("Allure.step()", () -> {
+                annotationStep(() -> {});
+                annotationStep(() -> {});
+                annotationStep(() -> {
+                    step("Allure.step()");
+                    step("Allure.step()", () -> {
+                        annotationStep(() -> {});
+                        annotationStep(() -> softly.collectAssertionError(new AssertionFailedError("hellow")));
+                    });
+                });
+                annotationStep(() -> {});
+            });
+        }, AllureAspectJ::setLifecycle, Allure::setLifecycle, StepsAspects::setLifecycle);
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getSteps)
+                .extracting(StepResult::getStatus)
+                .containsExactly(FAILED);
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getSteps)
+                .flatExtracting(StepResult::getSteps)
+                .extracting(StepResult::getStatus)
+                .containsExactly(PASSED, PASSED, FAILED, PASSED);
+        assertThat(softly.assertionErrorsCollected()).hasSize(1);
+    }
+
+    private static void customMethodStepShouldBeFailed(StandardSoftAssertionsProvider softly) {
+        final AllureResults results = runWithinTestContext(() -> {
+            List<String> notebookList = List.of("Tests string 0", "Tests string 1");
+            step("Allure.step()", () -> {
+                softly.assertThatList(notebookList)
+                        .hasSize(1_000_000)
+                        .containsAnyOf("Passed", "Tests string 0");
+            });
+            step("Allure.step()", () -> {
+                softly.assertThatList(notebookList)
+                        .hasSize(2)
+                        .containsExactly("failed", "nope", "its failed");
+            });
+        }, AllureAspectJ::setLifecycle, Allure::setLifecycle);
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getSteps)
+                .extracting(StepResult::getStatus)
+                .containsExactly(FAILED, FAILED);
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getSteps)
+                .flatExtracting(StepResult::getSteps)
+                .extracting(StepResult::getStatus)
+                .containsExactly(PASSED, FAILED, PASSED,
+                        PASSED, PASSED, FAILED);
+        assertThat(softly.assertionErrorsCollected()).hasSize(2);
+    }
+
+    private static void severalMiddleStepsShouldBeFailed(StandardSoftAssertionsProvider softly) {
+        final AllureResults results = runWithinTestContext(() -> {
+            softly.assertThat("Some test string")
+                    .as("%s description passed", "awesome")
+                    .containsAnyOf("passed", "blahblah", "me te")
+                    .containsOnlyDigits()
+                    .doesNotContainIgnoringCase("passed")
+                    .startsWith("failed")
+                    .containsPattern(".+ test .+")
+                    .endsWith("failed");
+        }, AllureAspectJ::setLifecycle);
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getSteps)
+                .extracting(StepResult::getStatus)
+                .containsExactly(PASSED, PASSED, PASSED, FAILED, PASSED, FAILED, PASSED, FAILED);
+        assertThat(softly.assertionErrorsCollected()).hasSize(3);
+    }
+
+    @Step("@Step")
+    public static void annotationStep(Runnable runnable) {
+        runnable.run();
+    }
+}

--- a/allure-assertj/src/test/java/io/qameta/allure/assertj/util/SoftAssertionsUtils.java
+++ b/allure-assertj/src/test/java/io/qameta/allure/assertj/util/SoftAssertionsUtils.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.assertj.util;
+
+import org.assertj.core.api.DefaultAssertionErrorCollector;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+/**
+ * @author Achitheus (Yury Yurchenko)
+ */
+@SuppressWarnings("unchecked")
+public class SoftAssertionsUtils {
+
+    public static void eraseCollectedErrors(DefaultAssertionErrorCollector softAssertions) {
+        try {
+            Field errorListField = DefaultAssertionErrorCollector.class.getDeclaredField("collectedAssertionErrors");
+            errorListField.setAccessible(true);
+            List<AssertionError> errorList = (List<AssertionError>) errorListField.get(softAssertions.getDelegate().orElse(softAssertions));
+            errorList.clear();
+        } catch (ReflectiveOperationException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/allure-assertj/src/test/java/io/qameta/allure/assertj/util/StringsUtils.java
+++ b/allure-assertj/src/test/java/io/qameta/allure/assertj/util/StringsUtils.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.assertj.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class StringsUtils {
+
+    /**
+     * Method converts camel-case string to human-readable one.
+     * It doesn't work correctly with names which contain abbreviations (DBConnection, helloASMFramework, etc.)
+     *
+     * @param camelCaseName standard Java style method or class name.
+     * @return human-readable name interpretation.
+     * @author Achitheus (Yury Yurchenko).
+     */
+    public static String humanReadableMethodOrClassName(String camelCaseName) {
+        StringBuilder sb = new StringBuilder();
+        Matcher matcher = Pattern.compile("([A-Za-z][^A-Z]*)").matcher(camelCaseName);
+        for (int i = 0; matcher.find(); i++) {
+            String group = matcher.group(1);
+            if (i == 0) {
+                sb.append(Character.toUpperCase(group.charAt(0)));
+                if (group.length() > 1) {
+                    sb.append(group, 1, group.length());
+                }
+            } else {
+                sb.append(" ").append(group.toLowerCase());
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
@@ -300,6 +300,15 @@ public class AllureLifecycle {
     }
 
     /**
+     * Returns uuid of current step.
+     *
+     * @return the uuid of current running test case or step.
+     */
+    public Optional<String> getCurrentStep() {
+        return threadContext.getCurrentStep();
+    }
+
+    /**
      * Sets specified test case uuid as current. Note that
      * test case with such uuid should be created and existed in storage, otherwise
      * method take no effect.

--- a/allure-java-commons/src/main/java/io/qameta/allure/internal/AllureThreadContext.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/internal/AllureThreadContext.java
@@ -29,6 +29,16 @@ public class AllureThreadContext {
     private final Context context = new Context();
 
     /**
+     * Returns last (most recent) uuid but not the root.
+     */
+    public Optional<String> getCurrentStep() {
+        final LinkedList<String> uuids = context.get();
+        return uuids.size() < 2
+                ? Optional.empty()
+                : Optional.of(uuids.getFirst());
+    }
+
+    /**
      * Returns last (most recent) uuid.
      */
     public Optional<String> getCurrent() {

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/StepsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/StepsUtils.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2019 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.util;
+
+import io.qameta.allure.model.Status;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.qameta.allure.Allure.getLifecycle;
+
+public class StepsUtils {
+
+    public static Status getStepStatus() {
+        AtomicReference<Status> outerStepRef = new AtomicReference<>();
+        getLifecycle().updateStep(step -> outerStepRef.set(step.getStatus()));
+        return outerStepRef.get();
+    }
+}


### PR DESCRIPTION
## Context
### Step tree
The first change is about processing step tree. If step fails its status should be escalated to all parent steps. (There is another way with substeps check for presence of at least one status differ from `PASSED`, but I preffered the mentioned above approach as more efficacious). This is achieved due to the following alghorythm:
```
final Status currentStepStatus = getStepStatus();
        if (currentStepStatus == null) {
            getLifecycle().updateStep(s -> s.setStatus(Status.PASSED));
            getLifecycle().stopStep();
        } else {
            getLifecycle().stopStep();
            if (getLifecycle().getCurrentStep().isPresent()) {
                getLifecycle().updateStep(outerStep -> outerStep.setStatus(currentStepStatus));
            }
        }
```
Ok, from now on any single failed step will be transformed to the real failed step branch. But do we have firm confidence that on each soft assertion error there is at least one failed step at the end of the step chain? Certainly we dont, I even found a case that confirms this.
### The first failed step
To be sure in existence of at least one failed step which can trigger failed status propagating to all outer steps I added `advice` for setting callback via `DefaultAssertionErrorCollector.setAfterAssertionErrorCollected()` for each created `SoftAssertions` object.
But there is a problem, because this method is absolutely ordinary setter. It means that its any following call will inevitably overwrite callback that was set before. Fortunately someone has already made corresponding [pull request](https://github.com/assertj/assertj/pull/3313) :)
### Additionaly
Added pointcut that filters out nested step duplicates created by generated `.class` files method calls. 
### Few words about tests
Extraordinary approach is used to avoid a lot of code duplicates and at the same time to cover all possible ways to create soft assertions objects. 

Thank you for your attention!

#### Checklist
- [x] [cla][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
