### PR TITLE
bump spring-web to 6.2.6 and fix compatibility with new api

### DIFF
--- a/allure-spring-web/build.gradle.kts
+++ b/allure-spring-web/build.gradle.kts
@@ -1,6 +1,6 @@
 description = "Allure Spring Web Integration"
 
-val springWebVersion = "5.3.37"
+val springWebVersion = "6.2.6"
 
 dependencies {
     api(project(":allure-attachments"))
@@ -28,4 +28,8 @@ tasks.jar {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+tasks.compileJava {
+    options.release.set(17)
 }

--- a/allure-spring-web/src/main/java/io/qameta/allure/springweb/AllureRestTemplate.java
+++ b/allure-spring-web/src/main/java/io/qameta/allure/springweb/AllureRestTemplate.java
@@ -81,7 +81,7 @@ public class AllureRestTemplate implements ClientHttpRequestInterceptor {
 
         final HttpRequestAttachment.Builder requestAttachmentBuilder = HttpRequestAttachment.Builder
                 .create("Request", request.getURI().toString())
-                .setMethod(request.getMethodValue())
+                .setMethod(request.getMethod().name())
                 .setHeaders(toMapConverter(request.getHeaders()));
         if (body.length != 0) {
             requestAttachmentBuilder.setBody(new String(body, StandardCharsets.UTF_8));
@@ -94,7 +94,7 @@ public class AllureRestTemplate implements ClientHttpRequestInterceptor {
 
         final HttpResponseAttachment responseAttachment = HttpResponseAttachment.Builder
                 .create("Response")
-                .setResponseCode(clientHttpResponse.getRawStatusCode())
+                .setResponseCode(clientHttpResponse.getStatusCode().value())
                 .setHeaders(toMapConverter(clientHttpResponse.getHeaders()))
                 .setBody(StreamUtils.copyToString(clientHttpResponse.getBody(), StandardCharsets.UTF_8))
                 .build();


### PR DESCRIPTION
### Context
* bump spring-web to 6.2.6
* fix compatibility with new api

Spring-web changes:
1. spring-web 6+ have java 17 baseline
2. removed method `org.springframework.http.HttpRequest.getMethodValue()`
3. deprecated method `org.springframework.http.client.ClientHttpResponse.getRawStatusCode()`

Breaking changes:
1. allure-spring-web compile java version set to 17, was 8

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
