### PR TITLE
feat(allure-model): add optional attachment size

### DIFF
--- a/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
@@ -344,6 +344,10 @@ class AllureLifecycleTest {
                         tuple(attachment2Name, "text/plain")
                 );
 
+        assertThat(attachments)
+                .extracting(io.qameta.allure.model.Attachment::getSize)
+                .containsOnlyNulls();
+
         final String[] sources = attachments.stream()
                 .map(io.qameta.allure.model.Attachment::getSource)
                 .toArray(String[]::new);

--- a/allure-model/src/main/java/io/qameta/allure/model/Attachment.java
+++ b/allure-model/src/main/java/io/qameta/allure/model/Attachment.java
@@ -32,6 +32,7 @@ public class Attachment implements Serializable {
     private String name;
     private String source;
     private String type;
+    private Long size;
 
     /**
      * Gets name.
@@ -90,6 +91,26 @@ public class Attachment implements Serializable {
      */
     public Attachment setType(final String value) {
         this.type = value;
+        return this;
+    }
+
+    /**
+     * Gets size.
+     *
+     * @return the size
+     */
+    public Long getSize() {
+        return size;
+    }
+
+    /**
+     * Sets size.
+     *
+     * @param value the value
+     * @return self for method chaining
+     */
+    public Attachment setSize(final Long value) {
+        this.size = value;
         return this;
     }
 


### PR DESCRIPTION
### Context

This PR adds an optional `size` field to the `io.qameta.allure.model.Attachment` class to eliminate `HEAD` HTTP roundtrips for remote attachments (when they are implemented, of course — but here it is a chicken and egg problem).

This change aligns with ongoing efforts to add optional size support across Allure implementations.
See related PR in allure-js: https://github.com/allure-framework/allure-js/pull/1302

**Changes:**

- Added optional `Long size` field to `Attachment` class
- Added `getSize()` and `setSize()` methods following existing patterns
- Field is nullable to maintain backward compatibility

**Benefits:**

- Enables efficient attachment handling when size is already known from JSON
- Eliminates need for reflection-based workarounds
- Maintains backward compatibility with existing code
- Follows Allure's established patterns and conventions
- Supports remote attachment workflows without HTTP roundtrips

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2