### PR TITLE
Improve AllureGrpc integartion for support non-blocking (streaming) stubs

### DIFF
--- a/allure-grpc/build.gradle.kts
+++ b/allure-grpc/build.gradle.kts
@@ -8,14 +8,15 @@ description = "Allure gRPC Integration"
 
 val agent: Configuration by configurations.creating
 
-val grpcVersion = "1.57.2"
-val protobufVersion = "3.22.4"
+val grpcVersion = "1.62.2"
+val protobufVersion = "3.25.3"
 
 dependencies {
     agent("org.aspectj:aspectjweaver")
     api(project(":allure-attachments"))
     implementation("io.grpc:grpc-core:$grpcVersion")
     implementation("com.google.protobuf:protobuf-java-util:$protobufVersion")
+    internal("com.fasterxml.jackson.core:jackson-databind")
 
     testImplementation("io.grpc:grpc-stub:$grpcVersion")
     testImplementation("io.grpc:grpc-protobuf:$grpcVersion")

--- a/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
+++ b/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
@@ -15,6 +15,11 @@
  */
 package io.qameta.allure.grpc;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.util.JsonFormat;
@@ -27,6 +32,7 @@ import io.grpc.ForwardingClientCallListener;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.qameta.allure.Allure;
+import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.attachment.AttachmentData;
 import io.qameta.allure.attachment.AttachmentProcessor;
 import io.qameta.allure.attachment.DefaultAttachmentProcessor;
@@ -37,16 +43,66 @@ import io.qameta.allure.util.ResultsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 import java.util.UUID;
-
-import static java.util.Objects.requireNonNull;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Allure interceptor logger for gRPC.
+ * Allure interceptor logger for gRPC that is used to create allure steps and attach gRPC messages
+ * for the gRPC Channel, blocking stubs, or non-blocking stubs with after-each hook (see examples).
+ * Channels, stubs may be either static or non-static.
  *
- * @author dtuchs (Dmitry Tuchs).
+ * <h2>Usage with Channel</h2>
+ * <pre>
+ *   static Channel channel = ManagedChannelBuilder.forAddress("localhost", 8092)
+ *       .intercept(new AllureGrpc())
+ *       .build();
+ * </pre>
+ * When {@code AllureGrpc} object is present in a Channel,
+ * all stubs (both blocking and non-blocking) that using this Channel will intercept messages
+ * to Allure-report.
+ * <h3>NOTE!
+ * With non-blocking Stubs you have to use after-each hook for tests because non-blocking stubs
+ * are async, and allure-report might not be created after non-blocking Stubs call. See examples below
+ * </h3>
+ *
+ * <h2>Usage with blocking Stubs</h2>
+ * <pre>
+ *   ServiceGrpc.ServiceBlockingStub blockingStub = ServiceGrpc
+ *      .newBlockingStub(channel)
+ *      .withInterceptors(new AllureGrpc());
+ * </pre>
+ * You can just add {@code AllureGrpc} object to blocking Stub object, all unary calls from
+ * this stub will be logged to Allure-report.
+ *
+ * <h2>Usage with non-blocking Stubs (example for JUnit 5)</h2>
+ * <pre>
+ *   ServiceGrpc.ServiceStub stub = ServiceGrpc
+ *      .newStub(channel)
+ *      .withInterceptors(new AllureGrpc());
+ *
+ *   {@code @Test}
+ *   void test() {
+ *       stub.streamingCall(...);
+ *   }
+ *
+ *   {@code @AfterEach}
+ *   void awaitAllureForNonBlockingCalls() {
+ *     AllureGrpc.await();
+ *   }
+ * </pre>
+ * You can use {@code @AfterTest} annotation for TestNG and {@code @After} for JUnit 4.
+ * Of course, you can implement Extension or Rule to achieve that.
+ *
+ * @author dtuchs (Dmitrii Tuchs).
  */
 @SuppressWarnings({
         "PMD.AvoidFieldNameMatchingMethodName",
@@ -57,7 +113,12 @@ import static java.util.Objects.requireNonNull;
 public class AllureGrpc implements ClientInterceptor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AllureGrpc.class);
-    private static final JsonFormat.Printer JSON_PRINTER = JsonFormat.printer();
+    private static final JsonFormat.Printer GRPC_TO_JSON_PRINTER = JsonFormat.printer();
+    private static final Map<String, CountDownLatch> TEST_CASE_HOLDER = new ConcurrentHashMap<>();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final DefaultPrettyPrinter JSON_PRETTY_PRINTER = new DefaultPrettyPrinter();
+    private static final String STREAMING_MESSAGE
+            = "gRPC messages (collection of elements from %s stream)";
 
     private String requestTemplatePath = "grpc-request.ftl";
     private String responseTemplatePath = "grpc-response.ftl";
@@ -85,44 +146,122 @@ public class AllureGrpc implements ClientInterceptor {
         return this;
     }
 
-    @SuppressWarnings({"PMD.MethodArgumentCouldBeFinal", "PMD.NPathComplexity"})
+    /**
+     *  <h3>Should be called only after tests that use non-blocking Stubs.</h3>
+     * Generally, you can do it in the {@code @AfterEach} method in JUnit 5,
+     * {@code @AfterTest} in TestNG, or {@code @After} in JUnit 4 tests
+     */
+    public static void await() {
+        Allure.getLifecycle().getCurrentTestCase().ifPresent(caseId -> {
+            try {
+                final CountDownLatch latch = TEST_CASE_HOLDER.get(caseId);
+                if (latch != null) {
+                    latch.await();
+                    TEST_CASE_HOLDER.remove(caseId);
+                }
+            } catch (InterruptedException e) {
+                throw new IllegalStateException("Thread interrupted", e);
+            }
+        });
+    }
+
+    @SuppressWarnings({"checkstyle:Methodlength", "PMD.MethodArgumentCouldBeFinal", "PMD.NPathComplexity"})
     @Override
     public <T, A> ClientCall<T, A> interceptCall(MethodDescriptor<T, A> method,
                                                  CallOptions callOptions,
                                                  Channel next) {
-        final AttachmentProcessor<AttachmentData> processor = new DefaultAttachmentProcessor();
-
         return new ForwardingClientCall.SimpleForwardingClientCall<T, A>(
                 next.newCall(method, callOptions.withoutWaitForReady())) {
 
-            private String stepUuid;
-            private List<String> parsedResponses = new ArrayList<>();
+            private final Queue<String> parsedResponses = new ConcurrentLinkedQueue<>();
+            private final Queue<String> parsedRequests = new ConcurrentLinkedQueue<>();
+
+            private final AtomicBoolean allureThreadStarted = new AtomicBoolean(false);
+            private final CountDownLatch interceptorLatch = new CountDownLatch(1);
+
+            private final AtomicReference<Throwable> exceptionHolder = new AtomicReference<>();
+            private final AtomicReference<io.grpc.Status> statusHolder = new AtomicReference<>();
+            private final AtomicReference<Metadata> metadataHolder = new AtomicReference<>();
+
+            private final ExecutorService executor = Executors.newSingleThreadExecutor();
+            private String caseUuid;
 
             @SuppressWarnings("PMD.MethodArgumentCouldBeFinal")
             @Override
             public void sendMessage(T message) {
-                stepUuid = UUID.randomUUID().toString();
-                Allure.getLifecycle().startStep(stepUuid, (new StepResult()).setName(
-                        "Send gRPC request to "
-                                + next.authority()
-                                + trimGrpcMethodName(method.getFullMethodName())
-                ));
+                final AllureLifecycle lifecycle = Allure.getLifecycle();
+                caseUuid = lifecycle.getCurrentTestCase().orElseThrow(
+                        () -> new IllegalStateException("No test case started")
+                );
+                TEST_CASE_HOLDER.put(caseUuid, new CountDownLatch(1));
+
+                if (!allureThreadStarted.get()) {
+                    executor.submit(new Runnable() {
+                        private final AtomicBoolean stepCreated = new AtomicBoolean(false);
+                        private final AttachmentProcessor<AttachmentData> processor
+                                = new DefaultAttachmentProcessor(lifecycle);
+                        private String stepUuid;
+
+                        /**
+                         * Daemon thread that will be used to create steps and attachments.
+                         * This approach should be used because non-blocking stubs use several threads
+                         * to send and receive messages,
+                         * while {@code AllureThreadContext} uses {@code ThreadLocal} internally.
+                         */
+                        @Override
+                        public void run() {
+                            if (!stepCreated.get()) {
+                                stepUuid = startStep(lifecycle);
+                            }
+
+                            try {
+                                interceptorLatch.await();
+                                if (exceptionHolder.get() != null) {
+                                    markStepBrokenByException(lifecycle);
+                                } else {
+                                    final io.grpc.Status status = statusHolder.get();
+                                    final Metadata metadata = metadataHolder.get();
+                                    final GrpcRequestAttachment.Builder requestAttachment
+                                            = requestAttachment(method);
+                                    final GrpcResponseAttachment.Builder responseAttachment
+                                            = responseAttachment(method, status, metadata);
+
+                                    processor.addAttachment(
+                                            requestAttachment.build(),
+                                            new FreemarkerAttachmentRenderer(requestTemplatePath)
+                                    );
+                                    processor.addAttachment(
+                                            responseAttachment.build(),
+                                            new FreemarkerAttachmentRenderer(responseTemplatePath)
+                                    );
+
+                                    if (status.isOk() || !markStepFailedOnNonZeroCode) {
+                                        lifecycle.updateStep(stepUuid, step -> step.setStatus(Status.PASSED));
+                                    } else {
+                                        lifecycle.updateStep(stepUuid, step -> step.setStatus(Status.FAILED));
+                                    }
+                                }
+                                lifecycle.stopStep(stepUuid);
+                                TEST_CASE_HOLDER.get(caseUuid).countDown();
+                            } catch (InterruptedException e) {
+                                throw new IllegalStateException("Thread interrupted ", e);
+                            } finally {
+                                stepUuid = null;
+                                stepCreated.set(false);
+                            }
+                        }
+                    });
+                    allureThreadStarted.set(true);
+                }
+
                 try {
-                    final GrpcRequestAttachment rpcRequestAttach = GrpcRequestAttachment.Builder
-                            .create("gRPC request", method.getFullMethodName())
-                            .setBody(JSON_PRINTER.print((MessageOrBuilder) message))
-                            .build();
-                    processor.addAttachment(rpcRequestAttach, new FreemarkerAttachmentRenderer(requestTemplatePath));
+                    parsedRequests.add(GRPC_TO_JSON_PRINTER.print((MessageOrBuilder) message));
                     super.sendMessage(message);
                 } catch (InvalidProtocolBufferException e) {
                     LOGGER.warn("Can`t parse gRPC request", e);
-                } catch (Throwable e) {
-                    Allure.getLifecycle().updateStep(stepResult ->
-                            stepResult.setStatus(ResultsUtils.getStatus(e).orElse(Status.BROKEN))
-                                    .setStatusDetails(ResultsUtils.getStatusDetails(e).orElse(null))
-                    );
-                    Allure.getLifecycle().stopStep(stepUuid);
-                    stepUuid = null;
+                } catch (Exception e) {
+                    exceptionHolder.set(e);
+                    shutdownAllureThread();
                 }
             }
 
@@ -138,48 +277,9 @@ public class AllureGrpc implements ClientInterceptor {
                     @SuppressWarnings({"PMD.MethodArgumentCouldBeFinal", "PMD.AvoidLiteralsInIfCondition"})
                     @Override
                     public void onClose(io.grpc.Status status, Metadata trailers) {
-                        GrpcResponseAttachment.Builder responseAttachmentBuilder = null;
-
-                        if (parsedResponses.size() == 1) {
-                            responseAttachmentBuilder = GrpcResponseAttachment.Builder
-                                    .create("gRPC response")
-                                    .setBody(parsedResponses.iterator().next());
-                        } else if (parsedResponses.size() > 1) {
-                            responseAttachmentBuilder = GrpcResponseAttachment.Builder
-                                    .create("gRPC response (collection of elements from Server stream)")
-                                    .setBody("[" + String.join(",\n", parsedResponses) + "]");
-                        }
-                        if (!status.isOk()) {
-                            String description = status.getDescription();
-                            if (description == null) {
-                                description = "No description provided";
-                            }
-                            responseAttachmentBuilder = GrpcResponseAttachment.Builder
-                                    .create(status.getCode().name())
-                                    .setStatus(description);
-                        }
-
-                        requireNonNull(responseAttachmentBuilder).setStatus(status.toString());
-                        if (interceptResponseMetadata) {
-                            for (String key : headers.keys()) {
-                                requireNonNull(responseAttachmentBuilder).setMetadata(
-                                        key,
-                                        headers.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER))
-                                );
-                            }
-                        }
-                        processor.addAttachment(
-                                requireNonNull(responseAttachmentBuilder).build(),
-                                new FreemarkerAttachmentRenderer(responseTemplatePath)
-                        );
-
-                        if (status.isOk() || !markStepFailedOnNonZeroCode) {
-                            Allure.getLifecycle().updateStep(stepUuid, step -> step.setStatus(Status.PASSED));
-                        } else {
-                            Allure.getLifecycle().updateStep(stepUuid, step -> step.setStatus(Status.FAILED));
-                        }
-                        Allure.getLifecycle().stopStep(stepUuid);
-                        stepUuid = null;
+                        statusHolder.set(status);
+                        metadataHolder.set(trailers);
+                        shutdownAllureThread();
                         super.onClose(status, trailers);
                     }
 
@@ -187,25 +287,111 @@ public class AllureGrpc implements ClientInterceptor {
                     @Override
                     public void onMessage(A message) {
                         try {
-                            parsedResponses.add(JSON_PRINTER.print((MessageOrBuilder) message));
+                            parsedResponses.add(GRPC_TO_JSON_PRINTER.print((MessageOrBuilder) message));
                             super.onMessage(message);
                         } catch (InvalidProtocolBufferException e) {
                             LOGGER.warn("Can`t parse gRPC response", e);
-                        } catch (Throwable e) {
-                            Allure.getLifecycle().updateStep(step ->
-                                    step.setStatus(ResultsUtils.getStatus(e).orElse(Status.BROKEN))
-                                            .setStatusDetails(ResultsUtils.getStatusDetails(e).orElse(null))
-                            );
-                            Allure.getLifecycle().stopStep(stepUuid);
-                            stepUuid = null;
+                        } catch (Exception e) {
+                            exceptionHolder.set(e);
+                            shutdownAllureThread();
                         }
                     }
                 };
                 super.start(listener, headers);
             }
 
-            private String trimGrpcMethodName(final String source) {
+            private String stepBody(final Queue<String> messages) {
+                JSON_PRETTY_PRINTER.indentArraysWith(DefaultIndenter.SYSTEM_LINEFEED_INSTANCE);
+                try {
+                    return OBJECT_MAPPER.writer(JSON_PRETTY_PRINTER)
+                            .writeValueAsString(
+                                    OBJECT_MAPPER.readValue(
+                                            "[" + String.join(",", messages) + "]",
+                                            ArrayNode.class
+                                    )
+                            );
+                } catch (JsonProcessingException e) {
+                    LOGGER.warn("Can`t parse collected gRPC messages");
+                    return "";
+                }
+            }
+
+            private String grpcMethodName(final String source) {
                 return source.substring(source.lastIndexOf('/'));
+            }
+
+            private void shutdownAllureThread() {
+                interceptorLatch.countDown();
+                executor.shutdown();
+                try {
+                    if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                        executor.shutdownNow();
+                    }
+                } catch (InterruptedException ex) {
+                    executor.shutdownNow();
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            private String startStep(final AllureLifecycle lifecycle) {
+                final String stepUuid = UUID.randomUUID().toString();
+                lifecycle.startStep(stepUuid, (new StepResult()).setName(
+                        "Send " + method.getType().toString().toLowerCase() + " gRPC request to "
+                                + next.authority()
+                                + grpcMethodName(method.getFullMethodName())
+                ));
+                return stepUuid;
+            }
+
+            private void markStepBrokenByException(final AllureLifecycle lifecycle) {
+                final Throwable e = exceptionHolder.get();
+                lifecycle.updateStep(stepResult ->
+                        stepResult.setStatus(ResultsUtils.getStatus(e).orElse(Status.BROKEN))
+                                .setStatusDetails(
+                                        ResultsUtils.getStatusDetails(e).orElse(null)
+                                )
+                );
+            }
+
+            private <T, A> GrpcRequestAttachment.Builder requestAttachment(final MethodDescriptor<T, A> method) {
+                if (method.getType().clientSendsOneMessage()) {
+                    return GrpcRequestAttachment.Builder
+                            .create("gRPC request", method.getFullMethodName())
+                            .setBody(parsedRequests.element());
+                } else {
+                    return GrpcRequestAttachment.Builder
+                            .create(String.format(STREAMING_MESSAGE, "Client"), method.getFullMethodName())
+                            .setBody(stepBody(parsedRequests));
+                }
+            }
+
+            private <T, A> GrpcResponseAttachment.Builder responseAttachment(final MethodDescriptor<T, A> method,
+                                                                             final io.grpc.Status status,
+                                                                             final Metadata metadata) {
+                final GrpcResponseAttachment.Builder result;
+                if (!status.isOk()) {
+                    final String description = status.getDescription() == null
+                            ? "No description provided"
+                            : status.getDescription();
+                    result = GrpcResponseAttachment.Builder.create(status.getCode().name())
+                            .setStatus(status + " " + description);
+                } else {
+                    if (method.getType().serverSendsOneMessage()) {
+                        result = GrpcResponseAttachment.Builder.create("gRPC response")
+                                .setBody(parsedResponses.element())
+                                .setStatus(status.toString());
+                    } else {
+                        result = GrpcResponseAttachment.Builder.create(String.format(STREAMING_MESSAGE, "Server"))
+                                .setBody(stepBody(parsedResponses))
+                                .setStatus(status.toString());
+                    }
+                }
+                if (interceptResponseMetadata) {
+                    for (String key : metadata.keys()) {
+                        result.setMetadata(key, metadata.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER)));
+                    }
+                }
+                return result;
             }
         };
     }

--- a/allure-grpc/src/main/java/io/qameta/allure/grpc/GrpcRequestAttachment.java
+++ b/allure-grpc/src/main/java/io/qameta/allure/grpc/GrpcRequestAttachment.java
@@ -19,6 +19,9 @@ import io.qameta.allure.attachment.AttachmentData;
 
 import java.util.Objects;
 
+/**
+ * @author dtuchs (Dmitrii Tuchs).
+ */
 public class GrpcRequestAttachment implements AttachmentData {
 
     private final String name;

--- a/allure-grpc/src/main/java/io/qameta/allure/grpc/GrpcResponseAttachment.java
+++ b/allure-grpc/src/main/java/io/qameta/allure/grpc/GrpcResponseAttachment.java
@@ -21,6 +21,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * @author dtuchs (Dmitrii Tuchs).
+ */
 public class GrpcResponseAttachment implements AttachmentData {
 
     private final String name;

--- a/allure-grpc/src/test/proto/api.proto
+++ b/allure-grpc/src/test/proto/api.proto
@@ -6,6 +6,8 @@ option java_package = "io.qameta.allure.grpc";
 service TestService {
   rpc Calculate (Request) returns (Response);
   rpc CalculateServerStream (Request) returns (stream Response);
+  rpc CalculateClientStream (stream Request) returns (Response);
+  rpc CalculateBidirectionalStream (stream Request) returns (stream Response);
 }
 
 message Request {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,7 +56,7 @@ pluginManagement {
         id("io.qameta.allure-download") version "2.11.2"
         id("io.qameta.allure-report") version "2.11.2"
         id("io.spring.dependency-management") version "1.1.0"
-        id("com.google.protobuf") version "0.9.1"
+        id("com.google.protobuf") version "0.9.4"
         id("com.github.spotbugs") version "6.0.6"
         kotlin("jvm") version "1.7.10"
     }


### PR DESCRIPTION
### Context
In gRPC, client streaming and bidirectional streaming require to use a **non-blocking (async) Stubs**. These stubs uses different threads for handling `sendMessage(T message)` and `onClose(status, trailers)` events. Typically, it's not possible to create and commit a single Allure step within these methods, as `AllureThreadContext` internally uses `ThreadLocal`. However, it's possible to achieve this in a separate daemon thread.

Due to the asynchronous of non-blocking stubs, **we cannot guarantee that the Allure daemon thread committing the step will terminate immediately upon the completion of the non-blocking stub call**. Therefore, for such non-blocking calls, it will be necessary to execute `AllureGrpc.await()` method after each test.

This approach is explained in the README and javadocs. 

There is example report for bidirectional calls:
<img width="746" alt="Screenshot 2024-03-02 at 22 32 33" src="https://github.com/allure-framework/allure-java/assets/25635227/86f16064-ee37-4775-ba6c-663fedb981c8">


#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
