### PR TITLE
Crosscompile allure-scalatest to scala 2.12 & 2.13

### DIFF
--- a/gradle/quality-configs/spotbugs/exclude.xml
+++ b/gradle/quality-configs/spotbugs/exclude.xml
@@ -6,6 +6,9 @@
     <Match>
         <Source name="~.*\.groovy"/>
     </Match>
+    <Match>
+        <Source name="~.*\.scala"/>
+    </Match>
 
     <!-- Disable check -->
     <Match>


### PR DESCRIPTION
fixes #1104 

### Todo list
- [x] compile 2.12
- [x] compile 2.13
- [x] publish with 2.12 suffix
- [x] publish with 2.13 suffix
- [ ] publish 2.12 sources & javadoc
- [x] publish 2.13 sources & javadoc
- [ ] disable publishing jar without suffix

### Context
https://mvnrepository.com/artifact/io.qameta.allure/allure-scalatest
missing _2.12 and _2.13 suffixes

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests - not applicable

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
