### PR TITLE
Fix for #893 - param annotation name not coming up in report

### DIFF
--- a/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
@@ -1198,6 +1198,22 @@ public class AllureTestNgTest {
                 );
     }
 
+    @SuppressWarnings("unchecked")
+    @AllureFeatures.Parameters
+    @Issue("893")
+    @Test
+    public void shouldDisplayCustomNamesOfParameters() {
+        final AllureResults results = runTestNgSuites("suites/gh-893.xml");
+        assertThat(results.getTestResults())
+            .flatExtracting(TestResult::getParameters)
+            .extracting(Parameter::getName, Parameter::getValue)
+            .containsExactlyInAnyOrder(
+                tuple("First", "1"),
+                tuple("Second", "1"),
+                tuple("Third", "2"),
+                tuple("Fourth", "5"));
+    }
+
     @DataProvider(name = "failedFixtures")
     public Object[][] failedFixtures() {
         return new Object[][]{

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/CustomParameterNamesTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/CustomParameterNamesTest.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2016-2024 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import io.qameta.allure.Param;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static io.qameta.allure.Allure.step;
+
+/**
+ * @author Sambhav Dave sambhavd4@gmail.com
+ */
+public class CustomParameterNamesTest {
+
+    @DataProvider
+    public static Object[][] testDataForParamNames() {
+        return new Object[][]{
+            {1, 1, 2, 5}
+        };
+    }
+
+    @Test(dataProvider = "testDataForParamNames")
+    public void sumTest(
+        @Param(name = "First") Integer a,
+        @Param(name = "Second") Integer b,
+        @Param(name = "Third") Integer expectedSum,
+        @Param(name = "Fourth") Integer unusedParam) {
+
+        step("Arrange", () -> step(String.format("Use parameters: First = [%s], Second = [%s], Third = [%s], Fourth = [%s]",
+            a, b, expectedSum, unusedParam)));
+
+        Integer result = step("Act", () -> {
+            step(String.format("Add First [%s] and Second [%s]", a, b));
+            return a + b;
+        });
+
+        step("Assert", () -> {
+            step(String.format("Compare result [%s] with expected [%s]", result, expectedSum));
+            assert result.equals(expectedSum) : "Sum does not match the expected value";
+        });
+    }
+
+}

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/ParameterizedTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/ParameterizedTest.java
@@ -15,10 +15,11 @@
  */
 package io.qameta.allure.testng.samples;
 
-import io.qameta.allure.Step;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import static io.qameta.allure.Allure.step;
 
 /**
  * @author Egor Borisov ehborisov@gmail.com
@@ -41,10 +42,5 @@ public class ParameterizedTest {
     @Test(dataProvider = "testData")
     public void parameterizedTest(String param) {
         step(param);
-    }
-
-    @Step
-    public void step(String param) {
-
     }
 }

--- a/allure-testng/src/test/resources/suites/gh-893.xml
+++ b/allure-testng/src/test/resources/suites/gh-893.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
-<suite name="Test suite 6">
-    <test name="Test tag 6">
+<suite name="Github Issues">
+    <test name="gh-893">
         <classes>
-            <class name="io.qameta.allure.testng.samples.ParameterizedTest"/>
+            <class name="io.qameta.allure.testng.samples.CustomParameterNamesTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
Fixes #893

### Context
**Before fix:**
![before-fix](https://github.com/user-attachments/assets/b7a31c8f-0002-465d-a8e3-45c92e88bae6)

**After fix:**
![after-fix](https://github.com/user-attachments/assets/b32eb461-d324-4fdb-92f0-1f74ae80ef97)


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
