### PR TITLE
feat(rest-assured): add support for headers blacklist

### DIFF
--- a/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
+++ b/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
@@ -137,7 +137,8 @@ public class AllureRestAssured implements OrderedFilter {
         return response;
     }
 
-    private static Map<String, String> toMapConverter(final Iterable<? extends NameAndValue> items, final Set<String> toHide) {
+    private static Map<String, String> toMapConverter(final Iterable<? extends NameAndValue> items,
+                                                      final Set<String> toHide) {
         final Map<String, String> result = new HashMap<>();
         items.forEach(h -> result.put(h.getName(), toHide.contains(h.getName()) ? HIDDEN_PLACEHOLDER : h.getValue()));
         return result;

--- a/allure-rest-assured/src/test/java/io/qameta/allure/restassured/AllureRestAssuredTest.java
+++ b/allure-rest-assured/src/test/java/io/qameta/allure/restassured/AllureRestAssuredTest.java
@@ -191,6 +191,7 @@ class AllureRestAssuredTest {
             } finally {
                 server.stop();
                 RestAssured.replaceFiltersWith(ImmutableList.of());
+                RestAssured.config = new RestAssuredConfig();
             }
         });
     }

--- a/allure-rest-assured/src/test/java/io/qameta/allure/restassured/AllureRestAssuredTest.java
+++ b/allure-rest-assured/src/test/java/io/qameta/allure/restassured/AllureRestAssuredTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -80,7 +79,6 @@ class BlacklistHeadersArgumentProvider implements ArgumentsProvider {
 /**
  * @author charlie (Dmitry Baev).
  */
-@SuppressWarnings("unchecked")
 class AllureRestAssuredTest {
 
     @ParameterizedTest
@@ -94,7 +92,7 @@ class AllureRestAssuredTest {
                 .map(TestResult::getAttachments)
                 .flatMap(Collection::stream)
                 .map(Attachment::getName))
-                .isEqualTo(attachmentNames);
+                .containsExactlyElementsOf(attachmentNames);
     }
 
     @Test
@@ -144,19 +142,19 @@ class AllureRestAssuredTest {
                 .collect(Collectors.toList());
 
         assertThat(actualAttachments)
-                .flatExtracting(Attachment::getName)
-                .isEqualTo(attachmentNames)
+                .map(Attachment::getName)
+                .containsExactlyElementsOf(attachmentNames)
                 .doesNotContainNull();
 
         assertThat(actualAttachments)
-                .flatExtracting(Attachment::getSource)
-                .containsExactlyInAnyOrderElementsOf(new ArrayList<>(results.getAttachments().keySet()))
+                .map(Attachment::getSource)
+                .containsExactlyInAnyOrderElementsOf(results.getAttachments().keySet())
                 .doesNotContainNull();
     }
 
     @ParameterizedTest
     @ArgumentsSource(BlacklistHeadersArgumentProvider.class)
-    void shouldBlacklistHeaders(final Map<String, String> headers, final String blacklistedHeader, final List<String> expectedValues, AllureRestAssured filter) {
+    void shouldBlacklistHeadersInAttachments(final Map<String, String> headers, final String blacklistedHeader, final List<String> expectedValues, AllureRestAssured filter) {
         final ResponseDefinitionBuilder responseBuilder = WireMock.aResponse().withStatus(200);
         headers.forEach(responseBuilder::withHeader);
 

--- a/allure-rest-assured/src/test/java/io/qameta/allure/restassured/AllureRestAssuredTest.java
+++ b/allure-rest-assured/src/test/java/io/qameta/allure/restassured/AllureRestAssuredTest.java
@@ -155,8 +155,10 @@ class AllureRestAssuredTest {
 
     @ParameterizedTest
     @ArgumentsSource(HiddenHeadersArgumentProvider.class)
-    void shouldHideHeadersInAttachments(
-        final Map<String, String> headers, final String hiddenHeader, final List<String> expectedValues, AllureRestAssured filter) {
+    void shouldHideHeadersInAttachments(final Map<String, String> headers,
+                                        final String hiddenHeader,
+                                        final List<String> expectedValues,
+                                        final AllureRestAssured filter) {
 
         final ResponseDefinitionBuilder responseBuilder = WireMock.aResponse().withStatus(200);
         headers.forEach(responseBuilder::withHeader);

--- a/allure-rest-assured/src/test/java/io/qameta/allure/restassured/AllureRestAssuredTest.java
+++ b/allure-rest-assured/src/test/java/io/qameta/allure/restassured/AllureRestAssuredTest.java
@@ -69,7 +69,7 @@ class BlacklistHeadersArgumentProvider implements ArgumentsProvider {
         final Map<String, String> headers = Map.of(blacklistedHeader, headerValue, header, headerValue);
 
         return Stream.of(
-                arguments(headers, blacklistedHeader, List.of(blacklistedHeader + ": " + headerValue, header + ": " + headerValue), new AllureRestAssured().considerBlacklistedHeaders(false)),
+                arguments(headers, blacklistedHeader, List.of(blacklistedHeader + ": " + headerValue, header + ": " + headerValue), new AllureRestAssured().followHeadersBlacklist(false)),
                 arguments(headers, blacklistedHeader, List.of(blacklistedHeader + ": [ BLACKLISTED ]", header + ": " + headerValue), new AllureRestAssured()),
                 arguments(headers, blacklistedHeader.toUpperCase(), List.of(blacklistedHeader + ": [ BLACKLISTED ]", header + ": " + headerValue), new AllureRestAssured())
         );


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
RestAssured from version 4.2.0 added possibility to blacklist headers in the request or response logs.
~~This adds a configurable option to consider blacklisted headers from the RestAssured LogConfiguration and blacklist them in the Allure report as well. Enabled by default, so if there is a need to expose header blacklisted by RestAssured in Allure report it must be set explicitly.~~
This makes Allure report to blacklist the same headers.

Example of header blacklisted in Allure report:
![image](https://github.com/allure-framework/allure-java/assets/41286257/5ad29739-0349-47d7-9478-f1eeeffff13a)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
