### PR TITLE
Fix for #893 - param annotation name not coming up in report

### DIFF
--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/ParameterizedTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/ParameterizedTest.java
@@ -15,10 +15,12 @@
  */
 package io.qameta.allure.testng.samples;
 
-import io.qameta.allure.Step;
+import io.qameta.allure.Param;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import static io.qameta.allure.Allure.step;
 
 /**
  * @author Egor Borisov ehborisov@gmail.com
@@ -38,13 +40,36 @@ public class ParameterizedTest {
         };
     }
 
+    @DataProvider
+    public static Object[][] testDataForParamNames() {
+        return new Object[][]{
+            {1, 1, 2, 5},
+            {2, 2, 4, 5}
+        };
+    }
+
     @Test(dataProvider = "testData")
     public void parameterizedTest(String param) {
         step(param);
     }
 
-    @Step
-    public void step(String param) {
+    @Test(dataProvider = "testDataForParamNames")
+    public void sumTest(
+        @Param(name = "First") Integer a,
+        @Param(name = "Second") Integer b,
+        @Param(name = "Third") Integer r,
+        @Param(name = "Fourth") Integer s) {
+
+        step(("Arrange"), () -> {
+            step(String.format("Take collection №[%s] of parameters", a));
+        });
+        step(("Act"), () -> {
+            step(String.format("Add [%s]", a) + String.format("to [%s]", b));
+        });
+        step(("Assert"), () -> {
+            step("Compare the sum");
+            assert a + b == r;
+        });
 
     }
 }

--- a/allure-testng/src/test/resources/suites/parameterized-test.xml
+++ b/allure-testng/src/test/resources/suites/parameterized-test.xml
@@ -2,10 +2,12 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <suite name="Test suite 6">
+    <listeners>
+        <listener class-name="io.qameta.allure.testng.AllureTestNg"/>
+    </listeners>
     <test name="Test tag 6">
         <classes>
-            <class name="io.qameta.allure.testng.samples.ParameterizedTest">
-            </class>
+            <class name="io.qameta.allure.testng.samples.ParameterizedTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
fixes #893 

### Context
This pull request concerns the [issue](https://github.com/allure-framework/allure-java/issues/893) where the user saw arbitrary data-provider parameter names if he/she used `@Param` with explicit `name` values. 

**Before the fix:**
![Screenshot 2024-09-22 at 12 23 06 PM](https://github.com/user-attachments/assets/2efde250-444d-4459-9efc-8850040e45bd)

**After the fix:**
![Screenshot 2024-09-22 at 12 17 43 PM](https://github.com/user-attachments/assets/150b9635-af3f-421f-96ed-d34731bd5655)

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
