### PR TITLE
Inherited test methods don't support their annotations (fixes #1032)

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/util/AnnotationUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/AnnotationUtils.java
@@ -37,7 +37,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.qameta.allure.util.ReflectionUtils.getAllClassAnnotations;
+import static io.qameta.allure.util.ReflectionUtils.getAllAnnotations;
 import static io.qameta.allure.util.ResultsUtils.createLabel;
 import static io.qameta.allure.util.ResultsUtils.createLink;
 import static java.util.Arrays.asList;
@@ -117,7 +117,7 @@ public final class AnnotationUtils {
      * @return discovered labels.
      */
     public static Set<Label> getLabels(final AnnotatedElement annotatedElement) {
-        return getLabels(getAllClassAnnotations(annotatedElement));
+        return getLabels(getAllAnnotations(annotatedElement));
     }
 
     /**

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/AnnotationUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/AnnotationUtils.java
@@ -37,6 +37,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.qameta.allure.util.ReflectionUtils.getAllClassAnnotations;
 import static io.qameta.allure.util.ResultsUtils.createLabel;
 import static io.qameta.allure.util.ResultsUtils.createLink;
 import static java.util.Arrays.asList;
@@ -116,7 +117,7 @@ public final class AnnotationUtils {
      * @return discovered labels.
      */
     public static Set<Label> getLabels(final AnnotatedElement annotatedElement) {
-        return getLabels(annotatedElement.getAnnotations());
+        return getLabels(getAllClassAnnotations(annotatedElement));
     }
 
     /**

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ReflectionUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ReflectionUtils.java
@@ -44,6 +44,12 @@ public class ReflectionUtils {
         return methods;
     }
 
+    /**
+     * The function gives back all the annotations that users have declared in subclasses and interfaces.
+     *
+     * @param annotatedElement An introspecting element.
+     * @return All a user declared annotations.
+     */
     public static List<Annotation> getAllAnnotations(AnnotatedElement annotatedElement) {
         if (annotatedElement instanceof Class) {
             List<Annotation> annotations = new ArrayList<>();

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ReflectionUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ReflectionUtils.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright 2016-2024 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.util;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+public class ReflectionUtils {
+    /**
+     * The function gives back all the methods that users have declared in subclasses and interfaces.
+     *
+     * @param clazz An introspecting class.
+     * @return All a user declared methods.
+     */
+    public static List<Method> getAllDeclaredMethods(final Class<?> clazz) {
+        List<Method> methods = new ArrayList<>();
+
+        doRecursivelyWith(
+                clazz,
+                ReflectionUtils::extractMethods,
+                methods::add
+        );
+
+        return methods;
+    }
+
+    public static List<Annotation> getAllClassAnnotations(AnnotatedElement annotatedElement) {
+        if (annotatedElement instanceof Class) {
+            List<Annotation> annotations = new ArrayList<>();
+
+            doRecursivelyWith(
+                    (Class<?>) annotatedElement,
+                    ReflectionUtils::extractAnnotations,
+                    annotations::add
+            );
+
+            return annotations;
+        } else {
+            return Arrays.asList(annotatedElement.getAnnotations());
+        }
+    }
+
+    private static void extractMethods(Class<?> clazz, Consumer<Method> callback) {
+        Arrays.stream(clazz.getDeclaredMethods())
+                .forEach(callback);
+
+        // The default methods might have test declarations, them are needed to introspect.
+        Arrays.stream(clazz.getInterfaces())
+                .flatMap(ifc -> Stream.of(ifc.getMethods()))
+                .filter(Method::isDefault)
+                .forEach(callback);
+    }
+
+    private static void extractAnnotations(Class<?> clazz, Consumer<Annotation> callback) {
+        Arrays.stream(clazz.getAnnotations())
+                .forEach(callback);
+
+        Arrays.stream(clazz.getInterfaces())
+                .flatMap(ifc -> Stream.of(ifc.getAnnotations()))
+                .forEach(callback);
+    }
+
+    private static <T> void doRecursivelyWith(
+            final Class<?> clazz,
+            final BiConsumer<Class<?>, Consumer<T>> introspector,
+            final Consumer<T> resultCallback
+    ) {
+        if (clazz == Object.class) {
+            return;
+        }
+
+        introspector.accept(clazz, resultCallback);
+
+        if (clazz.getSuperclass() != null && clazz.getSuperclass() != Object.class) {
+            doRecursivelyWith(clazz.getSuperclass(), introspector, resultCallback);
+        } else if (clazz.isInterface()) {
+            for (Class<?> superIfc : clazz.getInterfaces()) {
+                doRecursivelyWith(superIfc, introspector, resultCallback);
+            }
+        }
+    }
+}

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ReflectionUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ReflectionUtils.java
@@ -44,7 +44,7 @@ public class ReflectionUtils {
         return methods;
     }
 
-    public static List<Annotation> getAllClassAnnotations(AnnotatedElement annotatedElement) {
+    public static List<Annotation> getAllAnnotations(AnnotatedElement annotatedElement) {
         if (annotatedElement instanceof Class) {
             List<Annotation> annotations = new ArrayList<>();
 

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ReflectionUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ReflectionUtils.java
@@ -50,7 +50,7 @@ public class ReflectionUtils {
      * @param annotatedElement An introspecting element.
      * @return All a user declared annotations.
      */
-    public static List<Annotation> getAllAnnotations(AnnotatedElement annotatedElement) {
+    public static List<Annotation> getAllAnnotations(final AnnotatedElement annotatedElement) {
         if (annotatedElement instanceof Class) {
             List<Annotation> annotations = new ArrayList<>();
 
@@ -66,7 +66,7 @@ public class ReflectionUtils {
         }
     }
 
-    private static void extractMethods(Class<?> clazz, Consumer<Method> callback) {
+    private static void extractMethods(final Class<?> clazz, final Consumer<Method> callback) {
         Arrays.stream(clazz.getDeclaredMethods())
                 .forEach(callback);
 
@@ -77,7 +77,7 @@ public class ReflectionUtils {
                 .forEach(callback);
     }
 
-    private static void extractAnnotations(Class<?> clazz, Consumer<Annotation> callback) {
+    private static void extractAnnotations(final Class<?> clazz, final Consumer<Annotation> callback) {
         Arrays.stream(clazz.getAnnotations())
                 .forEach(callback);
 

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ReflectionUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ReflectionUtils.java
@@ -25,7 +25,10 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-public class ReflectionUtils {
+public final class ReflectionUtils {
+    private ReflectionUtils() {
+    }
+
     /**
      * The function gives back all the methods that users have declared in subclasses and interfaces.
      *
@@ -33,7 +36,7 @@ public class ReflectionUtils {
      * @return All a user declared methods.
      */
     public static List<Method> getAllDeclaredMethods(final Class<?> clazz) {
-        List<Method> methods = new ArrayList<>();
+        final List<Method> methods = new ArrayList<>();
 
         doRecursivelyWith(
                 clazz,
@@ -52,7 +55,7 @@ public class ReflectionUtils {
      */
     public static List<Annotation> getAllAnnotations(final AnnotatedElement annotatedElement) {
         if (annotatedElement instanceof Class) {
-            List<Annotation> annotations = new ArrayList<>();
+            final List<Annotation> annotations = new ArrayList<>();
 
             doRecursivelyWith(
                     (Class<?>) annotatedElement,

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatformUtils.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatformUtils.java
@@ -86,12 +86,20 @@ import java.util.stream.Stream;
     public static Optional<Method> getTestMethod(final MethodSource source) {
         try {
             final Class<?> aClass = Class.forName(source.getClassName());
-            return Stream.of(aClass.getDeclaredMethods())
-                    .filter(method -> MethodSource.from(method).equals(source))
+
+            return Stream.of(aClass.getMethods())
+                    // The filter ignores the class name, as the methods are already defined in an inherited class.
+                    .filter(method -> equalsWithoutClassName(MethodSource.from(method), source))
                     .findAny();
         } catch (ClassNotFoundException e) {
             LOGGER.trace("Could not get test method from method source {}", source, e);
         }
         return Optional.empty();
+    }
+
+    private static boolean equalsWithoutClassName(MethodSource a, MethodSource b) {
+        return a.getMethodName().equals(b.getMethodName())
+                && a.getMethodParameterTypes().equals(b.getMethodParameterTypes());
+
     }
 }

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatformUtils.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatformUtils.java
@@ -24,7 +24,8 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.Optional;
-import java.util.stream.Stream;
+
+import static io.qameta.allure.util.ReflectionUtils.getAllDeclaredMethods;
 
 /**
  * @author charlie (Dmitry Baev).
@@ -87,7 +88,7 @@ import java.util.stream.Stream;
         try {
             final Class<?> aClass = Class.forName(source.getClassName());
 
-            return Stream.of(aClass.getMethods())
+            return getAllDeclaredMethods(aClass).stream()
                     // The filter ignores the class name, as the methods are already defined in an inherited class.
                     .filter(method -> equalsWithoutClassName(MethodSource.from(method), source))
                     .findAny();

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatformUtils.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatformUtils.java
@@ -98,7 +98,7 @@ import static io.qameta.allure.util.ReflectionUtils.getAllDeclaredMethods;
         return Optional.empty();
     }
 
-    private static boolean equalsWithoutClassName(MethodSource a, MethodSource b) {
+    private static boolean equalsWithoutClassName(final MethodSource a, final MethodSource b) {
         return a.getMethodName().equals(b.getMethodName())
                 && a.getMethodParameterTypes().equals(b.getMethodParameterTypes());
 

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -26,6 +26,7 @@ import io.qameta.allure.junitplatform.features.DisabledRepeatedTests;
 import io.qameta.allure.junitplatform.features.DisabledTests;
 import io.qameta.allure.junitplatform.features.DynamicTests;
 import io.qameta.allure.junitplatform.features.FailedTests;
+import io.qameta.allure.junitplatform.features.InheritedTests;
 import io.qameta.allure.junitplatform.features.JupiterUniqueIdTest;
 import io.qameta.allure.junitplatform.features.MarkerAnnotationSupport;
 import io.qameta.allure.junitplatform.features.NestedTests;
@@ -75,6 +76,7 @@ import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 
+import java.lang.annotation.Inherited;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
@@ -872,6 +874,44 @@ public class AllureJunitPlatformTest {
                 .extracting(TestResult::getHistoryId)
                 .isEqualTo(tr2.getHistoryId());
 
+    }
+
+    @Test
+    void shouldInheritedTestAnnotations() {
+        final AllureResults allureResults = runClasses(InheritedTests.class);
+
+        TestResult grandparentTest = allureResults.getTestResultByName("grandparentTest()");
+        assertThat(grandparentTest.getLabels())
+                .extracting(Label::getName, Label::getValue)
+                .contains(
+                        tuple("epic", InheritedTests.INHERITED_TEST_EPIC),
+                        tuple("feature", InheritedTests.INHERITED_TEST_FUTURE),
+                        tuple("story", InheritedTests.INHERITED_TEST_GRANDPARENT_STORY)
+                );
+        assertThat(grandparentTest.getDescription()).isEqualTo(InheritedTests.TEST_DESCRIPTION);
+        assertThat(grandparentTest.getLinks()).extracting(Link::getName).contains(InheritedTests.TEST_LINK);
+
+        TestResult parentTest = allureResults.getTestResultByName("parentTest()");
+        assertThat(parentTest.getLabels())
+                .extracting(Label::getName, Label::getValue)
+                .contains(
+                        tuple("epic", InheritedTests.INHERITED_TEST_EPIC),
+                        tuple("feature", InheritedTests.INHERITED_TEST_FUTURE),
+                        tuple("story", InheritedTests.INHERITED_TEST_PARENT_STORY)
+                );
+        assertThat(parentTest.getDescription()).isEqualTo(InheritedTests.TEST_DESCRIPTION);
+        assertThat(parentTest.getLinks()).extracting(Link::getName).contains(InheritedTests.TEST_LINK);
+
+        TestResult childTest = allureResults.getTestResultByName("childTest()");
+        assertThat(childTest.getLabels())
+                .extracting(Label::getName, Label::getValue)
+                .contains(
+                        tuple("epic", InheritedTests.INHERITED_TEST_EPIC),
+                        tuple("feature", InheritedTests.INHERITED_TEST_FUTURE),
+                        tuple("story", InheritedTests.INHERITED_TEST_CHILD_STORY)
+                );
+        assertThat(childTest.getDescription()).isEqualTo(InheritedTests.TEST_DESCRIPTION);
+        assertThat(childTest.getLinks()).extracting(Link::getName).contains(InheritedTests.TEST_LINK);
     }
 
     @Test

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -76,7 +76,6 @@ import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 
-import java.lang.annotation.Inherited;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/InheritedTests.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/InheritedTests.java
@@ -38,21 +38,21 @@ public class InheritedTests {
 
     @Epic(INHERITED_TEST_EPIC)
     @Feature(INHERITED_TEST_FUTURE)
-    public abstract static class GrandparentTest {
+    public interface GrandparentTest {
         @Test
         @Description(TEST_DESCRIPTION)
         @Story(INHERITED_TEST_GRANDPARENT_STORY)
         @Link(TEST_LINK)
-        public void grandparentTest() {
+        default void grandparentTest() {
         }
     }
 
-    public abstract static class ParentTest extends GrandparentTest {
+    public abstract static class ParentTest implements GrandparentTest {
         @Test
         @Description(TEST_DESCRIPTION)
         @Story(INHERITED_TEST_PARENT_STORY)
         @Link(TEST_LINK)
-        public void parentTest() {
+        void parentTest() {
         }
 
     }
@@ -63,7 +63,7 @@ public class InheritedTests {
         @Description(TEST_DESCRIPTION)
         @Story(INHERITED_TEST_CHILD_STORY)
         @Link(TEST_LINK)
-        public void childTest() {
+        void childTest() {
         }
     }
 }

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/InheritedTests.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/InheritedTests.java
@@ -1,0 +1,54 @@
+package io.qameta.allure.junitplatform.features;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Epic;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Link;
+import io.qameta.allure.Story;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class InheritedTests {
+    public static final String INHERITED_TEST_EPIC = "Inherited epic";
+    public static final String INHERITED_TEST_FUTURE = "Inherited future";
+    public static final String INHERITED_TEST_GRANDPARENT_STORY = "Inherited grandparent story";
+
+    public static final String INHERITED_TEST_PARENT_STORY = "Inherited parent story";
+
+    public static final String INHERITED_TEST_CHILD_STORY = "Inherited child story";
+
+    public static final String TEST_DESCRIPTION = "Test description";
+
+    public static final String TEST_LINK = "Test link";
+
+    @Epic(INHERITED_TEST_EPIC)
+    @Feature(INHERITED_TEST_FUTURE)
+    public abstract static class GrandparentTest {
+        @Test
+        @Description(TEST_DESCRIPTION)
+        @Story(INHERITED_TEST_GRANDPARENT_STORY)
+        @Link(TEST_LINK)
+        public void grandparentTest() {
+        }
+    }
+
+    public abstract static class ParentTest extends GrandparentTest {
+        @Test
+        @Description(TEST_DESCRIPTION)
+        @Story(INHERITED_TEST_PARENT_STORY)
+        @Link(TEST_LINK)
+        public void parentTest() {
+        }
+
+    }
+
+    @Nested
+    class ChildTest extends ParentTest {
+        @Test
+        @Description(TEST_DESCRIPTION)
+        @Story(INHERITED_TEST_CHILD_STORY)
+        @Link(TEST_LINK)
+        public void childTest() {
+        }
+    }
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/InheritedTests.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/InheritedTests.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2016-2024 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package io.qameta.allure.junitplatform.features;
 
 import io.qameta.allure.Description;


### PR DESCRIPTION
fixes #1032 

### Context
The `getTestMethod` method in the `io.qameta.allure.junitplatform.AllureJunitPlatformUtils` class doesn't function as expected for tests that are inherited. This is because it uses `aClass.getDeclaredMethods()`, which only operates on the current instance and does not include methods that are inherited. This can cause issues with annotations related to methods, such as descriptions and others.

### Revision 1
In this revision, I used the `aClass.getMethods()` that returns all public methods on a checking class.

### Revision 2
However, revision 1 covers one of the test cases when all test methods are public. It doesn't work when:
1. Methods have package-based visibility that is usually for unit tests.
```
   public abstract static class ParentTest implements GrandparentTest {
        @Test
        @Description(TEST_DESCRIPTION)
        @Story(INHERITED_TEST_PARENT_STORY)
        @Link(TEST_LINK)
        void parentTest() {}
    }
 ```
2. Methods are members of the interface (as default methods).
```
 public interface GrandparentTest {
        @Test
        @Description(TEST_DESCRIPTION)
        @Story(INHERITED_TEST_GRANDPARENT_STORY)
        @Link(TEST_LINK)
        default void grandparentTest() {}
    }
```
3. Parent class has an upper-class annotation that must be applied to all inheritors.
```
 @Epic(INHERITED_TEST_EPIC)
    @Feature(INHERITED_TEST_FUTURE)
    public interface GrandparentTest { }
```

In short, I have to implement two methods placed into `ReflectionUtils` to recursively collect method and annotation information. These methods are designed as simplified logic of `org.springframework.data.util.ReflectionUtils` specifically for our needs.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
