### PR TITLE
limited prettifying length to 1mb

### DIFF
--- a/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
+++ b/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
@@ -51,11 +51,9 @@ public class AllureRestAssured implements OrderedFilter {
     private String requestAttachmentName = "Request";
     private String responseAttachmentName;
 
-    public AllureRestAssured() {
-    }
-
-    public AllureRestAssured(int maxAllowedPrettifyLength) {
+    public AllureRestAssured setMaxAllowedPrettifyLength(final int maxAllowedPrettifyLength) {
         this.maxAllowedPrettifyLength = maxAllowedPrettifyLength;
+        return this;
     }
 
     public AllureRestAssured setRequestTemplate(final String templatePath) {

--- a/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
+++ b/allure-rest-assured/src/main/java/io/qameta/allure/restassured/AllureRestAssured.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static io.qameta.allure.attachment.http.HttpRequestAttachment.Builder.create;
-import static io.qameta.allure.attachment.http.HttpResponseAttachment.Builder.create;
 import static java.util.Optional.ofNullable;
 
 /**
@@ -45,10 +44,19 @@ public class AllureRestAssured implements OrderedFilter {
 
     private static final String HIDDEN_PLACEHOLDER = "[ BLACKLISTED ]";
 
+    private int maxAllowedPrettifyLength = 1048576;
+
     private String requestTemplatePath = "http-request.ftl";
     private String responseTemplatePath = "http-response.ftl";
     private String requestAttachmentName = "Request";
     private String responseAttachmentName;
+
+    public AllureRestAssured() {
+    }
+
+    public AllureRestAssured(int maxAllowedPrettifyLength) {
+        this.maxAllowedPrettifyLength = maxAllowedPrettifyLength;
+    }
 
     public AllureRestAssured setRequestTemplate(final String templatePath) {
         this.requestTemplatePath = templatePath;
@@ -123,10 +131,13 @@ public class AllureRestAssured implements OrderedFilter {
         final String attachmentName = ofNullable(responseAttachmentName)
                 .orElse(response.getStatusLine());
 
-        final HttpResponseAttachment responseAttachment = create(attachmentName)
+        final String responseAsString = response.getBody().asString();
+        final String body = responseAsString.length() > maxAllowedPrettifyLength ? responseAsString : prettifier.getPrettifiedBodyIfPossible(response, response.getBody());
+
+        final HttpResponseAttachment responseAttachment = HttpResponseAttachment.Builder.create(attachmentName)
                 .setResponseCode(response.getStatusCode())
                 .setHeaders(toMapConverter(response.getHeaders(), hiddenHeaders))
-                .setBody(prettifier.getPrettifiedBodyIfPossible(response, response.getBody()))
+                .setBody(body)
                 .build();
 
         new DefaultAttachmentProcessor().addAttachment(


### PR DESCRIPTION
Limited prettifying length to 1mb.

Otherwise on long responses there is a memory leak in prettify method in groovy library
