### PR TITLE
Fix Steps bubbling in assertj aspect (fixes #1064)

### DIFF
--- a/allure-assertj/src/test/java/io/qameta/allure/assertj/AllureAspectJTest.java
+++ b/allure-assertj/src/test/java/io/qameta/allure/assertj/AllureAspectJTest.java
@@ -24,9 +24,13 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import static io.qameta.allure.test.RunUtils.runWithinTestContext;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatList;
+import static org.assertj.core.api.MapAssert.assertThatMap;
 
 /**
  * @author charlie (Dmitry Baev).
@@ -120,5 +124,28 @@ class AllureAspectJTest {
                 .flatExtracting(TestResult::getSteps)
                 .extracting(StepResult::getName)
                 .contains("as 'Test description []'", "isEqualTo '26'");
+    }
+
+    @Test
+    void preventListAssertionsBubblingTest() {
+        final AllureResults results = runWithinTestContext(
+                () -> assertThatList(List.of("value1")).isEqualTo(List.of("value1", "value2")),
+                AllureAspectJ::setLifecycle);
+
+        assertThat(results.getTestResults()).isNotEmpty();
+        assertThat(results.getTestResults().get(0).getSteps()).hasSize(2);
+        assertThat(results.getTestResults().get(0).getSteps().get(1).getSteps()).isEmpty();
+    }
+
+    @Test
+    void preventMapAssertionsBubblingTest() {
+        final AllureResults results = runWithinTestContext(
+                () -> assertThatMap(Map.of("key1", "value1"))
+                        .isEqualTo(Map.of("key1", "value1", "key2", "value2")),
+                AllureAspectJ::setLifecycle);
+
+        assertThat(results.getTestResults()).isNotEmpty();
+        assertThat(results.getTestResults().get(0).getSteps()).hasSize(2);
+        assertThat(results.getTestResults().get(0).getSteps().get(1).getSteps()).isEmpty();
     }
 }

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
@@ -300,6 +300,19 @@ public class AllureLifecycle {
     }
 
     /**
+     * Return optional current step result object.
+     *
+     * @return the optional wrapper of the current StepResult object.
+     */
+    public Optional<StepResult> getCurrentStepResult() {
+        final Optional<String> currentUuid = threadContext.getCurrent();
+        if (!currentUuid.isPresent()) {
+            return Optional.empty();
+        }
+        return storage.getStep(currentUuid.get());
+    }
+
+    /**
      * Sets specified test case uuid as current. Note that
      * test case with such uuid should be created and existed in storage, otherwise
      * method take no effect.

--- a/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
@@ -15,11 +15,8 @@
  */
 package io.qameta.allure;
 
+import io.qameta.allure.model.*;
 import io.qameta.allure.model.Attachment;
-import io.qameta.allure.model.FixtureResult;
-import io.qameta.allure.model.StepResult;
-import io.qameta.allure.model.TestResult;
-import io.qameta.allure.model.TestResultContainer;
 import io.qameta.allure.test.AllureResults;
 import io.qameta.allure.test.RunUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,12 +27,7 @@ import org.mockito.Mockito;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -43,10 +35,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static io.qameta.allure.Allure.addStreamAttachmentAsync;
+import static io.qameta.allure.test.RunUtils.runWithinTestContext;
 import static io.qameta.allure.test.TestData.randomId;
 import static io.qameta.allure.test.TestData.randomName;
 import static io.qameta.allure.test.TestData.randomString;
@@ -487,5 +481,23 @@ class AllureLifecycleTest {
             }
             return null;
         }
+    }
+
+    @Test
+    void getCurrentStepResultTest() {
+        final AtomicReference<AllureLifecycle> lifecycle = new AtomicReference<>();
+        runWithinTestContext(() -> {
+            assertThat(lifecycle.get().getCurrentStepResult()).isEmpty();
+
+            final StepResult testStepResult = new StepResult();
+            testStepResult.setName("test step");
+            testStepResult.setStatus(Status.PASSED);
+
+            lifecycle.get().startStep(UUID.randomUUID().toString(), testStepResult);
+            assertThat(lifecycle.get().getCurrentStepResult()).isPresent().isEqualTo(testStepResult);
+
+            lifecycle.get().stopStep();
+            assertThat(lifecycle.get().getCurrentStepResult()).isEmpty();
+        }, lifecycle::set);
     }
 }


### PR DESCRIPTION
### Context
Fix Steps bubbling in assertj aspect (fixes #1064).

I'm not sure if the problem can be fixed for all scenarios via a PointCut expression, so I suggest adding an explicit condition in the code to track the creation of duplicate steps. 

This functionality requires access to the last step created, and such functionality unfortunately does not exist, so I also suggest introducing a new method in AllureLifeCycle to get the last StepResult.


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
