### PR TITLE
Modernize allure-spring-web for current Spring HTTP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,42 @@ You can specify custom templates, which should be placed in src/main/resources/t
         .withResponseTemplate("custom-http-response.ftl"))
 ```
 
+## Spring Web
+
+Interceptor for Spring synchronous HTTP clients, that generates attachments for allure.
+
+```xml
+<dependency>
+   <groupId>io.qameta.allure</groupId>
+   <artifactId>allure-spring-web</artifactId>
+   <version>$LATEST_VERSION</version>
+</dependency>
+```
+
+Usage example with `RestClient`:
+```
+RestClient restClient = RestClient.builder()
+        .requestFactory(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()))
+        .requestInterceptor(new AllureRestTemplate())
+        .build();
+```
+Use a buffering request factory when the client should still be able to read the response body after Allure captures it.
+
+`RestTemplate` remains supported:
+```
+RestTemplate restTemplate = new RestTemplate(
+        new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())
+);
+restTemplate.setInterceptors(Collections.singletonList(new AllureRestTemplate()));
+```
+
+You can specify custom templates, which should be placed in src/main/resources/tpl folder:
+```
+new AllureRestTemplate()
+        .setRequestTemplate("custom-http-request.ftl")
+        .setResponseTemplate("custom-http-response.ftl")
+```
+
 ## OkHttp
 
 Interceptor for OkHttp client, that generates attachment for allure.

--- a/allure-spring-web/build.gradle.kts
+++ b/allure-spring-web/build.gradle.kts
@@ -1,6 +1,6 @@
 description = "Allure Spring Web Integration"
 
-val springWebVersion = "6.2.12"
+val springWebVersion = "6.2.17"
 
 dependencies {
     api(project(":allure-attachments"))

--- a/allure-spring-web/src/main/java/io/qameta/allure/springweb/AllureRestTemplate.java
+++ b/allure-spring-web/src/main/java/io/qameta/allure/springweb/AllureRestTemplate.java
@@ -36,7 +36,12 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Allure interceptor for spring rest template.
+ * Allure interceptor for Spring synchronous HTTP clients such as
+ * {@code RestTemplate} and {@code RestClient}.
+ * <p>
+ * Since this interceptor reads the response body to create an attachment,
+ * configure a buffering request factory when the caller also needs to consume
+ * the response body after interception.
  */
 public class AllureRestTemplate implements ClientHttpRequestInterceptor {
 

--- a/allure-spring-web/src/test/java/io/qameta/allure/springweb/AllureRestTemplateTest.java
+++ b/allure-spring-web/src/test/java/io/qameta/allure/springweb/AllureRestTemplateTest.java
@@ -33,11 +33,13 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static io.qameta.allure.test.RunUtils.runWithinTestContext;
@@ -49,55 +51,119 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("unchecked")
 public class AllureRestTemplateTest {
 
-    static Stream<String> attachmentNameProvider() {
-        return Stream.of("Request", "Response");
+    static Stream<SpringClientType> clientTypeProvider() {
+        return Stream.of(SpringClientType.values());
     }
 
     @ParameterizedTest
-    @MethodSource(value = "attachmentNameProvider")
-    void shouldCreateAttachment(final String attachmentName) {
-        final AllureResults results = execute();
+    @MethodSource("clientTypeProvider")
+    void shouldCreateAttachment(final SpringClientType clientType) {
+        final AllureResults results = execute(clientType).getAllureResults();
         assertThat(results.getTestResults())
                 .flatExtracting(TestResult::getAttachments)
                 .flatExtracting(Attachment::getName)
-                .contains(attachmentName);
+                .contains("Request", "Response");
     }
 
     @ParameterizedTest
-    @MethodSource(value = "attachmentNameProvider")
-    void shouldCatchAttachmentBody(final String attachmentName) {
-        final AllureResults results = execute();
+    @MethodSource("clientTypeProvider")
+    void shouldCatchAttachmentBody(final SpringClientType clientType) {
+        final AllureResults results = execute(clientType).getAllureResults();
 
-        final Attachment found = results.getTestResults().stream()
+        Stream.of("Request", "Response")
+                .map(attachmentName -> findAttachment(results, attachmentName))
+                .forEach(found -> assertThat(results.getAttachments())
+                        .containsKeys(found.getSource()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("clientTypeProvider")
+    void shouldAllowResponseBodyConsumptionAfterInterception(final SpringClientType clientType) {
+        final ExecutionResult executionResult = execute(clientType);
+        assertThat(executionResult.getResponse().getBody()).isEqualTo("some body");
+    }
+
+    protected final ExecutionResult execute(final SpringClientType clientType) {
+        final WireMockServer server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        final AtomicReference<ResponseEntity<String>> response = new AtomicReference<>();
+
+        final AllureResults results = runWithinTestContext(() -> {
+            server.start();
+            WireMock.configureFor(server.port());
+            WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/hello")).willReturn(WireMock.aResponse().withBody("some body")));
+            try {
+                final ResponseEntity<String> result = clientType.execute(server.url("/hello"));
+                response.set(result);
+                Assertions.assertEquals(result.getStatusCode(), HttpStatus.OK);
+                Assertions.assertEquals(result.getBody(), "some body");
+            } finally {
+                server.stop();
+            }
+        });
+
+        return new ExecutionResult(results, response.get());
+    }
+
+    private static Attachment findAttachment(final AllureResults results, final String attachmentName) {
+        return results.getTestResults().stream()
                 .map(TestResult::getAttachments)
                 .flatMap(Collection::stream)
                 .filter(attachment -> Objects.equals(attachmentName, attachment.getName()))
                 .findAny()
                 .orElseThrow(() -> new RuntimeException("attachment not found"));
-
-        assertThat(results.getAttachments())
-                .containsKeys(found.getSource());
     }
 
-    protected final AllureResults execute() {
-        final RestTemplate restTemplate = new RestTemplate(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory()));
-        restTemplate.setInterceptors(Collections.singletonList(new AllureRestTemplate()));
+    private static BufferingClientHttpRequestFactory createBufferingRequestFactory() {
+        return new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory());
+    }
 
-        final WireMockServer server = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+    private enum SpringClientType {
+        REST_TEMPLATE {
+            @Override
+            ResponseEntity<String> execute(final String url) {
+                final RestTemplate restTemplate = new RestTemplate(createBufferingRequestFactory());
+                restTemplate.setInterceptors(Collections.singletonList(new AllureRestTemplate()));
 
-        return runWithinTestContext(() -> {
-            server.start();
-            WireMock.configureFor(server.port());
-            WireMock.stubFor(WireMock.get(WireMock.urlEqualTo("/hello")).willReturn(WireMock.aResponse().withBody("some body")));
-            try {
-                HttpHeaders headers = new HttpHeaders();
+                final HttpHeaders headers = new HttpHeaders();
                 headers.setContentType(MediaType.APPLICATION_JSON);
-                HttpEntity<JsonNode> entity = new HttpEntity<>(headers);
-                ResponseEntity<String> result = restTemplate.exchange(server.url("/hello"), HttpMethod.GET, entity, String.class);
-                Assertions.assertEquals(result.getStatusCode(), HttpStatus.OK);
-            } finally {
-                server.stop();
+                final HttpEntity<JsonNode> entity = new HttpEntity<>(headers);
+                return restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
             }
-        });
+        },
+        REST_CLIENT {
+            @Override
+            ResponseEntity<String> execute(final String url) {
+                final RestClient restClient = RestClient.builder()
+                        .requestFactory(createBufferingRequestFactory())
+                        .requestInterceptor(new AllureRestTemplate())
+                        .build();
+                return restClient.get()
+                        .uri(url)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .retrieve()
+                        .toEntity(String.class);
+            }
+        };
+
+        abstract ResponseEntity<String> execute(String url);
+    }
+
+    private static final class ExecutionResult {
+
+        private final AllureResults allureResults;
+        private final ResponseEntity<String> response;
+
+        private ExecutionResult(final AllureResults allureResults, final ResponseEntity<String> response) {
+            this.allureResults = allureResults;
+            this.response = response;
+        }
+
+        AllureResults getAllureResults() {
+            return allureResults;
+        }
+
+        ResponseEntity<String> getResponse() {
+            return response;
+        }
     }
 }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->
* bump allure-spring-web from Spring Web 6.2.12 to 6.2.17
* keep the existing AllureRestTemplate API and interceptor contract unchanged
* document the module as supporting both RestTemplate and RestClient
* add test coverage for both client entrypoints


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2