### PR TITLE
Build with Java 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,22 +14,18 @@ jobs:
   build:
     name: "Build"
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        java-version: [ '17.0.x' ]
     steps:
       - uses: actions/checkout@v4.1.1
 
-      - name: Set up JDK ${{ matrix.java-version }}
+      - name: "Set up JDK"
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: ${{ matrix.java-version }}
+          java-version: 21
 
-      - name: Build with Gradle
+      - name: "Build with Gradle"
         run: ./gradlew build -x test --scan
 
-      - name: Run tests
+      - name: "Run tests"
         if: always()
         run: ./gradlew --no-build-cache cleanTest test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
 
-      - name: "Set up JDK 17.0.x"
+      - name: "Set up JDK"
         uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '17.0.x'
+          java-version: '21'
 
       - name: Set up GPG
         run: echo -n "${GPG_PRIVATE_KEY}" | base64 --decode > ${GITHUB_WORKSPACE}/${GPG_KEY_ID}.gpg

--- a/allure-scalatest/build.gradle.kts
+++ b/allure-scalatest/build.gradle.kts
@@ -4,17 +4,15 @@ description = "Allure ScalaTest Integration"
 
 apply(plugin = "scala")
 
-val availableScalaVersions = listOf("2.11", "2.12", "2.13")
-val defaultScala211Version = "2.11.12"
-val defaultScala212Version = "2.12.8"
-val defaultScala213Version = "2.13.1"
+val availableScalaVersions = listOf("2.12", "2.13")
+val defaultScala212Version = "2.12.19"
+val defaultScala213Version = "2.13.14"
 
 var selectedScalaVersion = defaultScala213Version
 
 if (hasProperty("scalaVersion")) {
     val scalaVersion: String by project
     selectedScalaVersion = when (scalaVersion) {
-        "2.11" -> defaultScala211Version
         "2.12" -> defaultScala212Version
         "2.13" -> defaultScala213Version
         else -> scalaVersion
@@ -80,8 +78,8 @@ val installAll by tasks.creating {
 
 dependencies {
     api(project(":allure-java-commons"))
-    implementation("org.scalatest:scalatest_$baseScalaVersion:3.1.1")
-    implementation("org.scala-lang.modules:scala-collection-compat_$baseScalaVersion:2.1.4")
+    implementation("org.scalatest:scalatest_$baseScalaVersion:3.2.19")
+    implementation("org.scala-lang.modules:scala-collection-compat_$baseScalaVersion:2.12.0")
     testAnnotationProcessor(project(":allure-descriptions-javadoc"))
     testImplementation("io.github.glytching:junit-extensions")
     testImplementation("org.assertj:assertj-core")

--- a/allure-spock/build.gradle.kts
+++ b/allure-spock/build.gradle.kts
@@ -3,7 +3,7 @@ description = "Allure Spock Framework Integration"
 apply(plugin = "groovy")
 
 val spockFrameworkVersion = "1.3-groovy-2.5"
-val groovyVersion = "2.5.19"
+val groovyVersion = "2.5.23"
 
 dependencies {
     api(project(":allure-java-commons"))

--- a/allure-spock2/build.gradle.kts
+++ b/allure-spock2/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 val spockFrameworkVersion = "2.3-groovy-3.0"
-val groovyVersion = "3.0.13"
+val groovyVersion = "3.0.22"
 
 dependencies {
     api(project(":allure-java-commons"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -63,16 +63,17 @@ pluginManagement {
 }
 
 plugins {
-    id("com.gradle.enterprise")
+    id("com.gradle.develocity") version "3.17.5" apply false
 }
 
 val isCiServer = System.getenv().containsKey("CI")
 
 if (isCiServer) {
-    gradleEnterprise {
+    apply(plugin = "com.gradle.develocity")
+    develocity {
         buildScan {
-            termsOfServiceUrl = "https://gradle.com/terms-of-service"
-            termsOfServiceAgree = "yes"
+            termsOfUseUrl = "https://gradle.com/terms-of-service"
+            termsOfUseAgree = "yes"
             tag("CI")
         }
     }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Some of the dependencies already uses Multi-Version Java classes, e.g.
Jackson has Java 21 classes starting from version 16.1.

This change bumps the build JDK version to 21, keeping the same runtime
requirement of Java 8.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2