### PR TITLE
Add titlePath as the default test hierarchy path

### DIFF
--- a/allure-citrus/src/main/java/io/qameta/allure/citrus/AllureCitrus.java
+++ b/allure-citrus/src/main/java/io/qameta/allure/citrus/AllureCitrus.java
@@ -59,6 +59,7 @@ import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
 import static io.qameta.allure.util.ResultsUtils.createParameter;
 import static io.qameta.allure.util.ResultsUtils.createSuiteLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
 import static io.qameta.allure.util.ResultsUtils.getProvidedLabels;
 
 /**
@@ -161,16 +162,19 @@ public class AllureCitrus implements TestListener, TestSuiteListener, TestAction
 
     private void startTestCase(final TestCase testCase) {
         final String uuid = createUuid(testCase);
+        final Optional<? extends Class<?>> testClass = Optional.ofNullable(testCase.getTestClass());
 
         final TestResult result = new TestResult()
                 .setUuid(uuid)
                 .setName(testCase.getName())
+                .setTitlePath(testClass
+                        .map(ResultsUtils::createTitlePathFromJavaClass)
+                        .orElseGet(() -> createTitlePath(testCase.getName())))
                 .setStage(Stage.RUNNING);
 
         result.getLabels().addAll(getProvidedLabels());
 
 
-        final Optional<? extends Class<?>> testClass = Optional.ofNullable(testCase.getTestClass());
         testClass.map(this::getLabels).ifPresent(result.getLabels()::addAll);
         testClass.map(this::getLinks).ifPresent(result.getLinks()::addAll);
 

--- a/allure-citrus/src/test/java/io/qameta/allure/citrus/AllureCitrusTest.java
+++ b/allure-citrus/src/test/java/io/qameta/allure/citrus/AllureCitrusTest.java
@@ -61,6 +61,8 @@ class AllureCitrusTest {
         assertThat(results.getTestResults())
                 .extracting(TestResult::getName)
                 .containsExactly("Simple test");
+        assertThat(results.getTestResults().get(0).getTitlePath())
+                .containsExactly("com", "consol", "citrus", "dsl", "design", "DefaultTestDesigner");
     }
 
     @AllureFeatures.PassedTests

--- a/allure-cucumber4-jvm/src/main/java/io/qameta/allure/cucumber4jvm/AllureCucumber4Jvm.java
+++ b/allure-cucumber4-jvm/src/main/java/io/qameta/allure/cucumber4jvm/AllureCucumber4Jvm.java
@@ -71,6 +71,8 @@ import java.util.stream.Stream;
 
 import static cucumber.api.HookType.Before;
 import static io.qameta.allure.util.ResultsUtils.createParameter;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromSourcePath;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
 import static io.qameta.allure.util.ResultsUtils.md5;
@@ -156,11 +158,15 @@ public class AllureCucumber4Jvm implements ConcurrentEventListener {
         final String testCaseUuid = testCaseUuids
                 .computeIfAbsent(testCase, tc -> UUID.randomUUID().toString());
 
+        final List<String> titlePath = createTitlePathFromSourcePath(getTestCaseUri(testCase));
+        titlePath.addAll(createTitlePath(feature.getName()));
+
         final TestResult result = new TestResult()
                 .setUuid(testCaseUuid)
                 .setTestCaseId(getTestCaseId(testCase))
                 .setHistoryId(getHistoryId(testCase))
                 .setFullName(fullName)
+                .setTitlePath(titlePath)
                 .setName(name)
                 .setLabels(labelBuilder.getScenarioLabels())
                 .setLinks(labelBuilder.getScenarioLinks());

--- a/allure-cucumber4-jvm/src/test/java/io/qameta/allure/cucumber4jvm/AllureCucumber4JvmTest.java
+++ b/allure-cucumber4-jvm/src/test/java/io/qameta/allure/cucumber4jvm/AllureCucumber4JvmTest.java
@@ -77,6 +77,8 @@ class AllureCucumber4JvmTest {
         assertThat(testResults)
                 .extracting(TestResult::getName)
                 .containsExactlyInAnyOrder("Add a to b");
+        assertThat(testResults.get(0).getTitlePath())
+                .containsExactly("src", "test", "resources", "features", "simple.feature", "Simple feature");
     }
 
     @AllureFeatures.PassedTests

--- a/allure-cucumber5-jvm/src/main/java/io/qameta/allure/cucumber5jvm/AllureCucumber5Jvm.java
+++ b/allure-cucumber5-jvm/src/main/java/io/qameta/allure/cucumber5jvm/AllureCucumber5Jvm.java
@@ -67,6 +67,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static io.qameta.allure.util.ResultsUtils.createParameter;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromSourcePath;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
 import static io.qameta.allure.util.ResultsUtils.md5;
@@ -150,11 +152,15 @@ public class AllureCucumber5Jvm implements ConcurrentEventListener {
 
         final String testCaseUuid = testCase.getId().toString();
 
+        final List<String> titlePath = createTitlePathFromSourcePath(getTestCaseUri(testCase));
+        titlePath.addAll(createTitlePath(feature.getName()));
+
         final TestResult result = new TestResult()
                 .setUuid(testCaseUuid)
                 .setTestCaseId(getTestCaseId(testCase))
                 .setHistoryId(getHistoryId(testCase))
                 .setFullName(fullName)
+                .setTitlePath(titlePath)
                 .setName(name)
                 .setLabels(labelBuilder.getScenarioLabels())
                 .setLinks(labelBuilder.getScenarioLinks());

--- a/allure-cucumber5-jvm/src/test/java/io/qameta/allure/cucumber5jvm/AllureCucumber5JvmTest.java
+++ b/allure-cucumber5-jvm/src/test/java/io/qameta/allure/cucumber5jvm/AllureCucumber5JvmTest.java
@@ -80,6 +80,8 @@ class AllureCucumber5JvmTest {
         assertThat(testResults)
                 .extracting(TestResult::getName)
                 .containsExactlyInAnyOrder("Add a to b");
+        assertThat(testResults.get(0).getTitlePath())
+                .containsExactly("src", "test", "resources", "features", "simple.feature", "Simple feature");
     }
 
     @AllureFeatures.PassedTests

--- a/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/AllureCucumber6Jvm.java
+++ b/allure-cucumber6-jvm/src/main/java/io/qameta/allure/cucumber6jvm/AllureCucumber6Jvm.java
@@ -65,6 +65,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static io.qameta.allure.util.ResultsUtils.createParameter;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromSourcePath;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
 import static io.qameta.allure.util.ResultsUtils.md5;
@@ -145,11 +147,15 @@ public class AllureCucumber6Jvm implements ConcurrentEventListener {
 
         final String testCaseUuid = testCase.getId().toString();
 
+        final List<String> titlePath = createTitlePathFromSourcePath(getTestCaseUri(testCase));
+        titlePath.addAll(createTitlePath(feature.getName()));
+
         final TestResult result = new TestResult()
                 .setUuid(testCaseUuid)
                 .setTestCaseId(getTestCaseId(testCase))
                 .setHistoryId(getHistoryId(testCase))
                 .setFullName(fullName)
+                .setTitlePath(titlePath)
                 .setName(name)
                 .setLabels(labelBuilder.getScenarioLabels())
                 .setLinks(labelBuilder.getScenarioLinks());

--- a/allure-cucumber6-jvm/src/test/java/io/qameta/allure/cucumber6jvm/AllureCucumber6JvmTest.java
+++ b/allure-cucumber6-jvm/src/test/java/io/qameta/allure/cucumber6jvm/AllureCucumber6JvmTest.java
@@ -80,6 +80,8 @@ class AllureCucumber6JvmTest {
         assertThat(testResults)
                 .extracting(TestResult::getName)
                 .containsExactlyInAnyOrder("Add a to b");
+        assertThat(testResults.get(0).getTitlePath())
+                .containsExactly("src", "test", "resources", "features", "simple.feature", "Simple feature");
     }
 
     @AllureFeatures.PassedTests

--- a/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/AllureCucumber7Jvm.java
+++ b/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/AllureCucumber7Jvm.java
@@ -66,6 +66,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static io.qameta.allure.util.ResultsUtils.createParameter;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromSourcePath;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
 import static io.qameta.allure.util.ResultsUtils.md5;
@@ -146,11 +148,15 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
 
         final String testCaseUuid = testCase.getId().toString();
 
+        final List<String> titlePath = createTitlePathFromSourcePath(getTestCaseUri(testCase));
+        titlePath.addAll(createTitlePath(feature.getName()));
+
         final TestResult result = new TestResult()
                 .setUuid(testCaseUuid)
                 .setTestCaseId(getTestCaseId(testCase))
                 .setHistoryId(getHistoryId(testCase))
                 .setFullName(fullName)
+                .setTitlePath(titlePath)
                 .setName(name)
                 .setLabels(labelBuilder.getScenarioLabels())
                 .setLinks(labelBuilder.getScenarioLinks());

--- a/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
+++ b/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
@@ -80,6 +80,8 @@ class AllureCucumber7JvmTest {
         assertThat(testResults)
                 .extracting(TestResult::getName)
                 .containsExactlyInAnyOrder("Add a to b");
+        assertThat(testResults.get(0).getTitlePath())
+                .containsExactly("src", "test", "resources", "features", "simple.feature", "Simple feature");
     }
 
     @AllureFeatures.PassedTests

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -40,16 +41,21 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.net.InetAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -98,6 +104,7 @@ public final class ResultsUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResultsUtils.class);
     private static final String ALLURE_DESCRIPTIONS_FOLDER = "META-INF/allureDescriptions/";
     private static final String MD_5 = "MD5";
+    private static final String DOT = ".";
 
     private static String cachedHost;
 
@@ -140,6 +147,51 @@ public final class ResultsUtils {
 
     public static Label createPackageLabel(final String packageName) {
         return createLabel(PACKAGE_LABEL_NAME, packageName);
+    }
+
+    public static List<String> createTitlePath(final String... values) {
+        return createTitlePath(Arrays.asList(values));
+    }
+
+    public static List<String> createTitlePath(final Collection<String> values) {
+        if (Objects.isNull(values)) {
+            return new ArrayList<>();
+        }
+        return values.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    public static List<String> createTitlePathFromPackageAndClass(final String packageName, final String className) {
+        final List<String> result = createTitlePathFromPackage(packageName);
+        getClassTitle(packageName, className).ifPresent(result::add);
+        return result;
+    }
+
+    public static List<String> createTitlePathFromQualifiedClassName(final String className) {
+        return getPackageName(className)
+                .map(packageName -> createTitlePathFromPackageAndClass(packageName, className))
+                .orElseGet(() -> createTitlePath(className));
+    }
+
+    public static List<String> createTitlePathFromJavaClass(final Class<?> clazz) {
+        if (Objects.isNull(clazz)) {
+            return createTitlePath();
+        }
+        final String packageName = Optional.ofNullable(clazz.getPackage())
+                .map(Package::getName)
+                .orElse("");
+        return createTitlePathFromPackageAndClass(packageName, clazz.getName());
+    }
+
+    public static List<String> createTitlePathFromPackage(final String packageName) {
+        return split(packageName, DOT);
+    }
+
+    public static List<String> createTitlePathFromSourcePath(final String sourcePath) {
+        return split(normalizeSourcePath(sourcePath), "/");
     }
 
     public static Label createEpicLabel(final String epic) {
@@ -472,6 +524,64 @@ public final class ResultsUtils {
             return Optional.empty();
         }
         return Optional.of(simpleClassName(lambda.getImplClass()) + "::" + getLambdaMethodName(methodName));
+    }
+
+    private static Optional<String> getPackageName(final String className) {
+        if (Objects.isNull(className)) {
+            return Optional.empty();
+        }
+        final int index = className.lastIndexOf('.');
+        if (index < 0) {
+            return Optional.empty();
+        }
+        return Optional.of(className.substring(0, index));
+    }
+
+    private static Optional<String> getClassTitle(final String packageName, final String className) {
+        if (Objects.isNull(className) || className.isEmpty()) {
+            return Optional.empty();
+        }
+        final String prefix = packageName + DOT;
+        if (!packageName.isEmpty() && className.startsWith(prefix)) {
+            return Optional.of(className.substring(prefix.length()));
+        }
+        return Optional.of(className);
+    }
+
+    private static List<String> split(final String value, final String delimiter) {
+        if (Objects.isNull(value) || value.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return Stream.of(value.split(Pattern.quote(delimiter)))
+                .map(String::trim)
+                .filter(item -> !item.isEmpty())
+                .collect(Collectors.toList());
+    }
+
+    private static String normalizeSourcePath(final String sourcePath) {
+        if (Objects.isNull(sourcePath)) {
+            return "";
+        }
+        try {
+            final URI uri = URI.create(sourcePath);
+            if (nonNull(uri.getScheme())) {
+                final URI normalized = uri.normalize();
+                if (!normalized.isOpaque()) {
+                    final URI relative = new File("").toURI().relativize(normalized);
+                    final String path = relative.getPath();
+                    if (nonNull(path) && !path.isEmpty()) {
+                        return path.replace('\\', '/');
+                    }
+                }
+                final String schemeSpecificPart = normalized.getSchemeSpecificPart();
+                if (nonNull(schemeSpecificPart)) {
+                    return schemeSpecificPart.replace('\\', '/');
+                }
+            }
+        } catch (IllegalArgumentException ignored) {
+            // Fall back to plain path normalization below.
+        }
+        return sourcePath.replace('\\', '/');
     }
 
     private static String getLambdaMethodName(final String methodName) {

--- a/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.UUID;
 
 import static io.qameta.allure.FileSystemResultsWriter.generateTestResultName;
@@ -54,6 +55,22 @@ public class FileSystemResultsWriterTest {
 
         assertThat(folder.resolve(fileName))
                 .isRegularFile();
+    }
+
+    @Test
+    void shouldWriteTitlePath(@TempDir final Path folder) throws IOException {
+        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
+        final String uuid = UUID.randomUUID().toString();
+        final TestResult testResult = new TestResult()
+                .setUuid(uuid)
+                .setTitlePath(Arrays.asList("parent", "child"));
+
+        writer.write(testResult);
+
+        assertThat(Files.readString(folder.resolve(generateTestResultName(uuid))))
+                .contains("\"titlePath\"")
+                .contains("\"parent\"")
+                .contains("\"child\"");
     }
 
     @Test

--- a/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
@@ -34,6 +34,9 @@ import static io.qameta.allure.util.ResultsUtils.ISSUE_LINK_TYPE;
 import static io.qameta.allure.util.ResultsUtils.TMS_LINK_TYPE;
 import static io.qameta.allure.util.ResultsUtils.createIssueLink;
 import static io.qameta.allure.util.ResultsUtils.createLink;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromQualifiedClassName;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromSourcePath;
 import static io.qameta.allure.util.ResultsUtils.createTmsLink;
 import static io.qameta.allure.util.ResultsUtils.getLinkTypePatternPropertyName;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +46,24 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @ExtendWith(SystemPropertyExtension.class)
 class ResultsUtilsTest {
+
+    @Test
+    void shouldCreateTitlePath() {
+        assertThat(createTitlePath(" parent ", null, " ", "child"))
+                .containsExactly("parent", "child");
+    }
+
+    @Test
+    void shouldCreateTitlePathFromQualifiedClassName() {
+        assertThat(createTitlePathFromQualifiedClassName("io.qameta.allure.samples.MyTest"))
+                .containsExactly("io", "qameta", "allure", "samples", "MyTest");
+    }
+
+    @Test
+    void shouldCreateTitlePathFromSourcePath() {
+        assertThat(createTitlePathFromSourcePath("features/nested/my.test.feature"))
+                .containsExactly("features", "nested", "my.test.feature");
+    }
 
     @Test
     void shouldCreateLink() {

--- a/allure-jbehave/src/main/java/io/qameta/allure/jbehave/AllureJbehave.java
+++ b/allure-jbehave/src/main/java/io/qameta/allure/jbehave/AllureJbehave.java
@@ -50,6 +50,7 @@ import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
 import static io.qameta.allure.util.ResultsUtils.createParameter;
 import static io.qameta.allure.util.ResultsUtils.createStoryLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
 import static io.qameta.allure.util.ResultsUtils.getMd5Digest;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
@@ -245,6 +246,7 @@ public class AllureJbehave extends NullStoryReporter {
                 .setName(name)
                 .setFullName(fullName)
                 .setStage(Stage.SCHEDULED)
+                .setTitlePath(getTitlePath(story))
                 .setLabels(labels)
                 .setParameters(parameters)
                 .setDescription(story.getDescription().asString())
@@ -252,6 +254,13 @@ public class AllureJbehave extends NullStoryReporter {
 
         getLifecycle().scheduleTestCase(result);
         getLifecycle().startTestCase(result.getUuid());
+    }
+
+    private List<String> getTitlePath(final Story story) {
+        if (story.getPath() == null) {
+            return createTitlePath();
+        }
+        return createTitlePath(Arrays.asList(story.getPath().replace('\\', '/').split("/")));
     }
 
     protected void stopTestCase(final String uuid) {

--- a/allure-jbehave/src/test/java/io/qameta/allure/jbehave/AllureJbehaveTest.java
+++ b/allure-jbehave/src/test/java/io/qameta/allure/jbehave/AllureJbehaveTest.java
@@ -167,6 +167,8 @@ class AllureJbehaveTest {
         assertThat(results.getTestResults())
                 .extracting(TestResult::getFullName)
                 .containsExactlyInAnyOrder("simple.story: Add a to b");
+        assertThat(results.getTestResults().get(0).getTitlePath())
+                .containsExactly("stories", "simple.story");
     }
 
     @Test

--- a/allure-jbehave5/src/main/java/io/qameta/allure/jbehave5/AllureJbehave5.java
+++ b/allure-jbehave5/src/main/java/io/qameta/allure/jbehave5/AllureJbehave5.java
@@ -54,6 +54,7 @@ import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
 import static io.qameta.allure.util.ResultsUtils.createParameter;
 import static io.qameta.allure.util.ResultsUtils.createStoryLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
 import static io.qameta.allure.util.ResultsUtils.getMd5Digest;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
@@ -245,6 +246,7 @@ public class AllureJbehave5 extends NullStoryReporter {
                 .setName(name)
                 .setFullName(fullName)
                 .setStage(Stage.SCHEDULED)
+                .setTitlePath(getTitlePath(story))
                 .setLabels(labels)
                 .setParameters(parameters)
                 .setDescription(story.getDescription().asString())
@@ -252,6 +254,13 @@ public class AllureJbehave5 extends NullStoryReporter {
 
         getLifecycle().scheduleTestCase(result);
         getLifecycle().startTestCase(result.getUuid());
+    }
+
+    private List<String> getTitlePath(final Story story) {
+        if (story.getPath() == null) {
+            return createTitlePath();
+        }
+        return createTitlePath(Arrays.asList(story.getPath().replace('\\', '/').split("/")));
     }
 
     protected void stopTestCase(final String uuid) {

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/AllureJbehave5Test.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/AllureJbehave5Test.java
@@ -166,6 +166,8 @@ class AllureJbehave5Test {
         assertThat(results.getTestResults())
                 .extracting(TestResult::getFullName)
                 .containsExactlyInAnyOrder("simple.story: Add a to b");
+        assertThat(results.getTestResults().get(0).getTitlePath())
+                .containsExactly("stories", "simple.story");
     }
 
     @Test

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
@@ -523,6 +523,7 @@ public class AllureJunitPlatform implements TestExecutionListener {
                         ? maybeParent.get().getDisplayName() + " " + testIdentifier.getDisplayName()
                         : testIdentifier.getDisplayName()
                 )
+                .setTitlePath(getTitlePath(testIdentifier, testClass))
                 .setLabels(getTags(testIdentifier))
                 .setTestCaseId(testTemplate
                         ? maybeParent.map(TestIdentifier::getUniqueId)
@@ -660,6 +661,52 @@ public class AllureJunitPlatform implements TestExecutionListener {
                 .map(TestTag::getName)
                 .map(ResultsUtils::createTagLabel)
                 .collect(Collectors.toList());
+    }
+
+    private List<String> getTitlePath(final TestIdentifier testIdentifier,
+                                      final Optional<Class<?>> testClass) {
+        final List<String> result = testClass
+                .map(this::getClassTitlePath)
+                .orElseGet(ArrayList::new);
+
+        getParents(testIdentifier).stream()
+                .filter(parent -> !"engine".equals(parent.getUniqueIdObject().getLastSegment().getType()))
+                .filter(parent -> !parent.isTest())
+                .filter(parent -> !parent.getSource().filter(ClassSource.class::isInstance).isPresent())
+                .map(TestIdentifier::getDisplayName)
+                .forEach(result::add);
+
+        return ResultsUtils.createTitlePath(result);
+    }
+
+    private List<String> getClassTitlePath(final Class<?> testClass) {
+        final String packageName = Optional.ofNullable(testClass.getPackage())
+                .map(Package::getName)
+                .orElse("");
+        final List<String> result = ResultsUtils.createTitlePathFromPackage(packageName);
+        final List<String> classNames = new ArrayList<>();
+        Class<?> current = testClass;
+        while (Objects.nonNull(current)) {
+            classNames.add(getDisplayName(current).orElse(current.getSimpleName()));
+            current = current.getDeclaringClass();
+        }
+        Collections.reverse(classNames);
+        result.addAll(classNames);
+        return result;
+    }
+
+    private List<TestIdentifier> getParents(final TestIdentifier testIdentifier) {
+        final List<TestIdentifier> result = new ArrayList<>();
+        Optional<TestIdentifier> parent = Optional.ofNullable(testPlanStorage.get())
+                .flatMap(testPlan -> testPlan.getParent(testIdentifier));
+        while (parent.isPresent()) {
+            final TestIdentifier value = parent.get();
+            result.add(value);
+            parent = Optional.ofNullable(testPlanStorage.get())
+                    .flatMap(testPlan -> testPlan.getParent(value));
+        }
+        Collections.reverse(result);
+        return result;
     }
 
     protected String getHistoryId(final TestIdentifier testIdentifier) {

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -75,6 +75,7 @@ import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -883,6 +884,16 @@ public class AllureJunitPlatformTest {
                         "feature1Test()",
                         "feature2Test()",
                         "story1Test()"
+                );
+
+        assertThat(allureResults.getTestResults())
+                .filteredOn("name", "story1Test()")
+                .extracting(TestResult::getTitlePath)
+                .containsExactly(
+                        Arrays.asList(
+                                "io", "qameta", "allure", "junitplatform", "features",
+                                "NestedTests", "Feature2", "Story1"
+                        )
                 );
 
         assertThat(allureResults.getTestResults())

--- a/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
+++ b/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
@@ -49,6 +49,7 @@ import static io.qameta.allure.util.ResultsUtils.createSuiteLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestClassLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestMethodLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromPackageAndClass;
 import static io.qameta.allure.util.ResultsUtils.getJavadocDescription;
 import static io.qameta.allure.util.ResultsUtils.getProvidedLabels;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
@@ -264,7 +265,8 @@ public class AllureJunit4 extends RunListener {
                 .setUuid(uuid)
                 .setHistoryId(getHistoryId(description))
                 .setFullName(fullName)
-                .setName(name);
+                .setName(name)
+                .setTitlePath(createTitlePathFromPackageAndClass(getPackage(description.getTestClass()), suite));
 
         testResult.getLabels().addAll(getProvidedLabels());
         testResult.getLabels().addAll(Arrays.asList(

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
@@ -70,6 +70,11 @@ class AllureJunit4Test {
                 .hasSize(1)
                 .extracting(TestResult::getFullName)
                 .containsExactly("io.qameta.allure.junit4.samples.OneTest.simpleTest");
+        assertThat(testResults.get(0).getTitlePath())
+                .containsExactly(
+                        "io", "qameta", "allure", "junit4", "samples",
+                        "Should be overwritten by method annotation"
+                );
     }
 
     @Test

--- a/allure-karate/src/main/java/io/qameta/allure/karate/AllureKarate.java
+++ b/allure-karate/src/main/java/io/qameta/allure/karate/AllureKarate.java
@@ -54,6 +54,8 @@ import java.util.stream.Collectors;
 import static io.qameta.allure.util.ResultsUtils.createLabel;
 import static io.qameta.allure.util.ResultsUtils.createLink;
 import static io.qameta.allure.util.ResultsUtils.createParameter;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromSourcePath;
 import static io.qameta.allure.util.ResultsUtils.md5;
 
 /**
@@ -91,6 +93,8 @@ public class AllureKarate implements RuntimeHook {
         final String nameOrLine = getName(scenario, String.valueOf(scenario.getLine()));
         final String testCaseId = md5(String.format("%s:%s", featureNameQualified, nameOrLine));
         final String fullName = String.format("%s:%d", featureNameQualified, scenario.getLine());
+        final List<String> titlePath = createTitlePathFromSourcePath(featureNameQualified);
+        titlePath.addAll(createTitlePath(featureName));
         final TestResult result = new TestResult()
                 .setUuid(uuid)
                 .setFullName(fullName)
@@ -98,6 +102,7 @@ public class AllureKarate implements RuntimeHook {
                 .setDescription(scenario.getDescription())
                 .setTestCaseId(testCaseId)
                 .setHistoryId(md5(scenario.getUniqueId()))
+                .setTitlePath(titlePath)
                 .setStage(Stage.RUNNING);
 
         final List<String> labels = sr.tags.getTags();

--- a/allure-model/src/main/java/io/qameta/allure/model/TestResult.java
+++ b/allure-model/src/main/java/io/qameta/allure/model/TestResult.java
@@ -43,6 +43,7 @@ public class TestResult implements Serializable, ExecutableItem, WithLinks {
     private String testCaseId;
     private String testCaseName;
     private String fullName;
+    private List<String> titlePath = new ArrayList<>();
     private List<Label> labels = new ArrayList<>();
     private List<Link> links = new ArrayList<>();
     private String name;
@@ -154,6 +155,26 @@ public class TestResult implements Serializable, ExecutableItem, WithLinks {
      */
     public TestResult setFullName(final String value) {
         this.fullName = value;
+        return this;
+    }
+
+    /**
+     * Gets title path.
+     *
+     * @return the title path
+     */
+    public List<String> getTitlePath() {
+        return titlePath;
+    }
+
+    /**
+     * Sets title path.
+     *
+     * @param titlePath the title path
+     * @return self for method chaining.
+     */
+    public TestResult setTitlePath(final List<String> titlePath) {
+        this.titlePath = titlePath;
         return this;
     }
 

--- a/allure-model/src/test/java/io/qameta/allure/model/TestResultTest.java
+++ b/allure-model/src/test/java/io/qameta/allure/model/TestResultTest.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TestResultTest {
+
+    @Test
+    void shouldHaveEmptyTitlePathByDefault() {
+        assertThat(new TestResult().getTitlePath())
+                .isEmpty();
+    }
+
+    @Test
+    void shouldSetTitlePath() {
+        assertThat(new TestResult()
+                .setTitlePath(Arrays.asList("parent", "child"))
+                .getTitlePath())
+                .containsExactly("parent", "child");
+    }
+}

--- a/allure-reader/src/test/java/io/qameta/allure/reader/AllureObjectMapperFactoryTest.java
+++ b/allure-reader/src/test/java/io/qameta/allure/reader/AllureObjectMapperFactoryTest.java
@@ -36,6 +36,7 @@ class AllureObjectMapperFactoryTest {
             return mapper.readValue(
                     "{"
                     + "\"name\":\"demo\","
+                    + "\"titlePath\":[\"parent\",\"child\"],"
                     + "\"status\":\"pAsSeD\","
                     + "\"stage\":\"fInIsHeD\","
                     + "\"parameters\":[{\"name\":\"secret\",\"value\":\"42\",\"mode\":\"MaSkEd\"}],"
@@ -47,6 +48,8 @@ class AllureObjectMapperFactoryTest {
 
         Allure.step("Verify the mapper normalizes enums and keeps the expected payload", () -> {
             assertEquals("demo", result.getName());
+            assertEquals("parent", result.getTitlePath().get(0));
+            assertEquals("child", result.getTitlePath().get(1));
             assertEquals(Status.PASSED, result.getStatus());
             assertEquals(Stage.FINISHED, result.getStage());
             assertEquals(Parameter.Mode.MASKED, result.getParameters().get(0).getMode());

--- a/allure-scalatest/src/main/scala/io/qameta/allure/scalatest/AllureScalatest.scala
+++ b/allure-scalatest/src/main/scala/io/qameta/allure/scalatest/AllureScalatest.scala
@@ -195,6 +195,9 @@ class AllureScalatest(val lifecycle: AllureLifecycle) extends Reporter {
       .setUuid(uuid)
       .setTestCaseId(md5(suiteId + testName))
       .setHistoryId(md5(suiteId + testName))
+      .setTitlePath(suiteClassName
+        .map(createTitlePathFromQualifiedClassName)
+        .getOrElse(createTitlePath(suiteName)))
 
     val testAnnotations = getAnnotations(location)
     val suiteAnnotations = getAnnotations(getSuiteLocation(suiteId))

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/AllureScalatestTest.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/AllureScalatestTest.scala
@@ -37,6 +37,9 @@ class AllureScalatestTest {
     val results = run(classOf[SimpleSpec])
     results.getTestResults.asScala
       .map(item => item.getName) should contain("test should be passed")
+    results.getTestResults.asScala.head.getTitlePath.asScala.toList shouldBe List(
+      "io", "qameta", "allure", "scalatest", "testdata", "SimpleSpec"
+    )
   }
 
   @Test

--- a/allure-spock/src/main/java/io/qameta/allure/spock/AllureSpock.java
+++ b/allure-spock/src/main/java/io/qameta/allure/spock/AllureSpock.java
@@ -61,6 +61,8 @@ import static io.qameta.allure.util.ResultsUtils.createSuiteLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestClassLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestMethodLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromPackage;
 import static io.qameta.allure.util.ResultsUtils.firstNonEmpty;
 import static io.qameta.allure.util.ResultsUtils.getProvidedLabels;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
@@ -139,6 +141,12 @@ public class AllureSpock extends AbstractRunListener implements IGlobalExtension
         labels.addAll(getLabels(iteration));
         labels.addAll(getProvidedLabels());
 
+        final List<String> titlePath = new ArrayList<>(createTitlePathFromPackage(packageName));
+        titlePath.addAll(createTitlePath(
+                Objects.nonNull(superSpec) ? superSpec.getName() : null,
+                specName,
+                Objects.nonNull(subSpec) ? subSpec.getName() : null
+        ));
         final TestResult result = new TestResult()
                 .setUuid(uuid)
                 .setHistoryId(getHistoryId(getQualifiedName(iteration), parameters))
@@ -147,6 +155,7 @@ public class AllureSpock extends AbstractRunListener implements IGlobalExtension
                         feature.getDescription().getDisplayName(),
                         getQualifiedName(iteration)).orElse("Unknown"))
                 .setFullName(getQualifiedName(iteration))
+                .setTitlePath(titlePath)
                 .setStatusDetails(new StatusDetails()
                         .setFlaky(isFlaky(iteration))
                         .setMuted(isMuted(iteration)))

--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -68,6 +68,8 @@ import static io.qameta.allure.util.ResultsUtils.createSuiteLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestClassLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestMethodLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromPackage;
 import static io.qameta.allure.util.ResultsUtils.firstNonEmpty;
 import static io.qameta.allure.util.ResultsUtils.getMd5Digest;
 import static io.qameta.allure.util.ResultsUtils.getProvidedLabels;
@@ -192,12 +194,19 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         links.addAll(specLinks);
 
         final String qualifiedName = getQualifiedName(iteration);
+        final List<String> titlePath = new ArrayList<>(createTitlePathFromPackage(packageName));
+        titlePath.addAll(createTitlePath(
+                Objects.nonNull(superSpec) ? superSpec.getName() : null,
+                specName,
+                Objects.nonNull(subSpec) ? subSpec.getName() : null
+        ));
         final TestResult result = new TestResult()
                 .setUuid(uuid)
                 .setHistoryId(getHistoryId(qualifiedName, parameters))
                 .setTestCaseName(iteration.getName())
                 .setTestCaseId(md5(qualifiedName))
                 .setFullName(qualifiedName)
+                .setTitlePath(titlePath)
                 .setName(
                         firstNonEmpty(testMethodName, iteration.getName(), qualifiedName)
                                 .orElse("Unknown")

--- a/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
+++ b/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
@@ -91,6 +91,8 @@ import static io.qameta.allure.util.ResultsUtils.createSuiteLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestClassLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestMethodLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
+import static io.qameta.allure.util.ResultsUtils.createTitlePath;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromQualifiedClassName;
 import static io.qameta.allure.util.ResultsUtils.firstNonEmpty;
 import static io.qameta.allure.util.ResultsUtils.getMd5Digest;
 import static io.qameta.allure.util.ResultsUtils.getProvidedLabels;
@@ -390,6 +392,7 @@ public class AllureTestNg implements
                 .setHistoryId(getHistoryId(method, parameters))
                 .setName(getMethodName(method))
                 .setFullName(getQualifiedName(method))
+                .setTitlePath(getTitlePath(testClass))
                 .setStatusDetails(new StatusDetails()
                         .setFlaky(isFlaky(method, iClass))
                         .setMuted(isMuted(method, iClass)))
@@ -406,6 +409,15 @@ public class AllureTestNg implements
 
         getLifecycle().scheduleTestCase(parentUuid, result);
         getLifecycle().startTestCase(uuid);
+    }
+
+    private List<String> getTitlePath(final ITestClass testClass) {
+        final List<String> result = new ArrayList<>(createTitlePath(
+                safeExtractSuiteName(testClass),
+                safeExtractTestTag(testClass)
+        ));
+        result.addAll(createTitlePathFromQualifiedClassName(testClass.getName()));
+        return result;
     }
 
     @Override

--- a/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
@@ -161,6 +161,11 @@ public class AllureTestNgTest {
                 .hasFieldOrPropertyWithValue("status", Status.PASSED)
                 .hasFieldOrPropertyWithValue("stage", Stage.FINISHED)
                 .hasFieldOrPropertyWithValue("name", testName);
+        assertThat(testResult.get(0).getTitlePath())
+                .containsExactly(
+                        "Test suite 7", "Test tag 7",
+                        "io", "qameta", "allure", "testng", "samples", "TestsWithSteps"
+                );
         assertThat(testResult)
                 .flatExtracting(TestResult::getSteps)
                 .hasSize(1)


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->
This adds `titlePath` to Allure Java results as a structured, unambiguous hierarchy path for tests. Unlike package-based grouping, `titlePath` is stored as an array of path segments, so names containing dots or other punctuation are preserved instead of being split unexpectedly.

Allure Java integrations now populate `titlePath` from the test framework’s natural structure: Java packages and classes for class-based tests, nested containers for JUnit Platform, XML suite/test context for TestNG, source file paths and feature/story names for BDD-style frameworks, and native suite/spec information for Spock, ScalaTest, and Citrus. Existing labels, names, full names, history IDs, and test case IDs remain unchanged for compatibility.

For example, a Cucumber scenario in `features/simple.feature` with feature title `Simple feature` will now include a title path like `["features", "simple.feature", "Simple feature"]`, allowing reports to build a clearer default tree without relying on label splitting.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2