### PR TITLE
Make Allure result files durable before publishing

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/FileSystemResultsWriter.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/FileSystemResultsWriter.java
@@ -22,12 +22,16 @@ import io.qameta.allure.model.TestResultContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.DataOutput;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
 import java.util.Objects;
@@ -44,7 +48,11 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemResultsWriter.class);
 
-    private static final int ATTACHMENT_COPY_BUFFER_SIZE = 1024 * 1024;
+    private static final String TEST_RESULT_ENTITY_NAME = "test result";
+
+    private static final String TEST_RESULT_CONTAINER_ENTITY_NAME = "test result container";
+
+    private static final String ATTACHMENT_ENTITY_NAME = "attachment";
 
     private final Path outputDirectory;
 
@@ -89,13 +97,11 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
         final String testResultName = Objects.isNull(testResult.getUuid())
                 ? generateTestResultName()
                 : generateTestResultName(testResult.getUuid());
-        ensureInitialized();
         final Path file = outputDirectory.resolve(testResultName);
-        try {
-            mapper.writeValue(file.toFile(), testResult);
-        } catch (IOException e) {
-            throw new AllureResultsWriteException("Could not write Allure test result", e);
-        }
+        write(file, TEST_RESULT_ENTITY_NAME, channel -> {
+            final DataOutput output = new DataOutputStream(Channels.newOutputStream(channel));
+            mapper.writeValue(output, testResult);
+        });
     }
 
     /**
@@ -106,13 +112,11 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
         final String testResultContainerName = Objects.isNull(testResultContainer.getUuid())
                 ? generateTestResultContainerName()
                 : generateTestResultContainerName(testResultContainer.getUuid());
-        ensureInitialized();
         final Path file = outputDirectory.resolve(testResultContainerName);
-        try {
-            mapper.writeValue(file.toFile(), testResultContainer);
-        } catch (IOException e) {
-            throw new AllureResultsWriteException("Could not write Allure test result container", e);
-        }
+        write(file, TEST_RESULT_CONTAINER_ENTITY_NAME, channel -> {
+            final DataOutput output = new DataOutputStream(Channels.newOutputStream(channel));
+            mapper.writeValue(output, testResultContainer);
+        });
     }
 
     /**
@@ -120,38 +124,41 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
      */
     @Override
     public void write(final String source, final InputStream attachment) {
-        ensureInitialized();
         final Path file = outputDirectory.resolve(source);
-        Path tempFile = null;
         try (InputStream is = attachment) {
+            write(file, ATTACHMENT_ENTITY_NAME, channel -> {
+                final OutputStream output = Channels.newOutputStream(channel);
+                is.transferTo(output);
+            });
+        } catch (IOException e) {
+            throw new AllureResultsWriteException(getErrorMessage(ATTACHMENT_ENTITY_NAME), e);
+        }
+    }
+
+    private void write(final Path file, final String entityName, final ChannelConsumer consumer) {
+        ensureInitialized();
+        Path tempFile = null;
+        try {
             tempFile = Files.createTempFile(outputDirectory, ".allure-write-", ".tmp");
             try (FileChannel channel = FileChannel.open(tempFile, StandardOpenOption.WRITE)) {
-                copy(is, channel);
-                sync(channel);
+                consumer.accept(channel);
+                channel.force(true);
             }
-            Files.move(tempFile, file);
+            Files.move(tempFile, file, StandardCopyOption.REPLACE_EXISTING);
             tempFile = null;
         } catch (IOException e) {
             deleteIfExists(tempFile);
-            throw new AllureResultsWriteException("Could not write Allure attachment", e);
+            throw new AllureResultsWriteException(getErrorMessage(entityName), e);
         }
     }
 
-    private static void copy(final InputStream source, final FileChannel target) throws IOException {
-        final byte[] buffer = new byte[ATTACHMENT_COPY_BUFFER_SIZE];
-        final ByteBuffer byteBuffer = ByteBuffer.wrap(buffer);
-        int length;
-        while ((length = source.read(buffer)) != -1) {
-            byteBuffer.clear();
-            byteBuffer.limit(length);
-            while (byteBuffer.hasRemaining()) {
-                target.write(byteBuffer);
-            }
-        }
+    private static String getErrorMessage(final String entityName) {
+        return "Could not write Allure " + entityName;
     }
 
-    void sync(final FileChannel channel) throws IOException {
-        channel.force(true);
+    private interface ChannelConsumer {
+
+        void accept(FileChannel channel) throws IOException;
     }
 
     private static void deleteIfExists(final Path file) {
@@ -161,7 +168,7 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
         try {
             Files.deleteIfExists(file);
         } catch (IOException e) {
-            LOGGER.warn("Failed to delete temporary Allure attachment file {}", file, e);
+            LOGGER.warn("Failed to delete temporary Allure result file {}", file, e);
         }
     }
 

--- a/allure-java-commons/src/main/java/io/qameta/allure/FileSystemResultsWriter.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/FileSystemResultsWriter.java
@@ -24,8 +24,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.UUID;
@@ -40,6 +43,8 @@ import java.util.stream.Stream;
 public class FileSystemResultsWriter implements AllureResultsWriter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemResultsWriter.class);
+
+    private static final int ATTACHMENT_COPY_BUFFER_SIZE = 1024 * 1024;
 
     private final Path outputDirectory;
 
@@ -117,10 +122,46 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
     public void write(final String source, final InputStream attachment) {
         ensureInitialized();
         final Path file = outputDirectory.resolve(source);
+        Path tempFile = null;
         try (InputStream is = attachment) {
-            Files.copy(is, file);
+            tempFile = Files.createTempFile(outputDirectory, ".allure-write-", ".tmp");
+            try (FileChannel channel = FileChannel.open(tempFile, StandardOpenOption.WRITE)) {
+                copy(is, channel);
+                sync(channel);
+            }
+            Files.move(tempFile, file);
+            tempFile = null;
         } catch (IOException e) {
+            deleteIfExists(tempFile);
             throw new AllureResultsWriteException("Could not write Allure attachment", e);
+        }
+    }
+
+    private static void copy(final InputStream source, final FileChannel target) throws IOException {
+        final byte[] buffer = new byte[ATTACHMENT_COPY_BUFFER_SIZE];
+        final ByteBuffer byteBuffer = ByteBuffer.wrap(buffer);
+        int length;
+        while ((length = source.read(buffer)) != -1) {
+            byteBuffer.clear();
+            byteBuffer.limit(length);
+            while (byteBuffer.hasRemaining()) {
+                target.write(byteBuffer);
+            }
+        }
+    }
+
+    void sync(final FileChannel channel) throws IOException {
+        channel.force(true);
+    }
+
+    private static void deleteIfExists(final Path file) {
+        if (Objects.isNull(file)) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(file);
+        } catch (IOException e) {
+            LOGGER.warn("Failed to delete temporary Allure attachment file {}", file, e);
         }
     }
 

--- a/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
@@ -17,13 +17,13 @@ package io.qameta.allure;
 
 import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.model.TestResult;
+import io.qameta.allure.model.TestResultContainer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -33,10 +33,12 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.qameta.allure.FileSystemResultsWriter.generateTestResultContainerName;
 import static io.qameta.allure.FileSystemResultsWriter.generateTestResultName;
 import static io.qameta.allure.test.ThreadLocalEnhancedRandom.current;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class FileSystemResultsWriterTest {
 
     @Test
@@ -58,6 +60,19 @@ public class FileSystemResultsWriterTest {
         assertThat(folder)
                 .isDirectory();
 
+        assertThat(folder.resolve(fileName))
+                .isRegularFile();
+    }
+
+    @Test
+    void shouldWriteTestResultContainer(@TempDir final Path folder) {
+        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
+        final String uuid = UUID.randomUUID().toString();
+        final TestResultContainer container = current().nextObject(TestResultContainer.class).setUuid(uuid);
+
+        writer.write(container);
+
+        final String fileName = generateTestResultContainerName(uuid);
         assertThat(folder.resolve(fileName))
                 .isRegularFile();
     }
@@ -117,23 +132,6 @@ public class FileSystemResultsWriterTest {
         final byte[] content = "partial attachment body".getBytes(StandardCharsets.UTF_8);
 
         assertThatThrownBy(() -> writer.write(source, new FailingInputStream(content)))
-                .isInstanceOf(AllureResultsWriteException.class)
-                .hasMessage("Could not write Allure attachment")
-                .hasCauseInstanceOf(IOException.class);
-
-        assertThat(folder.resolve(source))
-                .doesNotExist();
-        assertThat(listFiles(folder))
-                .isEmpty();
-    }
-
-    @Test
-    void shouldNotCreateFinalAttachmentFileWhenFsyncFails(@TempDir final Path folder) throws IOException {
-        FileSystemResultsWriter writer = new FailingFsyncFileSystemResultsWriter(folder);
-        final String source = "broken-attachment.txt";
-        final byte[] content = "attachment body".getBytes(StandardCharsets.UTF_8);
-
-        assertThatThrownBy(() -> writer.write(source, new ByteArrayInputStream(content)))
                 .isInstanceOf(AllureResultsWriteException.class)
                 .hasMessage("Could not write Allure attachment")
                 .hasCauseInstanceOf(IOException.class);
@@ -256,15 +254,4 @@ public class FileSystemResultsWriterTest {
         }
     }
 
-    private static final class FailingFsyncFileSystemResultsWriter extends FileSystemResultsWriter {
-
-        private FailingFsyncFileSystemResultsWriter(final Path outputDirectory) {
-            super(outputDirectory);
-        }
-
-        @Override
-        void sync(final FileChannel channel) throws IOException {
-            throw new IOException("Simulated attachment fsync failure");
-        }
-    }
 }

--- a/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
@@ -20,15 +20,23 @@ import io.qameta.allure.model.TestResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.qameta.allure.FileSystemResultsWriter.generateTestResultName;
 import static io.qameta.allure.test.ThreadLocalEnhancedRandom.current;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class FileSystemResultsWriterTest {
 
     @Test
@@ -88,6 +96,52 @@ public class FileSystemResultsWriterTest {
         assertThat(payload)
                 .contains("\"actual\":\"actual value\"")
                 .contains("\"expected\":\"expected value\"");
+    }
+
+    @Test
+    void shouldWriteAttachmentFile(@TempDir final Path folder) throws IOException {
+        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
+        final String source = "source-attachment.txt";
+        final String content = "attachment body";
+
+        writer.write(source, new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
+
+        assertThat(Files.readString(folder.resolve(source)))
+                .isEqualTo(content);
+    }
+
+    @Test
+    void shouldNotCreateFinalAttachmentFileWhenStreamFails(@TempDir final Path folder) throws IOException {
+        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
+        final String source = "broken-attachment.txt";
+        final byte[] content = "partial attachment body".getBytes(StandardCharsets.UTF_8);
+
+        assertThatThrownBy(() -> writer.write(source, new FailingInputStream(content)))
+                .isInstanceOf(AllureResultsWriteException.class)
+                .hasMessage("Could not write Allure attachment")
+                .hasCauseInstanceOf(IOException.class);
+
+        assertThat(folder.resolve(source))
+                .doesNotExist();
+        assertThat(listFiles(folder))
+                .isEmpty();
+    }
+
+    @Test
+    void shouldNotCreateFinalAttachmentFileWhenFsyncFails(@TempDir final Path folder) throws IOException {
+        FileSystemResultsWriter writer = new FailingFsyncFileSystemResultsWriter(folder);
+        final String source = "broken-attachment.txt";
+        final byte[] content = "attachment body".getBytes(StandardCharsets.UTF_8);
+
+        assertThatThrownBy(() -> writer.write(source, new ByteArrayInputStream(content)))
+                .isInstanceOf(AllureResultsWriteException.class)
+                .hasMessage("Could not write Allure attachment")
+                .hasCauseInstanceOf(IOException.class);
+
+        assertThat(folder.resolve(source))
+                .doesNotExist();
+        assertThat(listFiles(folder))
+                .isEmpty();
     }
 
     @Test
@@ -175,5 +229,42 @@ public class FileSystemResultsWriterTest {
             step.parameter("uuid", testResult.getUuid());
             writer.write(testResult);
         });
+    }
+
+    private static List<Path> listFiles(final Path folder) throws IOException {
+        try (Stream<Path> files = Files.list(folder)) {
+            return files.collect(Collectors.toList());
+        }
+    }
+
+    private static final class FailingInputStream extends InputStream {
+
+        private final byte[] content;
+
+        private int index;
+
+        private FailingInputStream(final byte[] content) {
+            this.content = content;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (index < content.length) {
+                return content[index++] & 0xff;
+            }
+            throw new IOException("Simulated attachment stream failure");
+        }
+    }
+
+    private static final class FailingFsyncFileSystemResultsWriter extends FileSystemResultsWriter {
+
+        private FailingFsyncFileSystemResultsWriter(final Path outputDirectory) {
+            super(outputDirectory);
+        }
+
+        @Override
+        void sync(final FileChannel channel) throws IOException {
+            throw new IOException("Simulated attachment fsync failure");
+        }
     }
 }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure now writes filesystem result artifacts more safely, so test results do not expose partially written files when attachment or result persistence fails. Attachments, test result JSON, and container JSON are staged first and only published to the final Allure results path after the write is completed and synced.

This helps runs that persist large attachments or other heavy result data fail clearly instead of leaving behind final-looking files that cannot be read reliably afterwards.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2