### PR TITLE
Provided ability to handle package annotations (labels, links etc.)

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/Epic.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Epic.java
@@ -31,7 +31,7 @@ import static io.qameta.allure.util.ResultsUtils.EPIC_LABEL_NAME;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 @Repeatable(Epics.class)
 @LabelAnnotation(name = EPIC_LABEL_NAME)
 public @interface Epic {

--- a/allure-java-commons/src/main/java/io/qameta/allure/Epics.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Epics.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 public @interface Epics {
 
     Epic[] value();

--- a/allure-java-commons/src/main/java/io/qameta/allure/Feature.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Feature.java
@@ -31,7 +31,7 @@ import static io.qameta.allure.util.ResultsUtils.FEATURE_LABEL_NAME;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 @Repeatable(Features.class)
 @LabelAnnotation(name = FEATURE_LABEL_NAME)
 public @interface Feature {

--- a/allure-java-commons/src/main/java/io/qameta/allure/Features.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Features.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 public @interface Features {
 
     Feature[] value();

--- a/allure-java-commons/src/main/java/io/qameta/allure/Flaky.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Flaky.java
@@ -28,6 +28,6 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 public @interface Flaky {
 }

--- a/allure-java-commons/src/main/java/io/qameta/allure/Issue.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Issue.java
@@ -31,7 +31,7 @@ import static io.qameta.allure.util.ResultsUtils.ISSUE_LINK_TYPE;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 @LinkAnnotation(type = ISSUE_LINK_TYPE)
 @Repeatable(Issues.class)
 public @interface Issue {

--- a/allure-java-commons/src/main/java/io/qameta/allure/Issues.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Issues.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 public @interface Issues {
 
     Issue[] value();

--- a/allure-java-commons/src/main/java/io/qameta/allure/Link.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Link.java
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 @LinkAnnotation
 @Repeatable(Links.class)
 public @interface Link {

--- a/allure-java-commons/src/main/java/io/qameta/allure/Links.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Links.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 public @interface Links {
 
     Link[] value();

--- a/allure-java-commons/src/main/java/io/qameta/allure/Muted.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Muted.java
@@ -28,6 +28,6 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 public @interface Muted {
 }

--- a/allure-java-commons/src/main/java/io/qameta/allure/Owner.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Owner.java
@@ -33,7 +33,7 @@ import static io.qameta.allure.util.ResultsUtils.OWNER_LABEL_NAME;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 @LabelAnnotation(name = OWNER_LABEL_NAME)
 public @interface Owner {
 

--- a/allure-java-commons/src/main/java/io/qameta/allure/Severity.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Severity.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 public @interface Severity {
 
     SeverityLevel value();

--- a/allure-java-commons/src/main/java/io/qameta/allure/Stories.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Stories.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 public @interface Stories {
 
     Story[] value();

--- a/allure-java-commons/src/main/java/io/qameta/allure/Story.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Story.java
@@ -31,7 +31,7 @@ import static io.qameta.allure.util.ResultsUtils.STORY_LABEL_NAME;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 @Repeatable(Stories.class)
 @LabelAnnotation(name = STORY_LABEL_NAME)
 public @interface Story {

--- a/allure-java-commons/src/main/java/io/qameta/allure/TmsLink.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/TmsLink.java
@@ -31,7 +31,7 @@ import static io.qameta.allure.util.ResultsUtils.TMS_LINK_TYPE;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 @LinkAnnotation(type = TMS_LINK_TYPE)
 @Repeatable(TmsLinks.class)
 public @interface TmsLink {

--- a/allure-java-commons/src/main/java/io/qameta/allure/TmsLinks.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/TmsLinks.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE, ElementType.PACKAGE})
 public @interface TmsLinks {
 
     TmsLink[] value();

--- a/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/MutedAndFlakyTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/MutedAndFlakyTest.java
@@ -1,0 +1,15 @@
+package io.qameta.allure.annotatedpack;
+
+import io.qameta.allure.Flaky;
+import io.qameta.allure.Muted;
+
+@Muted
+@Flaky
+public class MutedAndFlakyTest {
+
+    @Muted
+    @Flaky
+    public void mutedAndFlakyMethod() {
+
+    }
+}

--- a/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/NotMutedAndFlakyTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/NotMutedAndFlakyTest.java
@@ -1,0 +1,8 @@
+package io.qameta.allure.annotatedpack;
+
+public class NotMutedAndFlakyTest {
+
+    public void notMutedAndFlakyMethod() {
+
+    }
+}

--- a/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/muted/and/flaky/MutedAndFlakyByPackageTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/muted/and/flaky/MutedAndFlakyByPackageTest.java
@@ -1,0 +1,8 @@
+package io.qameta.allure.annotatedpack.muted.and.flaky;
+
+public class MutedAndFlakyByPackageTest {
+
+    public void notMutedAndFlakyMethod() {
+
+    }
+}

--- a/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/muted/and/flaky/package-info.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/muted/and/flaky/package-info.java
@@ -1,0 +1,6 @@
+@Muted
+@Flaky
+package io.qameta.allure.annotatedpack.muted.and.flaky;
+
+import io.qameta.allure.Flaky;
+import io.qameta.allure.Muted;

--- a/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/package-info.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/package-info.java
@@ -1,0 +1,6 @@
+@Epic("High level epic")
+@Link("General link")
+package io.qameta.allure.annotatedpack;
+
+import io.qameta.allure.Epic;
+import io.qameta.allure.Link;

--- a/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/subpack/innerpack/SomeTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/subpack/innerpack/SomeTest.java
@@ -1,0 +1,7 @@
+package io.qameta.allure.annotatedpack.subpack.innerpack;
+
+import io.qameta.allure.Story;
+
+@Story("Marked pack story")
+public class SomeTest {
+}

--- a/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/subpack/package-info.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/annotatedpack/subpack/package-info.java
@@ -1,0 +1,6 @@
+@Feature("Some general feature")
+@Link("Some second level link")
+package io.qameta.allure.annotatedpack.subpack;
+
+import io.qameta.allure.Feature;
+import io.qameta.allure.Link;


### PR DESCRIPTION
Changes:
- provided ability to handle package annotations
- add package target to Epic(s), Feature(s), Flaky, Issue(s), Link(s), Muted, Owner, Severity, Story(es), TmsLink(s)

[The article about package level annotations and package-info files](https://www.baeldung.com/java-package-info)

### Context
Sometimes it has to do a lot of work
- mark many classes or methods with annotations
- check the relevance of the labels in the code in case of changes

I don't think that the creating a base class with necessary labels for further extending by tests classes is a good solution (personally, I think it's an anti-pattern). It's much easier to mark packages and put tests there and to add additional marks (to classes and methods) only if it is necessary
