### PR TITLE
Bump up jackson-bom to 2.17.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,7 +144,7 @@ configure(libs) {
 
     dependencyManagement {
         imports {
-            mavenBom("com.fasterxml.jackson:jackson-bom:2.14.1")
+            mavenBom("com.fasterxml.jackson:jackson-bom:2.17.0")
             mavenBom("org.junit:junit-bom:5.9.2")
         }
         dependencies {


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->
Related to: https://github.com/allure-framework/allure-java/issues/1037

Current jackson version embedded (2.14.1) in allure-java-commons has several vulnerabilities:
* https://github.com/FasterXML/jackson-core/pull/827 (high)
* https://nvd.nist.gov/vuln/detail/CVE-2023-35116 (medium)

Bump it up to the latest version 2.17.0

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
