### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/allure-framework/allure-java/security/code-scanning/6](https://github.com/allure-framework/allure-java/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the steps in the workflow, it appears that the workflow only needs read access to the repository contents. Therefore, we will set `contents: read` in the `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
