### PR TITLE
feat(allure-model): add optional size field to Attachment class

### DIFF
--- a/allure-model/src/main/java/io/qameta/allure/model/Attachment.java
+++ b/allure-model/src/main/java/io/qameta/allure/model/Attachment.java
@@ -32,6 +32,7 @@ public class Attachment implements Serializable {
     private String name;
     private String source;
     private String type;
+    private Long size;
 
     /**
      * Gets name.
@@ -90,6 +91,26 @@ public class Attachment implements Serializable {
      */
     public Attachment setType(final String value) {
         this.type = value;
+        return this;
+    }
+
+    /**
+     * Gets size.
+     *
+     * @return the size
+     */
+    public Long getSize() {
+        return size;
+    }
+
+    /**
+     * Sets size.
+     *
+     * @param value the value
+     * @return self for method chaining
+     */
+    public Attachment setSize(final Long value) {
+        this.size = value;
         return this;
     }
 


### PR DESCRIPTION
## Description

This PR adds an optional `size` field to the `io.qameta.allure.model.Attachment` class to support 'no-fetch' flows for attachments.

## Context

This change aligns with ongoing efforts to add optional size support across Allure implementations. See related PR in allure-js: https://github.com/allure-framework/allure-js/pull/1302

## Changes

- Added optional `Long size` field to `Attachment` class
- Added `getSize()` and `setSize()` methods following existing patterns
- Field is nullable to maintain backward compatibility

## Benefits

- Enables efficient attachment handling when size is already known from JSON
- Eliminates need for reflection-based workarounds
- Maintains backward compatibility with existing code
- Follows Allure's established patterns and conventions
- Supports remote attachment workflows without HTTP roundtrips

## Testing

- [ ] Verify backward compatibility with existing attachment usage
- [ ] Test with attachment JSON files that contain size information
- [ ] Ensure no-fetch flows work correctly with pre-calculated sizes

## Related Issues

Fixes the need for `AttachmentMixIn` workarounds and reflection-based size access. 