### PR TITLE
Publish JUnit 5 compatibility coordinates as Maven relocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 - 🚀 Documentation — https://allurereport.org/docs/junit5/
 - 📚 Example project — https://github.com/allure-examples?q=topic%3Ajunit5
 - ✅ Generate a project in 10 seconds via Allure Start - https://allurereport.org/start/
-- 🧩 Use `io.qameta.allure:allure-jupiter` for new setups. `allure-junit5` remains available as a deprecated compatibility alias during migration.
+- 🧩 Use `io.qameta.allure:allure-jupiter` for new setups. `allure-junit5` remains available as a deprecated relocation coordinate during migration.
 
 ## Cucumber JVM
 

--- a/allure-jupiter-assert/README.MD
+++ b/allure-jupiter-assert/README.MD
@@ -1,6 +1,6 @@
 Adding Jupiter assert may lead to java.lang.OutOfMemoryError: Java heap space
 
-The primary artifact is now `allure-jupiter-assert`. `allure-junit5-assert` remains available as a deprecated compatibility alias during the transition.
+The primary artifact is now `allure-jupiter-assert`. `allure-junit5-assert` remains available as a deprecated relocation coordinate during the transition.
 
 Having a huge class path may lead to OOM, because AspectJ processes all the classes. [Link to documentation](https://www.eclipse.org/aspectj/doc/released/devguide/ltw.html) 
 

--- a/allure-jupiter-assert/build.gradle.kts
+++ b/allure-jupiter-assert/build.gradle.kts
@@ -28,6 +28,17 @@ publishing {
     publications {
         create<MavenPublication>("legacyJunit5Assert") {
             artifactId = "allure-junit5-assert"
+            pom {
+                packaging = "pom"
+                distributionManagement {
+                    relocation {
+                        groupId.set(project.group.toString())
+                        artifactId.set("allure-jupiter-assert")
+                        version.set(project.version.toString())
+                        message.set("allure-junit5-assert has been renamed to allure-jupiter-assert.")
+                    }
+                }
+            }
         }
     }
 }

--- a/allure-jupiter/build.gradle.kts
+++ b/allure-jupiter/build.gradle.kts
@@ -45,7 +45,17 @@ publishing {
         }
         create<MavenPublication>("legacyJunit5") {
             artifactId = "allure-junit5"
-            artifact(spiOffJar)
+            pom {
+                packaging = "pom"
+                distributionManagement {
+                    relocation {
+                        groupId.set(project.group.toString())
+                        artifactId.set("allure-jupiter")
+                        version.set(project.version.toString())
+                        message.set("allure-junit5 has been renamed to allure-jupiter.")
+                    }
+                }
+            }
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -398,14 +398,18 @@ configure(libs) {
 }
 
 configure(standardJavaLibs) {
-    publishing.publications.withType<MavenPublication>().configureEach {
+    publishing.publications.named<MavenPublication>("maven") {
         from(components["java"])
     }
 }
 
 val verifyJupiterCompatibilityBridge by tasks.registering {
     dependsOn(
-        ":allure-bom:generatePomFileForMavenPublication"
+        ":allure-bom:generatePomFileForMavenPublication",
+        ":allure-jupiter:generatePomFileForMavenPublication",
+        ":allure-jupiter:generatePomFileForLegacyJunit5Publication",
+        ":allure-jupiter-assert:generatePomFileForMavenPublication",
+        ":allure-jupiter-assert:generatePomFileForLegacyJunit5AssertPublication"
     )
 
     doLast {
@@ -422,7 +426,7 @@ val verifyJupiterCompatibilityBridge by tasks.registering {
             "Expected :allure-jupiter to publish the primary allure-jupiter coordinate."
         }
         check("allure-junit5" in jupiterArtifactIds) {
-            "Expected :allure-jupiter to publish the legacy allure-junit5 alias."
+            "Expected :allure-jupiter to publish the legacy allure-junit5 relocation."
         }
 
         val jupiterAssertArtifactIds = publicationArtifactIds(":allure-jupiter-assert")
@@ -430,7 +434,7 @@ val verifyJupiterCompatibilityBridge by tasks.registering {
             "Expected :allure-jupiter-assert to publish the primary allure-jupiter-assert coordinate."
         }
         check("allure-junit5-assert" in jupiterAssertArtifactIds) {
-            "Expected :allure-jupiter-assert to publish the legacy allure-junit5-assert alias."
+            "Expected :allure-jupiter-assert to publish the legacy allure-junit5-assert relocation."
         }
 
         val bomPom = project(":allure-bom")
@@ -441,17 +445,60 @@ val verifyJupiterCompatibilityBridge by tasks.registering {
             .asFile
             .readText()
 
+        fun publicationPom(projectPath: String, publicationName: String): String =
+            project(projectPath)
+                .layout
+                .buildDirectory
+                .file("publications/$publicationName/pom-default.xml")
+                .get()
+                .asFile
+                .readText()
+
         check("<artifactId>allure-jupiter</artifactId>" in bomPom) {
             "Expected allure-bom to manage allure-jupiter."
         }
         check("<artifactId>allure-junit5</artifactId>" in bomPom) {
-            "Expected allure-bom to manage the legacy allure-junit5 alias."
+            "Expected allure-bom to manage the legacy allure-junit5 relocation."
         }
         check("<artifactId>allure-jupiter-assert</artifactId>" in bomPom) {
             "Expected allure-bom to manage allure-jupiter-assert."
         }
         check("<artifactId>allure-junit5-assert</artifactId>" in bomPom) {
-            "Expected allure-bom to manage the legacy allure-junit5-assert alias."
+            "Expected allure-bom to manage the legacy allure-junit5-assert relocation."
+        }
+
+        val legacyJunit5Pom = publicationPom(":allure-jupiter", "legacyJunit5")
+        check("<artifactId>allure-junit5</artifactId>" in legacyJunit5Pom) {
+            "Expected the legacy allure-junit5 publication to keep the old artifact id."
+        }
+        check("<relocation>" in legacyJunit5Pom) {
+            "Expected the legacy allure-junit5 publication to be a relocation POM."
+        }
+        check("<packaging>pom</packaging>" in legacyJunit5Pom) {
+            "Expected the legacy allure-junit5 relocation to use pom packaging."
+        }
+        check("<dependencies>" !in legacyJunit5Pom) {
+            "Expected the legacy allure-junit5 relocation POM to avoid publishing dependencies."
+        }
+        check("<artifactId>allure-jupiter</artifactId>" in legacyJunit5Pom) {
+            "Expected the legacy allure-junit5 publication to relocate to allure-jupiter."
+        }
+
+        val legacyJunit5AssertPom = publicationPom(":allure-jupiter-assert", "legacyJunit5Assert")
+        check("<artifactId>allure-junit5-assert</artifactId>" in legacyJunit5AssertPom) {
+            "Expected the legacy allure-junit5-assert publication to keep the old artifact id."
+        }
+        check("<relocation>" in legacyJunit5AssertPom) {
+            "Expected the legacy allure-junit5-assert publication to be a relocation POM."
+        }
+        check("<packaging>pom</packaging>" in legacyJunit5AssertPom) {
+            "Expected the legacy allure-junit5-assert relocation to use pom packaging."
+        }
+        check("<dependencies>" !in legacyJunit5AssertPom) {
+            "Expected the legacy allure-junit5-assert relocation POM to avoid publishing dependencies."
+        }
+        check("<artifactId>allure-jupiter-assert</artifactId>" in legacyJunit5AssertPom) {
+            "Expected the legacy allure-junit5-assert publication to relocate to allure-jupiter-assert."
         }
     }
 }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

The deprecated JUnit 5 coordinates now publish as relocation POMs to the renamed Jupiter artifacts. Existing builds that still reference `io.qameta.allure:allure-junit5` or `io.qameta.allure:allure-junit5-assert` can continue their migration path toward `allure-jupiter` and `allure-jupiter-assert`, while new setups are clearly guided to the canonical artifact names.

The release checks now verify that both primary and legacy coordinates generate the expected POM metadata, including relocation details, so publishing catches this compatibility path before artifacts reach users. Documentation has also been updated to describe the old coordinates as deprecated relocations instead of aliases.

The change should fix the recent publish failure #1279

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2