### PR TITLE
Split qualified title paths into package segments

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -348,7 +348,10 @@ public final class ResultsUtils {
      */
     public static List<String> createTitlePathFromPackageAndClass(final String packageName, final String className) {
         final List<String> result = createTitlePathFromPackage(packageName);
-        getClassTitle(packageName, className).ifPresent(result::add);
+        if (result.isEmpty()) {
+            return createTitlePathFromQualifiedClassName(className);
+        }
+        getClassTitle(String.join(DOT, result), className).ifPresent(result::add);
         return result;
     }
 
@@ -991,14 +994,18 @@ public final class ResultsUtils {
     }
 
     private static Optional<String> getClassTitle(final String packageName, final String className) {
-        if (Objects.isNull(className) || className.isEmpty()) {
+        if (Objects.isNull(className)) {
+            return Optional.empty();
+        }
+        final String trimmedClassName = className.trim();
+        if (trimmedClassName.isEmpty()) {
             return Optional.empty();
         }
         final String prefix = packageName + DOT;
-        if (!packageName.isEmpty() && className.startsWith(prefix)) {
-            return Optional.of(className.substring(prefix.length()));
+        if (!packageName.isEmpty() && trimmedClassName.startsWith(prefix)) {
+            return Optional.of(trimmedClassName.substring(prefix.length()));
         }
-        return Optional.of(className);
+        return Optional.of(trimmedClassName);
     }
 
     private static List<String> split(final String value, final String delimiter) {

--- a/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
@@ -29,15 +29,18 @@ import org.opentest4j.ValueWrapper;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static io.qameta.allure.Allure.step;
 import static io.qameta.allure.util.ResultsUtils.ISSUE_LINK_TYPE;
 import static io.qameta.allure.util.ResultsUtils.TMS_LINK_TYPE;
 import static io.qameta.allure.util.ResultsUtils.createIssueLink;
 import static io.qameta.allure.util.ResultsUtils.createLink;
 import static io.qameta.allure.util.ResultsUtils.createTitlePath;
+import static io.qameta.allure.util.ResultsUtils.createTitlePathFromPackageAndClass;
 import static io.qameta.allure.util.ResultsUtils.createTitlePathFromQualifiedClassName;
 import static io.qameta.allure.util.ResultsUtils.createTitlePathFromSourcePath;
 import static io.qameta.allure.util.ResultsUtils.createTmsLink;
@@ -56,6 +59,89 @@ class ResultsUtilsTest {
     void shouldCreateTitlePathFromQualifiedClassName() {
         assertThat(createTitlePathFromQualifiedClassName("io.qameta.allure.samples.MyTest"))
                 .containsExactly("io", "qameta", "allure", "samples", "MyTest");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("packageAndClassTitlePathData")
+    void shouldCreateTitlePathFromPackageAndClass(final String scenario,
+                                                  final String packageName,
+                                                  final String className,
+                                                  final List<String> expected) {
+        step("Verify " + scenario, () -> {
+            assertThat(createTitlePathFromPackageAndClass(packageName, className))
+                    .containsExactlyElementsOf(expected);
+        });
+    }
+
+    static Stream<Arguments> packageAndClassTitlePathData() {
+        return Stream.of(
+                Arguments.of(
+                        "null package and null class produce an empty title path",
+                        null,
+                        null,
+                        List.of()
+                ),
+                Arguments.of(
+                        "blank package and blank class produce an empty title path",
+                        " ",
+                        " ",
+                        List.of()
+                ),
+                Arguments.of(
+                        "empty package preserves a simple class name",
+                        "",
+                        "MyTest",
+                        List.of("MyTest")
+                ),
+                Arguments.of(
+                        "empty package splits a qualified name into segments",
+                        "",
+                        "io.qameta.allure",
+                        List.of("io", "qameta", "allure")
+                ),
+                Arguments.of(
+                        "null package splits a qualified class name into package and class segments",
+                        null,
+                        "io.qameta.allure.samples.MyTest",
+                        List.of("io", "qameta", "allure", "samples", "MyTest")
+                ),
+                Arguments.of(
+                        "package and null class produce package segments only",
+                        "io.qameta.allure.samples",
+                        null,
+                        List.of("io", "qameta", "allure", "samples")
+                ),
+                Arguments.of(
+                        "package and blank class produce package segments only",
+                        "io.qameta.allure.samples",
+                        " ",
+                        List.of("io", "qameta", "allure", "samples")
+                ),
+                Arguments.of(
+                        "package and simple class append the class segment",
+                        "io.qameta.allure.samples",
+                        "MyTest",
+                        List.of("io", "qameta", "allure", "samples", "MyTest")
+                ),
+                Arguments.of(
+                        "package and qualified class avoid duplicating package segments",
+                        "io.qameta.allure.samples",
+                        "io.qameta.allure.samples.MyTest",
+                        List.of("io", "qameta", "allure", "samples", "MyTest")
+                ),
+                Arguments.of(
+                        "package and class names are trimmed",
+                        " io . qameta . allure . samples ",
+                        " io.qameta.allure.samples.MyTest ",
+                        List.of("io", "qameta", "allure", "samples", "MyTest")
+                ),
+                Arguments.of(
+                        "empty package segments are ignored",
+                        "io..qameta.allure.",
+                        "MyTest",
+                        List.of("io", "qameta", "allure", "MyTest")
+                )
+        );
     }
 
     @Test

--- a/allurerc.mjs
+++ b/allurerc.mjs
@@ -12,7 +12,8 @@ export default {
     plugins: {
         awesome: {
             options: {
-                groupBy: ["module", "parentSuite", "suite", "subSuite"],
+                groupBy: ["module"],
+                appendTitlePath: true,
                 publish: true,
             },
         },


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure title paths now handle fully qualified package and class names as separate path segments instead of keeping dotted names as one combined entry. For example, `io.qameta.allure` is reported as `io / qameta / allure`, making title-path navigation and grouping match the expected package hierarchy.

The title path helper also handles null, blank, trimmed, simple, and already-qualified package/class inputs consistently, avoiding duplicated package segments and skipping empty title parts.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2