### PR TITLE
Leave Allure results cleanup to build tools

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
@@ -1190,13 +1190,7 @@ public class AllureLifecycle {
     private static FileSystemResultsWriter getDefaultWriter() {
         final Properties properties = PropertiesUtils.loadAllureProperties();
         final String path = properties.getProperty("allure.results.directory", "allure-results");
-        final boolean cleanBeforeRun = Boolean.parseBoolean(
-                properties.getProperty("allure.results.clean.before.run", "false")
-        );
-        final boolean cleanOnlyOnce = Boolean.parseBoolean(
-                properties.getProperty("allure.results.clean.only.once", "true")
-        );
-        return new FileSystemResultsWriter(Paths.get(path), cleanBeforeRun, cleanOnlyOnce);
+        return new FileSystemResultsWriter(Paths.get(path));
     }
 
     private static LifecycleNotifier getDefaultNotifier() {

--- a/allure-java-commons/src/main/java/io/qameta/allure/FileSystemResultsWriter.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/FileSystemResultsWriter.java
@@ -33,11 +33,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Stream;
 
 /**
  * Writes Allure result model objects and attachments to the file system.
@@ -58,34 +55,13 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
 
     private final ObjectMapper mapper;
 
-    private final boolean cleanBeforeRun;
-
-    private final boolean cleanOnlyOnce;
-
-    private final AtomicBoolean cleaned = new AtomicBoolean(false);
-
     /**
      * Creates a file system results writer with the supplied values.
      *
      * @param outputDirectory the output directory
      */
     public FileSystemResultsWriter(final Path outputDirectory) {
-        this(outputDirectory, false, true);
-    }
-
-    /**
-     * Creates a file system results writer with the supplied values.
-     *
-     * @param outputDirectory the output directory
-     * @param cleanBeforeRun the clean before run
-     * @param cleanOnlyOnce the clean only once
-     */
-    public FileSystemResultsWriter(final Path outputDirectory,
-                                   final boolean cleanBeforeRun,
-                                   final boolean cleanOnlyOnce) {
         this.outputDirectory = outputDirectory;
-        this.cleanBeforeRun = cleanBeforeRun;
-        this.cleanOnlyOnce = cleanOnlyOnce;
         this.mapper = Allure2ModelJackson.createMapper();
     }
 
@@ -182,31 +158,6 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
 
     private void ensureInitialized() {
         createDirectories(outputDirectory);
-        if (cleanBeforeRun) {
-            final boolean shouldClean = !cleanOnlyOnce || cleaned.compareAndSet(false, true);
-            if (shouldClean) {
-                cleanDirectoryContents(outputDirectory);
-            }
-        }
-    }
-
-    private void cleanDirectoryContents(final Path directory) {
-        if (!Files.exists(directory)) {
-            return;
-        }
-        try (Stream<Path> stream = Files.walk(directory)) {
-            stream.sorted(Comparator.reverseOrder())
-                    .filter(path -> !path.equals(directory))
-                    .forEach(path -> {
-                        try {
-                            Files.deleteIfExists(path);
-                        } catch (IOException e) {
-                            LOGGER.warn("Failed to delete {} during directory cleanup", path, e);
-                        }
-                    });
-        } catch (IOException e) {
-            LOGGER.warn("Failed to clean directory contents: {}", directory, e);
-        }
     }
 
     /**

--- a/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
@@ -143,82 +143,16 @@ public class FileSystemResultsWriterTest {
     }
 
     @Test
-    void shouldPreserveOldResultsWhenCleanIsDisabled(@TempDir final Path folder) throws IOException {
+    void shouldPreserveExistingResults(@TempDir final Path folder) throws IOException {
         Path existingFile = folder.resolve("existing-result.json");
         Files.writeString(existingFile, "{}");
 
-        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder, false, true);
+        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
         final String uuid = UUID.randomUUID().toString();
         final TestResult testResult = current().nextObject(TestResult.class, "steps").setUuid(uuid);
         writeTestResult(writer, testResult);
 
         assertThat(existingFile).exists();
-        assertThat(folder.resolve(generateTestResultName(uuid))).exists();
-    }
-
-    @Test
-    void shouldCleanDirectoryWhenCleanBeforeRunEnabled(@TempDir final Path folder) throws IOException {
-        Path existingFile = folder.resolve("existing-result.json");
-        Files.writeString(existingFile, "{}");
-
-        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder, true, true);
-        final String uuid = UUID.randomUUID().toString();
-        final TestResult testResult = current().nextObject(TestResult.class, "steps").setUuid(uuid);
-        writeTestResult(writer, testResult);
-
-        assertThat(existingFile).doesNotExist();
-        assertThat(folder.resolve(generateTestResultName(uuid))).exists();
-    }
-
-    @Test
-    void shouldCleanOnlyOnceWhenCleanOnlyOnceEnabled(@TempDir final Path folder) throws IOException {
-        Path existingFile = folder.resolve("existing-result.json");
-        Files.writeString(existingFile, "{}");
-
-        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder, true, true);
-
-        final String uuid1 = UUID.randomUUID().toString();
-        final TestResult testResult1 = current().nextObject(TestResult.class, "steps").setUuid(uuid1);
-        writeTestResult(writer, testResult1);
-
-        final String uuid2 = UUID.randomUUID().toString();
-        final TestResult testResult2 = current().nextObject(TestResult.class, "steps").setUuid(uuid2);
-        writeTestResult(writer, testResult2);
-
-        assertThat(folder.resolve(generateTestResultName(uuid1))).exists();
-        assertThat(folder.resolve(generateTestResultName(uuid2))).exists();
-    }
-
-    @Test
-    void shouldCleanOnEveryFirstWriteWhenCleanOnlyOnceDisabled(@TempDir final Path folder) throws IOException {
-        FileSystemResultsWriter writer1 = new FileSystemResultsWriter(folder, true, false);
-        final String uuid1 = UUID.randomUUID().toString();
-        final TestResult testResult1 = current().nextObject(TestResult.class, "steps").setUuid(uuid1);
-        writeTestResult(writer1, testResult1);
-
-        Path intermediateFile = folder.resolve("intermediate-result.json");
-        Files.writeString(intermediateFile, "{}");
-
-        FileSystemResultsWriter writer2 = new FileSystemResultsWriter(folder, true, false);
-        final String uuid2 = UUID.randomUUID().toString();
-        final TestResult testResult2 = current().nextObject(TestResult.class, "steps").setUuid(uuid2);
-        writeTestResult(writer2, testResult2);
-
-        assertThat(intermediateFile).doesNotExist();
-        assertThat(folder.resolve(generateTestResultName(uuid2))).exists();
-    }
-
-    @Test
-    void shouldNotDeleteDirectoryItself(@TempDir final Path folder) throws IOException {
-        Path existingFile = folder.resolve("existing-result.json");
-        Files.writeString(existingFile, "{}");
-
-        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder, true, true);
-        final String uuid = UUID.randomUUID().toString();
-        final TestResult testResult = current().nextObject(TestResult.class, "steps").setUuid(uuid);
-        writeTestResult(writer, testResult);
-
-        assertThat(folder).isDirectory();
         assertThat(folder.resolve(generateTestResultName(uuid))).exists();
     }
 


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure Java no longer cleans result directories from inside the filesystem results writer. Existing result files are preserved when new results are written, so cleanup remains the responsibility of normal Maven or Gradle workflows such as `clean`, `cleanTest`, or project-specific build configuration.

This avoids surprising runtime deletion behavior and keeps the writer focused on producing durable Allure result files.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2