### PR TITLE
Fix Allure AssertJ rendering for null assertion arguments

### DIFF
--- a/allure-assertj/src/main/java/io/qameta/allure/assertj/AssertJValueRenderer.java
+++ b/allure-assertj/src/main/java/io/qameta/allure/assertj/AssertJValueRenderer.java
@@ -529,6 +529,9 @@ final class AssertJValueRenderer {
     }
 
     private boolean isLambda(final Object value) {
+        if (value == null) {
+            return false;
+        }
         final Class<?> type = value.getClass();
         return type.isSynthetic() || type.getName().contains("$$Lambda$");
     }

--- a/allure-assertj/src/test/java/io/qameta/allure/assertj/AllureAspectJTest.java
+++ b/allure-assertj/src/test/java/io/qameta/allure/assertj/AllureAspectJTest.java
@@ -174,6 +174,56 @@ class AllureAspectJTest {
 
     @AllureFeatures.Steps
     @Test
+    void shouldRenderNullValuesInContainsExactlyInAnyOrder() {
+        final AllureResults results = runWithinTestContext(() -> {
+            assertThat(Arrays.asList(null, "a", "b"))
+                    .containsExactlyInAnyOrder(null, "a", "b");
+        }, AllureAspectJ::setLifecycle);
+
+        final TestResult result = assertOnlyOneResult(results);
+        assertThat(result.getSteps())
+                .extracting(StepResult::getName)
+                .containsExactly("assert [null, \"a\", \"b\"]");
+        assertThat(result.getSteps())
+                .flatExtracting(StepResult::getSteps)
+                .extracting(StepResult::getName)
+                .containsExactly("contains exactly in any order [null, \"a\", \"b\"]");
+        assertThat(result.getSteps())
+                .flatExtracting(StepResult::getSteps)
+                .flatExtracting(StepResult::getParameters)
+                .isEmpty();
+    }
+
+    @AllureFeatures.Steps
+    @Test
+    void shouldRenderNullValuesAfterExtractingAndKeepLambdaVarargs() {
+        final TestResult model = new TestResult();
+
+        final AllureResults results = runWithinTestContext(() -> {
+            assertThat(model)
+                    .extracting(TestResult::getDescription, TestResult::getDescriptionHtml)
+                    .containsExactly(null, null);
+        }, AllureAspectJ::setLifecycle);
+
+        final TestResult result = assertOnlyOneResult(results);
+        assertThat(result.getSteps())
+                .extracting(StepResult::getName)
+                .containsExactly("assert TestResult");
+        assertThat(result.getSteps())
+                .flatExtracting(StepResult::getSteps)
+                .extracting(StepResult::getName)
+                .containsExactly(
+                        "extracts [<lambda>, <lambda>] -> [null, null]",
+                        "contains exactly [null, null]"
+                );
+        assertThat(result.getSteps())
+                .flatExtracting(StepResult::getSteps)
+                .flatExtracting(StepResult::getParameters)
+                .isEmpty();
+    }
+
+    @AllureFeatures.Steps
+    @Test
     void shouldRenderFieldOrPropertyValueAssertions() {
         final StatusDetails details = new StatusDetails()
                 .setMessage("Make the test failed");


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure AssertJ now handles valid AssertJ assertions that include `null` expected values without interrupting the test. Assertions such as `containsExactlyInAnyOrder(null, "a", "b")` and extracted values checked with `containsExactly(null, null)` can now be recorded as Allure steps instead of failing during step rendering.

Lambda-based assertion arguments continue to render as before, so existing step names for extracted properties and callbacks remain stable while mixed null-containing argument lists are displayed safely.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2