### PR TITLE
Improve JUnit Platform and Jupiter reporting

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ParameterUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ParameterUtils.java
@@ -18,6 +18,7 @@ package io.qameta.allure.util;
 import io.qameta.allure.Param;
 import io.qameta.allure.model.Parameter;
 
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Objects;
@@ -70,12 +71,12 @@ public final class ParameterUtils {
     /**
      * Creates and returns the parameter.
      *
-     * @param parameter the framework or Java parameter to inspect
+     * @param parameter the parameter declaration site to inspect — a method or constructor parameter, or a field
      * @param value the value
      * @param defaultName the name to use when {@link Param} does not override it
      * @return the parameter
      */
-    public static Parameter createParameter(final java.lang.reflect.Parameter parameter,
+    public static Parameter createParameter(final AnnotatedElement parameter,
                                             final Object value,
                                             final String defaultName) {
         Objects.requireNonNull(defaultName, "defaultName");

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
@@ -22,7 +22,6 @@ import io.qameta.allure.AttachmentOptions;
 import io.qameta.allure.Description;
 import io.qameta.allure.Severity;
 import io.qameta.allure.SeverityLevel;
-import io.qameta.allure.model.FixtureResult;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Status;
@@ -35,6 +34,7 @@ import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.TestTag;
 import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.reporting.FileEntry;
 import org.junit.platform.engine.reporting.ReportEntry;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.MethodSource;
@@ -45,6 +45,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -52,17 +56,12 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -85,7 +84,11 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 /**
  * Reports JUnit Platform execution to Allure.
  *
- * <p>Register this listener with the JUnit Platform launcher to translate test plan, container, test, fixture, report-entry, and failure events into Allure results. It is the core listener used by Platform-based Allure adapters.</p>
+ * <p>Register this listener with the JUnit Platform launcher to translate test plan, container, test, report-entry, and failure events into Allure results. It is the core listener used by Platform-based Allure adapters.</p>
+ *
+ * <p>Scopes and tests are addressed by lifecycle keys recomputed from JUnit Platform unique ids — see
+ * {@link #scopeKey(String)} and {@link #testKey(String)} — so companion integrations such as the Jupiter extension
+ * can enrich them through the Allure lifecycle directly, without a shared registry.</p>
  */
 @SuppressWarnings(
     {
@@ -124,36 +127,6 @@ public class AllureJunitPlatform implements TestExecutionListener {
     public static final String ALLURE_PARAMETER_EXCLUDED_KEY = "excluded";
 
     /**
-     * Configuration key for allure fixture.
-     */
-    public static final String ALLURE_FIXTURE = "allure.fixture";
-
-    /**
-     * Constant value for prepare.
-     */
-    public static final String PREPARE = "prepare";
-
-    /**
-     * Constant value for tear down.
-     */
-    public static final String TEAR_DOWN = "tear_down";
-
-    /**
-     * Constant value for event start.
-     */
-    public static final String EVENT_START = "start";
-
-    /**
-     * Constant value for event stop.
-     */
-    public static final String EVENT_STOP = "stop";
-
-    /**
-     * Constant value for event failure.
-     */
-    public static final String EVENT_FAILURE = "failure";
-
-    /**
      * Constant value for junit platform unique id.
      */
     public static final String JUNIT_PLATFORM_UNIQUE_ID = "junit.platform.uniqueid";
@@ -161,6 +134,9 @@ public class AllureJunitPlatform implements TestExecutionListener {
     private static final String STDOUT = "stdout";
     private static final String STDERR = "stderr";
     private static final String TEXT_PLAIN = "text/plain";
+
+    private static final String TEST_TEMPLATE_INVOCATION_SEGMENT = "test-template-invocation";
+    private static final String CLASS_TEMPLATE_INVOCATION_SEGMENT = "class-template-invocation";
 
     private static final boolean HAS_SPOCK2_IN_CLASSPATH = isClassAvailableOnClasspath("io.qameta.allure.spock2.AllureSpock2");
 
@@ -170,19 +146,6 @@ public class AllureJunitPlatform implements TestExecutionListener {
     private static final String ENGINE_CUCUMBER = "cucumber";
 
     private final ThreadLocal<TestPlan> testPlanStorage = new InheritableThreadLocal<>();
-
-    private final ThreadLocal<Uuids> tests = new InheritableThreadLocal<Uuids>() {
-        @Override
-        protected Uuids initialValue() {
-            return new Uuids();
-        }
-    };
-    private final ThreadLocal<Uuids> containers = new InheritableThreadLocal<Uuids>() {
-        @Override
-        protected Uuids initialValue() {
-            return new Uuids();
-        }
-    };
 
     private final AllureLifecycle lifecycle;
 
@@ -209,6 +172,34 @@ public class AllureJunitPlatform implements TestExecutionListener {
      */
     public AllureLifecycle getLifecycle() {
         return lifecycle;
+    }
+
+    /**
+     * Returns the lifecycle key of the Allure scope registered for the JUnit Platform node with the given unique id.
+     *
+     * <p>The key is recomputable: any code that knows the unique id of a running node — such as the Jupiter
+     * extension reporting fixtures — addresses the same scope without access to this listener. Unique ids are
+     * unique within a test plan, so the key is unique per live scope of a single launch.</p>
+     *
+     * @param uniqueId the JUnit Platform unique id of the node
+     * @return the scope key
+     */
+    public static AllureExternalKey scopeKey(final String uniqueId) {
+        return AllureExternalKey.of(AllureJunitPlatform.class, "scope", uniqueId);
+    }
+
+    /**
+     * Returns the lifecycle key of the Allure test started for the JUnit Platform node with the given unique id.
+     *
+     * <p>The key is recomputable: any code that knows the unique id of a running node — such as the Jupiter
+     * extension reporting parameters — addresses the same test without access to this listener. Unique ids are
+     * unique within a test plan, so the key is unique per live test of a single launch.</p>
+     *
+     * @param uniqueId the JUnit Platform unique id of the node
+     * @return the test key
+     */
+    public static AllureExternalKey testKey(final String uniqueId) {
+        return AllureExternalKey.of(AllureJunitPlatform.class, "test", uniqueId);
     }
 
     @SuppressWarnings({"CyclomaticComplexity", "BooleanExpressionComplexity"})
@@ -262,8 +253,6 @@ public class AllureJunitPlatform implements TestExecutionListener {
     @Override
     public void testPlanExecutionStarted(final TestPlan testPlan) {
         testPlanStorage.set(testPlan);
-        tests.set(new Uuids());
-        containers.set(new Uuids());
     }
 
     /**
@@ -272,8 +261,6 @@ public class AllureJunitPlatform implements TestExecutionListener {
     @Override
     public void testPlanExecutionFinished(final TestPlan testPlan) {
         testPlanStorage.remove();
-        tests.remove();
-        containers.remove();
     }
 
     /**
@@ -284,12 +271,14 @@ public class AllureJunitPlatform implements TestExecutionListener {
         if (shouldSkipReportingFor(testIdentifier)) {
             return;
         }
-        // create container for every TestIdentifier. We need containers for tests in order
+        // register a scope for every TestIdentifier. We need scopes for tests in order
         // to support method fixtures.
-        registerScope(testIdentifier);
+        getLifecycle().registerScope(scopeKey(testIdentifier.getUniqueId()));
 
         if (testIdentifier.isTest()) {
-            startTest(testIdentifier);
+            final List<AllureExternalKey> scopeKeys = getParentScopeKeys(testIdentifier);
+            scopeKeys.add(scopeKey(testIdentifier.getUniqueId()));
+            startTest(testIdentifier, scopeKeys);
         }
     }
 
@@ -310,11 +299,11 @@ public class AllureJunitPlatform implements TestExecutionListener {
         if (testIdentifier.isTest()) {
             stopTest(testIdentifier, status, statusDetails);
         } else if (testExecutionResult.getStatus() != TestExecutionResult.Status.SUCCESSFUL) {
-            // report failed containers as fake test results
-            startTest(testIdentifier);
+            // report failed containers as fake test results, linked to their own scope only
+            startTest(testIdentifier, Collections.singletonList(scopeKey(testIdentifier.getUniqueId())));
             stopTest(testIdentifier, status, statusDetails);
         }
-        writeScope(testIdentifier);
+        getLifecycle().writeScope(scopeKey(testIdentifier.getUniqueId()));
     }
 
     /**
@@ -330,19 +319,22 @@ public class AllureJunitPlatform implements TestExecutionListener {
         if (Objects.isNull(testPlan)) {
             return;
         }
+        // only ancestors of the skipped node have running scopes: nodes inside the skipped
+        // subtree never start, so their scopes are never registered
+        final List<AllureExternalKey> scopeKeys = getParentScopeKeys(testIdentifier);
         reportNested(
                 testPlan,
                 testIdentifier,
                 SKIPPED,
                 new StatusDetails().setMessage(reason),
-                new HashSet<>()
+                new HashSet<>(),
+                scopeKeys
         );
     }
 
     /**
      * {@inheritDoc}
      */
-    @SuppressWarnings({"ReturnCount", "CyclomaticComplexity"})
     @Override
     public void reportingEntryPublished(final TestIdentifier testIdentifier,
                                         final ReportEntry entry) {
@@ -350,11 +342,7 @@ public class AllureJunitPlatform implements TestExecutionListener {
             return;
         }
 
-        final Map<String, String> keyValuePairs = unwrap(entry.getKeyValuePairs());
-        if (keyValuePairs.containsKey(ALLURE_FIXTURE)) {
-            processFixtureEvent(testIdentifier, keyValuePairs);
-            return;
-        }
+        final Map<String, String> keyValuePairs = entry.getKeyValuePairs();
         if (keyValuePairs.containsKey(ALLURE_PARAMETER)) {
             processParameterEvent(keyValuePairs);
             return;
@@ -385,20 +373,44 @@ public class AllureJunitPlatform implements TestExecutionListener {
         });
     }
 
-    @SuppressWarnings("PMD.InefficientEmptyStringCheck")
-    private Map<String, String> unwrap(final Map<String, String> data) {
-        final Map<String, String> res = new HashMap<>();
-        data.forEach((key, value) -> {
-            if (Objects.nonNull(value)
-                    && value.trim().isEmpty()
-                    && value.startsWith(ALLURE_REPORT_ENTRY_BLANK_PREFIX)) {
-                res.put(key, value.substring(ALLURE_REPORT_ENTRY_BLANK_PREFIX.length()));
-            } else {
-                res.put(key, value);
-            }
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void fileEntryPublished(final TestIdentifier testIdentifier,
+                                   final FileEntry file) {
+        if (shouldSkipReportingFor(testIdentifier)) {
+            return;
         }
-        );
-        return res;
+        final Path path = file.getPath();
+        if (!Files.isRegularFile(path)) {
+            // TestReporter#publishDirectory entries are not supported
+            LOGGER.debug("skip published file entry {}: not a regular file", path);
+            return;
+        }
+        // published files are ambient, same as captured output: they land under
+        // whatever executable is current on the publishing thread
+        getLifecycle().getCurrentExecutableKey().ifPresent(key -> {
+            final String fileName = String.valueOf(path.getFileName());
+            try (InputStream content = Files.newInputStream(path)) {
+                getLifecycle().addAttachment(
+                        key,
+                        fileName,
+                        file.getMediaType().orElse(null),
+                        content,
+                        attachmentOptions(fileName)
+                );
+            } catch (IOException e) {
+                LOGGER.warn("could not attach published file entry {}", path, e);
+            }
+        });
+    }
+
+    private static AttachmentOptions attachmentOptions(final String fileName) {
+        final int dotIndex = fileName.lastIndexOf('.');
+        return dotIndex > 0 && dotIndex < fileName.length() - 1
+                ? AttachmentOptions.withFileExtension(fileName.substring(dotIndex + 1))
+                : AttachmentOptions.empty();
     }
 
     private void processParameterEvent(final Map<String, String> keyValuePairs) {
@@ -433,62 +445,21 @@ public class AllureJunitPlatform implements TestExecutionListener {
         );
     }
 
-    @SuppressWarnings({"ReturnCount"})
-    private void processFixtureEvent(final TestIdentifier testIdentifier,
-                                     final Map<String, String> keyValuePairs) {
-        final String type = keyValuePairs.get(ALLURE_FIXTURE);
-        final String event = keyValuePairs.get("event");
-
-        // skip for invalid events
-        if (Objects.isNull(type) || Objects.isNull(event)) {
-            return;
-        }
-
-        switch (event) {
-            case EVENT_START:
-                final Optional<String> maybeParent = getContainer(testIdentifier);
-                if (!maybeParent.isPresent()) {
-                    return;
-                }
-                final String parentUuid = maybeParent.get();
-                startFixture(parentUuid, type, keyValuePairs);
-                return;
-            case EVENT_FAILURE:
-                failFixture(keyValuePairs);
-                resetContext(testIdentifier);
-                return;
-            case EVENT_STOP:
-                stopFixture(keyValuePairs);
-                resetContext(testIdentifier);
-                return;
-            default:
-                break;
-        }
-    }
-
-    private void resetContext(final TestIdentifier testIdentifier) {
-        // in case of fixtures that reported within a test we need to return current
-        // test case uuid to allure thread local storage
-        Optional.of(testIdentifier)
-                .filter(TestIdentifier::isTest)
-                .flatMap(this::getTest)
-                .ifPresent(uuid -> getLifecycle().setCurrent(testKey(uuid)));
-    }
-
     private void reportNested(final TestPlan testPlan,
                               final TestIdentifier testIdentifier,
                               final Status status,
                               final StatusDetails statusDetails,
-                              final Set<TestIdentifier> visited) {
+                              final Set<TestIdentifier> visited,
+                              final List<AllureExternalKey> scopeKeys) {
         final Set<TestIdentifier> children = testPlan.getChildren(testIdentifier);
         if (testIdentifier.isTest() || children.isEmpty()) {
-            startTest(testIdentifier);
+            startTest(testIdentifier, scopeKeys);
             stopTest(testIdentifier, status, statusDetails);
         }
         visited.add(testIdentifier);
         children.stream()
                 .filter(id -> !visited.contains(id))
-                .forEach(child -> reportNested(testPlan, child, status, statusDetails, visited));
+                .forEach(child -> reportNested(testPlan, child, status, statusDetails, visited, scopeKeys));
     }
 
     /**
@@ -501,136 +472,80 @@ public class AllureJunitPlatform implements TestExecutionListener {
         return ResultsUtils.getStatus(throwable).orElse(FAILED);
     }
 
-    private void registerScope(final TestIdentifier testIdentifier) {
-        final String uuid = getOrCreateContainer(testIdentifier);
-        getLifecycle().registerScope(scopeKey(uuid));
-    }
-
-    private void writeScope(final TestIdentifier testIdentifier) {
-        final Optional<String> maybeUuid = getContainer(testIdentifier);
-        if (!maybeUuid.isPresent()) {
-            return;
-        }
-        final String uuid = maybeUuid.get();
-        final TestPlan context = testPlanStorage.get();
-        final List<String> children = Optional.ofNullable(context)
-                .map(tp -> tp.getDescendants(testIdentifier))
-                .orElseGet(Collections::emptySet)
-                .stream()
-                .filter(TestIdentifier::isTest)
-                .map(this::getTest)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .distinct()
+    private List<AllureExternalKey> getParentScopeKeys(final TestIdentifier testIdentifier) {
+        return getParents(testIdentifier).stream()
+                // roots are engines: reporting for them is skipped, so they have no scopes
+                .filter(parent -> parent.getParentId().isPresent())
+                .map(parent -> scopeKey(parent.getUniqueId()))
                 .collect(Collectors.toCollection(ArrayList::new));
-
-        getTest(testIdentifier).ifPresent(children::add);
-
-        final AllureExternalKey scopeKey = scopeKey(uuid);
-        children.forEach(child -> getLifecycle().addTestToScope(scopeKey, child));
-        getLifecycle().writeScope(scopeKey);
     }
 
-    private AllureExternalKey scopeKey(final String uuid) {
-        return AllureExternalKey.of(AllureJunitPlatform.class, "scope", uuid);
+    private String getName(final TestIdentifier testIdentifier,
+                           final boolean testTemplate,
+                           final Optional<TestIdentifier> maybeParent) {
+        final String baseName = testTemplate && maybeParent.isPresent()
+                ? maybeParent.get().getDisplayName() + " " + testIdentifier.getDisplayName()
+                : testIdentifier.getDisplayName();
+        // prefix the name with parameterized class invocation display names, so results
+        // of the same method from different invocations are distinguishable
+        final String prefix = getParents(testIdentifier).stream()
+                .filter(parent -> CLASS_TEMPLATE_INVOCATION_SEGMENT
+                        .equals(parent.getUniqueIdObject().getLastSegment().getType()))
+                .map(TestIdentifier::getDisplayName)
+                .collect(Collectors.joining(" "));
+        return prefix.isEmpty() ? baseName : prefix + " " + baseName;
     }
 
-    private AllureExternalKey testKey(final String uuid) {
-        return AllureExternalKey.of(AllureJunitPlatform.class, "test", uuid);
-    }
-
-    private AllureExternalKey fixtureKey(final String uuid) {
-        return AllureExternalKey.of(AllureJunitPlatform.class, "fixture", uuid);
-    }
-
-    private void startFixture(final String parentUuid,
-                              final String type,
-                              final Map<String, String> keyValue) {
-        final String uuid = keyValue.get("uuid");
-        if (Objects.isNull(uuid)) {
-            return;
+    /**
+     * Returns the test case id — the identity of the logical test case shared by every invocation: the unique id
+     * with all template invocation segments removed.
+     *
+     * @param uniqueId the unique id of the started test
+     * @return the test case id
+     */
+    private static String getTestCaseId(final UniqueId uniqueId) {
+        final List<UniqueId.Segment> segments = uniqueId.getSegments();
+        final List<UniqueId.Segment> kept = segments.stream()
+                .filter(segment -> !isInvocationSegment(segment))
+                .collect(Collectors.toList());
+        if (kept.size() == segments.size()) {
+            return uniqueId.toString();
         }
-        final String name = keyValue.getOrDefault("name", "Unknown");
-        final FixtureResult result = new FixtureResult().setName(name);
-
-        switch (type) {
-            case PREPARE:
-                getLifecycle().startBeforeFixture(scopeKey(parentUuid), fixtureKey(uuid), result);
-                return;
-            case TEAR_DOWN:
-                getLifecycle().startAfterFixture(scopeKey(parentUuid), fixtureKey(uuid), result);
-                return;
-            default:
-                LOGGER.debug("unknown fixture type {}", type);
-                break;
+        UniqueId testCaseId = UniqueId.root(kept.get(0).getType(), kept.get(0).getValue());
+        for (int i = 1; i < kept.size(); i++) {
+            testCaseId = testCaseId.append(kept.get(i));
         }
-
+        return testCaseId.toString();
     }
 
-    private void failFixture(final Map<String, String> keyValue) {
-        final String uuid = keyValue.get("uuid");
-        if (Objects.isNull(uuid)) {
-            return;
-        }
-        final AllureExternalKey fixtureKey = fixtureKey(uuid);
-        getLifecycle().updateFixture(fixtureKey, fixtureResult -> {
-            Optional.of(keyValue.get("status"))
-                    .map(Status::fromValue)
-                    .ifPresent(fixtureResult::setStatus);
-            fixtureResult.setStatusDetails(new StatusDetails());
-            Optional.of(keyValue.get("message"))
-                    .ifPresent(fixtureResult.getStatusDetails()::setMessage);
-            Optional.of(keyValue.get("trace"))
-                    .ifPresent(fixtureResult.getStatusDetails()::setTrace);
-            Optional.of(keyValue.get("actual"))
-                    .ifPresent(fixtureResult.getStatusDetails()::setActual);
-            Optional.of(keyValue.get("expected"))
-                    .ifPresent(fixtureResult.getStatusDetails()::setExpected);
-        });
-        getLifecycle().stopFixture(fixtureKey);
+    private static boolean isInvocationSegment(final UniqueId.Segment segment) {
+        return TEST_TEMPLATE_INVOCATION_SEGMENT.equals(segment.getType())
+                || CLASS_TEMPLATE_INVOCATION_SEGMENT.equals(segment.getType());
     }
 
-    private void stopFixture(final Map<String, String> keyValue) {
-        final String uuid = keyValue.get("uuid");
-        if (Objects.isNull(uuid)) {
-            return;
-        }
-        final AllureExternalKey fixtureKey = fixtureKey(uuid);
-        getLifecycle().updateFixture(fixtureKey, fixtureResult -> fixtureResult.setStatus(PASSED));
-        getLifecycle().stopFixture(fixtureKey);
-    }
-
-    private void startTest(final TestIdentifier testIdentifier) {
-        final String uuid = getOrCreateTest(testIdentifier);
-
+    private void startTest(final TestIdentifier testIdentifier,
+                           final List<AllureExternalKey> scopeKeys) {
         final Optional<TestSource> testSource = testIdentifier.getSource();
         final Optional<Method> testMethod = testSource
                 .flatMap(AllureJunitPlatformUtils::getTestMethod);
         final Optional<Class<?>> testClass = testSource
                 .flatMap(AllureJunitPlatformUtils::getTestClass);
 
-        final boolean testTemplate = "test-template-invocation"
-                .equals(testIdentifier.getUniqueIdObject().getLastSegment().getType());
+        final UniqueId uniqueId = testIdentifier.getUniqueIdObject();
+        final boolean testTemplate = TEST_TEMPLATE_INVOCATION_SEGMENT
+                .equals(uniqueId.getLastSegment().getType());
+        final boolean parameterized = uniqueId.getSegments().stream()
+                .anyMatch(AllureJunitPlatform::isInvocationSegment);
 
         final Optional<TestIdentifier> maybeParent = Optional.of(testPlanStorage)
                 .map(ThreadLocal::get)
                 .flatMap(tp -> tp.getParent(testIdentifier));
 
         final TestResult result = new TestResult()
-                .setUuid(uuid)
-                .setName(
-                        testTemplate && maybeParent.isPresent()
-                                ? maybeParent.get().getDisplayName() + " " + testIdentifier.getDisplayName()
-                                : testIdentifier.getDisplayName()
-                )
+                .setName(getName(testIdentifier, testTemplate, maybeParent))
                 .setTitlePath(getTitlePath(testIdentifier, testClass))
                 .setLabels(getTags(testIdentifier))
-                .setTestCaseId(
-                        testTemplate
-                                ? maybeParent.map(TestIdentifier::getUniqueId)
-                                        .orElseGet(testIdentifier::getUniqueId)
-                                : testIdentifier.getUniqueId()
-                )
+                .setTestCaseId(getTestCaseId(uniqueId))
                 .setTestCaseName(
                         testTemplate
                                 ? maybeParent.map(TestIdentifier::getDisplayName)
@@ -639,9 +554,9 @@ public class AllureJunitPlatform implements TestExecutionListener {
                 )
                 .setHistoryId(getHistoryId(testIdentifier));
 
-        if (testTemplate) {
+        if (parameterized) {
             // history id is ignored in Allure TestOps, so we add a hidden parameter
-            // to make sure different results are not considered as retries
+            // to make sure results of different invocations are not considered as retries
             result.getParameters().add(
                     new Parameter()
                             .setMode(Parameter.Mode.HIDDEN)
@@ -710,20 +625,15 @@ public class AllureJunitPlatform implements TestExecutionListener {
                 )
         );
 
-        final AllureExternalKey testKey = testKey(uuid);
-        getLifecycle().scheduleTest(testKey, result);
+        final AllureExternalKey testKey = testKey(testIdentifier.getUniqueId());
+        getLifecycle().scheduleTest(scopeKeys, testKey, result);
         getLifecycle().startTest(testKey);
     }
 
     private void stopTest(final TestIdentifier testIdentifier,
                           final Status status,
                           final StatusDetails statusDetails) {
-        final Optional<String> maybeUuid = getTest(testIdentifier);
-        if (!maybeUuid.isPresent()) {
-            return;
-        }
-        final String uuid = maybeUuid.get();
-        final AllureExternalKey testKey = testKey(uuid);
+        final AllureExternalKey testKey = testKey(testIdentifier.getUniqueId());
         getLifecycle().updateTest(testKey, result -> {
             if (!testIdentifier.isTest()) {
                 result.getLabels().add(new Label().setName(ALLURE_ID_LABEL_NAME).setValue("-1"));
@@ -889,46 +799,4 @@ public class AllureJunitPlatform implements TestExecutionListener {
         return label;
     }
 
-    private Optional<String> getContainer(final TestIdentifier testIdentifier) {
-        return containers.get().get(testIdentifier);
-    }
-
-    private String getOrCreateContainer(final TestIdentifier testIdentifier) {
-        return containers.get().getOrCreate(testIdentifier);
-    }
-
-    private Optional<String> getTest(final TestIdentifier testIdentifier) {
-        return tests.get().get(testIdentifier);
-    }
-
-    private String getOrCreateTest(final TestIdentifier testIdentifier) {
-        return tests.get().getOrCreate(testIdentifier);
-    }
-
-    /**
-     * Thread-safe registry of the Allure uuids assigned to JUnit Platform test identifiers within one launch.
-     */
-    private static final class Uuids {
-
-        private final Map<TestIdentifier, String> storage = new ConcurrentHashMap<>();
-        private final ReadWriteLock lock = new ReentrantReadWriteLock();
-
-        private Optional<String> get(final TestIdentifier testIdentifier) {
-            try {
-                lock.readLock().lock();
-                return Optional.ofNullable(storage.get(testIdentifier));
-            } finally {
-                lock.readLock().unlock();
-            }
-        }
-
-        private String getOrCreate(final TestIdentifier testIdentifier) {
-            try {
-                lock.writeLock().lock();
-                return storage.computeIfAbsent(testIdentifier, ti -> UUID.randomUUID().toString());
-            } finally {
-                lock.writeLock().unlock();
-            }
-        }
-    }
 }

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
@@ -47,12 +47,12 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -489,8 +489,10 @@ public class AllureJunitPlatform implements TestExecutionListener {
         // prefix the name with parameterized class invocation display names, so results
         // of the same method from different invocations are distinguishable
         final String prefix = getParents(testIdentifier).stream()
-                .filter(parent -> CLASS_TEMPLATE_INVOCATION_SEGMENT
-                        .equals(parent.getUniqueIdObject().getLastSegment().getType()))
+                .filter(
+                        parent -> CLASS_TEMPLATE_INVOCATION_SEGMENT
+                                .equals(parent.getUniqueIdObject().getLastSegment().getType())
+                )
                 .map(TestIdentifier::getDisplayName)
                 .collect(Collectors.joining(" "));
         return prefix.isEmpty() ? baseName : prefix + " " + baseName;

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -33,6 +33,7 @@ import io.qameta.allure.junitplatform.features.NestedTests;
 import io.qameta.allure.junitplatform.features.OneTest;
 import io.qameta.allure.junitplatform.features.OwnerTest;
 import io.qameta.allure.junitplatform.features.ParallelTests;
+import io.qameta.allure.junitplatform.features.ParameterisedClassTests;
 import io.qameta.allure.junitplatform.features.ParameterisedTests;
 import io.qameta.allure.junitplatform.features.ParameterisedTestsWithDisplayName;
 import io.qameta.allure.junitplatform.features.PassedTests;
@@ -51,6 +52,7 @@ import io.qameta.allure.junitplatform.features.TestWithDescription;
 import io.qameta.allure.junitplatform.features.TestWithDisplayName;
 import io.qameta.allure.junitplatform.features.TestWithMethodLabels;
 import io.qameta.allure.junitplatform.features.TestWithMethodLinks;
+import io.qameta.allure.junitplatform.features.TestWithPublishedFile;
 import io.qameta.allure.junitplatform.features.TestWithSteps;
 import io.qameta.allure.junitplatform.features.TestWithSystemErr;
 import io.qameta.allure.junitplatform.features.TestWithSystemOut;
@@ -63,11 +65,13 @@ import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.model.StepResult;
 import io.qameta.allure.model.TestResult;
+import io.qameta.allure.model.TestResultContainer;
 import io.qameta.allure.test.AllureFeatures;
 import io.qameta.allure.test.AllureResults;
 import io.qameta.allure.test.IsolatedLifecycle;
 import io.qameta.allure.test.RunUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.launcher.Launcher;
@@ -76,9 +80,11 @@ import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static io.qameta.allure.junitplatform.AllureJunitPlatform.JUNIT_PLATFORM_UNIQUE_ID;
 import static io.qameta.allure.junitplatform.AllureJunitPlatformTestUtils.runClasses;
@@ -976,5 +982,136 @@ public class AllureJunitPlatformTest {
                         tuple("feature", "Feature 2"),
                         tuple("story", "Story 1")
                 );
+    }
+
+    @AllureFeatures.Attachments
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    @Test
+    void shouldAttachPublishedFiles(@TempDir final Path outputDir) {
+        final AllureResults results = RunUtils.runTests(lifecycle -> {
+            final LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                    .selectors(DiscoverySelectors.selectClass(TestWithPublishedFile.class))
+                    .configurationParameter("junit.platform.reporting.output.dir", outputDir.toString())
+                    .build();
+            final LauncherConfig config = LauncherConfig.builder()
+                    .enableTestExecutionListenerAutoRegistration(false)
+                    .addTestExecutionListeners(new AllureJunitPlatform(lifecycle))
+                    .build();
+            LauncherFactory.create(config).execute(request);
+        });
+
+        final List<Attachment> attachments = results.getAttachmentsRecursively();
+
+        assertThat(attachments)
+                .extracting(Attachment::getName, Attachment::getType)
+                .contains(
+                        tuple("published-file.txt", "text/plain")
+                );
+
+        final Attachment found = attachments.stream()
+                .filter(attachment -> "published-file.txt".equals(attachment.getName()))
+                .findAny()
+                .get();
+
+        assertThat(found.getSource())
+                .endsWith(".txt");
+
+        assertThat(results.getAttachments())
+                .containsKeys(found.getSource());
+
+        assertThat(results.getAttachmentContentAsString(found))
+                .isEqualTo("PUBLISHED FILE CONTENT");
+    }
+
+    @Test
+    @AllureFeatures.Parameters
+    void shouldProcessParameterizedClassInvocations() {
+        final AllureResults results = runClasses(ParameterisedClassTests.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(4);
+
+        // invocation display names make results of the same method distinguishable
+        final List<String> firstNames = testResults.stream()
+                .map(TestResult::getName)
+                .filter(name -> name.endsWith("first()"))
+                .collect(Collectors.toList());
+        assertThat(firstNames)
+                .hasSize(2)
+                .doesNotHaveDuplicates()
+                .allMatch(name -> name.startsWith("["));
+
+        // invocations of the same method share a test case id free of invocation segments
+        final List<String> firstCaseIds = testResults.stream()
+                .filter(testResult -> testResult.getName().endsWith("first()"))
+                .map(TestResult::getTestCaseId)
+                .collect(Collectors.toList());
+        assertThat(firstCaseIds)
+                .hasSize(2)
+                .containsOnly(firstCaseIds.get(0));
+        assertThat(firstCaseIds.get(0))
+                .doesNotContain("class-template-invocation")
+                .contains("[method:first()]");
+
+        final List<String> secondCaseIds = testResults.stream()
+                .filter(testResult -> testResult.getName().endsWith("second()"))
+                .map(TestResult::getTestCaseId)
+                .collect(Collectors.toList());
+        assertThat(secondCaseIds)
+                .doesNotContain(firstCaseIds.get(0));
+
+        // every invocation carries a distinct hidden UniqueId parameter
+        final List<Parameter> uniqueIdParameters = testResults.stream()
+                .flatMap(testResult -> testResult.getParameters().stream())
+                .filter(parameter -> "UniqueId".equals(parameter.getName()))
+                .collect(Collectors.toList());
+        assertThat(uniqueIdParameters)
+                .hasSize(4)
+                .allMatch(parameter -> Parameter.Mode.HIDDEN.equals(parameter.getMode()));
+        assertThat(uniqueIdParameters)
+                .extracting(Parameter::getValue)
+                .doesNotHaveDuplicates();
+    }
+
+    @Test
+    @AllureFeatures.Fixtures
+    void shouldLinkTestsToTheirScopes() {
+        final AllureResults results = runClasses(PassedTests.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(3);
+
+        final List<String> uuids = testResults.stream()
+                .map(TestResult::getUuid)
+                .collect(Collectors.toList());
+
+        final List<TestResultContainer> containers = results.getTestResultContainers();
+
+        // the class scope references every test of the class
+        assertThat(containers)
+                .filteredOn(container -> container.getChildren().containsAll(uuids))
+                .hasSize(1);
+
+        // every test also gets a method scope of its own
+        uuids.forEach(uuid -> assertThat(containers)
+                .filteredOn(container -> container.getChildren().equals(List.of(uuid)))
+                .hasSize(1));
+    }
+
+    @Test
+    @AllureFeatures.Fixtures
+    void shouldLinkFailedContainerFakeTestToItsScope() {
+        final AllureResults results = runClasses(BrokenInBeforeAllTests.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1);
+
+        final String uuid = testResults.get(0).getUuid();
+        assertThat(results.getTestResultContainers())
+                .filteredOn(container -> container.getChildren().contains(uuid))
+                .hasSize(1);
     }
 }

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -1095,9 +1095,11 @@ public class AllureJunitPlatformTest {
                 .hasSize(1);
 
         // every test also gets a method scope of its own
-        uuids.forEach(uuid -> assertThat(containers)
-                .filteredOn(container -> container.getChildren().equals(List.of(uuid)))
-                .hasSize(1));
+        uuids.forEach(
+                uuid -> assertThat(containers)
+                        .filteredOn(container -> container.getChildren().equals(List.of(uuid)))
+                        .hasSize(1)
+        );
     }
 
     @Test

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/ParameterisedClassTests.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/ParameterisedClassTests.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@ParameterizedClass
+@ValueSource(strings = {"a", "b"})
+public class ParameterisedClassTests {
+
+    @SuppressWarnings("unused")
+    private final String value;
+
+    public ParameterisedClassTests(final String value) {
+        this.value = value;
+    }
+
+    @Test
+    void first() {
+    }
+
+    @Test
+    void second() {
+    }
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/TestWithPublishedFile.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/TestWithPublishedFile.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import org.junit.jupiter.api.MediaType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestReporter;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class TestWithPublishedFile {
+
+    @Test
+    void testWithPublishedFile(final TestReporter testReporter) {
+        testReporter.publishFile(
+                "published-file.txt",
+                MediaType.TEXT_PLAIN,
+                path -> Files.write(path, "PUBLISHED FILE CONTENT".getBytes(StandardCharsets.UTF_8))
+        );
+    }
+}

--- a/allure-jupiter/build.gradle.kts
+++ b/allure-jupiter/build.gradle.kts
@@ -3,6 +3,7 @@ description = "Allure Jupiter Integration"
 dependencies {
     api(project(":allure-junit-platform"))
     compileOnly("org.junit.jupiter:junit-jupiter-api")
+    compileOnly("org.junit.jupiter:junit-jupiter-params")
     compileOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("io.github.glytching:junit-extensions")
     testImplementation("org.assertj:assertj-core")

--- a/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiter.java
+++ b/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiter.java
@@ -15,46 +15,70 @@
  */
 package io.qameta.allure.jupiter;
 
-import io.qameta.allure.Param;
+import io.qameta.allure.Allure;
+import io.qameta.allure.AllureExternalKey;
+import io.qameta.allure.AllureLifecycle;
+import io.qameta.allure.junitplatform.AllureJunitPlatform;
+import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Status;
-import io.qameta.allure.model.StatusDetails;
-import io.qameta.allure.util.ObjectUtils;
+import io.qameta.allure.util.ParameterUtils;
 import io.qameta.allure.util.ResultsUtils;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.stream.Stream;
-
-import static io.qameta.allure.junitplatform.AllureJunitPlatform.ALLURE_FIXTURE;
-import static io.qameta.allure.junitplatform.AllureJunitPlatform.ALLURE_PARAMETER;
-import static io.qameta.allure.junitplatform.AllureJunitPlatform.ALLURE_PARAMETER_EXCLUDED_KEY;
-import static io.qameta.allure.junitplatform.AllureJunitPlatform.ALLURE_PARAMETER_MODE_KEY;
-import static io.qameta.allure.junitplatform.AllureJunitPlatform.ALLURE_PARAMETER_VALUE_KEY;
-import static io.qameta.allure.junitplatform.AllureJunitPlatform.ALLURE_REPORT_ENTRY_BLANK_PREFIX;
-import static io.qameta.allure.junitplatform.AllureJunitPlatform.EVENT_FAILURE;
-import static io.qameta.allure.junitplatform.AllureJunitPlatform.EVENT_START;
-import static io.qameta.allure.junitplatform.AllureJunitPlatform.EVENT_STOP;
-import static io.qameta.allure.junitplatform.AllureJunitPlatform.PREPARE;
-import static io.qameta.allure.junitplatform.AllureJunitPlatform.TEAR_DOWN;
 
 /**
- * Reports JUnit Jupiter fixture execution details to Allure.
+ * Reports JUnit Jupiter fixture and parameter execution details to Allure.
  *
- * <p>Register this extension when Jupiter lifecycle methods should appear as Allure fixtures with start, stop, and failure metadata.</p>
+ * <p>Register this extension together with {@link AllureJunitPlatform} when Jupiter lifecycle methods should appear
+ * as Allure fixtures and parameterized-test arguments as Allure parameters. The extension writes through the Allure
+ * lifecycle directly, addressing the scopes and tests started by the listener with keys recomputed from the JUnit
+ * Platform unique ids — see {@link AllureJunitPlatform#scopeKey(String)} and
+ * {@link AllureJunitPlatform#testKey(String)}.</p>
  */
-@SuppressWarnings("MultipleStringLiterals")
 public class AllureJupiter implements InvocationInterceptor {
 
     private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(AllureJupiter.class);
+
+    private static final String TEST = "test";
+    private static final String TEMPLATE = "template";
+    private static final String PREPARE = "prepare";
+    private static final String TEAR_DOWN = "tear_down";
+
+    // parameterized class support requires the ParameterInfo API of junit-jupiter-params 6.x
+    private static final boolean CLASS_PARAMETERS_SUPPORTED =
+            isClassAvailableOnClasspath("org.junit.jupiter.params.ParameterInfo");
+
+    /**
+     * Returns the lifecycle. Resolved at call time, so the extension follows process-wide lifecycle swaps.
+     *
+     * @return the Allure lifecycle used by this integration
+     */
+    protected AllureLifecycle getLifecycle() {
+        return Allure.getLifecycle();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void interceptTestMethod(final Invocation<Void> invocation,
+                                    final ReflectiveInvocationContext<Method> invocationContext,
+                                    final ExtensionContext extensionContext)
+            throws Throwable {
+        if (!shouldHandle(extensionContext, TEST, invocationContext.getExecutable())) {
+            invocation.proceed();
+            return;
+        }
+        addParameters(extensionContext, getClassParameters(invocationContext, extensionContext));
+        invocation.proceed();
+    }
 
     /**
      * {@inheritDoc}
@@ -64,22 +88,46 @@ public class AllureJupiter implements InvocationInterceptor {
                                             final ReflectiveInvocationContext<Method> invocationContext,
                                             final ExtensionContext extensionContext)
             throws Throwable {
-        if (!shouldHandle(extensionContext, "template", invocationContext.getExecutable())) {
+        if (!shouldHandle(extensionContext, TEMPLATE, invocationContext.getExecutable())) {
             invocation.proceed();
             return;
         }
-        sendParameterEvent(invocationContext, extensionContext);
+        final List<Parameter> testParameters
+                = new ArrayList<>(getClassParameters(invocationContext, extensionContext));
+        testParameters.addAll(getArgumentParameters(invocationContext));
+        addParameters(extensionContext, testParameters);
         invocation.proceed();
     }
 
-    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-    private void sendParameterEvent(final ReflectiveInvocationContext<Method> invocationContext,
-                                    final ExtensionContext extensionContext) {
-        final Parameter[] parameters = invocationContext.getExecutable().getParameters();
+    private void addParameters(final ExtensionContext extensionContext,
+                               final List<Parameter> testParameters) {
+        if (testParameters.isEmpty()) {
+            return;
+        }
+        getLifecycle().updateTest(
+                AllureJunitPlatform.testKey(extensionContext.getUniqueId()),
+                testResult -> testResult.getParameters().addAll(testParameters)
+        );
+    }
+
+    private List<Parameter> getClassParameters(final ReflectiveInvocationContext<Method> invocationContext,
+                                               final ExtensionContext extensionContext) {
+        if (!CLASS_PARAMETERS_SUPPORTED) {
+            return Collections.emptyList();
+        }
+        return AllureJupiterParameterInfoSupport.getClassParameters(
+                extensionContext,
+                invocationContext.getExecutable()
+        );
+    }
+
+    private List<Parameter> getArgumentParameters(final ReflectiveInvocationContext<Method> invocationContext) {
+        final java.lang.reflect.Parameter[] parameters = invocationContext.getExecutable().getParameters();
         final List<Object> arguments = invocationContext.getArguments();
+        final List<Parameter> testParameters = new ArrayList<>();
         int argumentIndex = 0;
 
-        for (final Parameter parameter : parameters) {
+        for (final java.lang.reflect.Parameter parameter : parameters) {
             final Class<?> parameterType = parameter.getType();
 
             // Skip JUnit injectables AND synthetic parameters
@@ -90,24 +138,17 @@ public class AllureJupiter implements InvocationInterceptor {
             }
 
             final Object value = arguments.get(argumentIndex++);
-            final Map<String, String> map = new HashMap<>();
-            map.put(ALLURE_PARAMETER, parameter.getName());
-            map.put(ALLURE_PARAMETER_VALUE_KEY, ObjectUtils.toString(value));
+            testParameters.add(ParameterUtils.createParameter(parameter, value));
+        }
+        return testParameters;
+    }
 
-            Stream.of(parameter.getAnnotationsByType(Param.class))
-                    .findFirst()
-                    .ifPresent(param -> {
-                        Stream.of(param.value(), param.name())
-                                .map(String::trim)
-                                .filter(name -> !name.isEmpty())
-                                .findFirst()
-                                .ifPresent(name -> map.put(ALLURE_PARAMETER, name));
-
-                        map.put(ALLURE_PARAMETER_MODE_KEY, param.mode().name());
-                        map.put(ALLURE_PARAMETER_EXCLUDED_KEY, Boolean.toString(param.excluded()));
-                    });
-
-            extensionContext.publishReportEntry(wrap(map));
+    private static boolean isClassAvailableOnClasspath(final String clazz) {
+        try {
+            Class.forName(clazz, false, AllureJupiter.class.getClassLoader());
+            return true;
+        } catch (Exception ignored) {
+            return false;
         }
     }
 
@@ -160,9 +201,11 @@ public class AllureJupiter implements InvocationInterceptor {
     }
 
     /**
-     * Handles the process fixture callback.
+     * Runs a Jupiter lifecycle method as an Allure fixture of the scope registered for the current extension
+     * context. The fixture is stopped in every case; on failure its status and details are taken from the thrown
+     * exception, which is then rethrown.
      *
-     * @param type the event or label type
+     * @param type the fixture type, {@code prepare} for before fixtures, {@code tear_down} for after fixtures
      * @param invocation the invocation
      * @param invocationContext the invocation context
      * @param extensionContext the extension context
@@ -177,120 +220,29 @@ public class AllureJupiter implements InvocationInterceptor {
             invocation.proceed();
             return;
         }
-        final String uuid = UUID.randomUUID().toString();
+        final AllureLifecycle lifecycle = getLifecycle();
+        final AllureExternalKey scopeKey = AllureJunitPlatform.scopeKey(extensionContext.getUniqueId());
+        final AllureExternalKey fixtureKey = AllureExternalKey.random(AllureJupiter.class);
+        final FixtureResult fixtureResult = new FixtureResult()
+                .setName(invocationContext.getExecutable().getName());
+        if (PREPARE.equals(type)) {
+            lifecycle.startBeforeFixture(scopeKey, fixtureKey, fixtureResult);
+        } else {
+            lifecycle.startAfterFixture(scopeKey, fixtureKey, fixtureResult);
+        }
         try {
-            extensionContext.publishReportEntry(
-                    wrap(
-                            buildStartEvent(
-                                    type,
-                                    uuid,
-                                    invocationContext.getExecutable()
-                            )
-                    )
-            );
             invocation.proceed();
-            extensionContext.publishReportEntry(
-                    wrap(
-                            buildStopEvent(
-                                    type,
-                                    uuid
-                            )
-                    )
-            );
+            lifecycle.updateFixture(fixtureKey, fixture -> fixture.setStatus(Status.PASSED));
         } catch (Throwable throwable) {
-            extensionContext.publishReportEntry(
-                    wrap(
-                            buildFailureEvent(
-                                    type,
-                                    uuid,
-                                    throwable
-                            )
-                    )
-            );
+            lifecycle.updateFixture(fixtureKey, fixture -> {
+                ResultsUtils.getStatus(throwable).ifPresent(fixture::setStatus);
+                ResultsUtils.getStatusDetails(throwable).ifPresent(fixture::setStatusDetails);
+            });
             throw throwable;
+        } finally {
+            // also restores the thread binding saved at fixture start
+            lifecycle.stopFixture(fixtureKey);
         }
-    }
-
-    /**
-     * Builds and returns the start event.
-     *
-     * @param type the event or label type
-     * @param uuid the Allure UUID of the model object
-     * @param method the framework or Java method to inspect
-     * @return the start event
-     */
-    public Map<String, String> buildStartEvent(final String type,
-                                               final String uuid,
-                                               final Method method) {
-        final Map<String, String> map = new HashMap<>();
-        map.put(ALLURE_FIXTURE, type);
-        map.put("event", EVENT_START);
-        map.put("uuid", uuid);
-        map.put("name", method.getName());
-        return map;
-    }
-
-    /**
-     * Builds and returns the stop event.
-     *
-     * @param type the event or label type
-     * @param uuid the Allure UUID of the model object
-     * @return the stop event
-     */
-    public Map<String, String> buildStopEvent(final String type,
-                                              final String uuid) {
-        final Map<String, String> map = new HashMap<>();
-        map.put(ALLURE_FIXTURE, type);
-        map.put("event", EVENT_STOP);
-        map.put("uuid", uuid);
-        return map;
-    }
-
-    /**
-     * Builds and returns the failure event.
-     *
-     * @param type the event or label type
-     * @param uuid the Allure UUID of the model object
-     * @param throwable the throwable
-     * @return the failure event
-     */
-    public Map<String, String> buildFailureEvent(final String type,
-                                                 final String uuid,
-                                                 final Throwable throwable) {
-        final Map<String, String> map = new HashMap<>();
-        map.put(ALLURE_FIXTURE, type);
-        map.put("event", EVENT_FAILURE);
-        map.put("uuid", uuid);
-
-        final Optional<Status> maybeStatus = ResultsUtils.getStatus(throwable);
-        maybeStatus.map(Status::value).ifPresent(status -> map.put("status", status));
-
-        final Optional<StatusDetails> maybeDetails = ResultsUtils.getStatusDetails(throwable);
-        maybeDetails.map(StatusDetails::getMessage).ifPresent(message -> map.put("message", message));
-        maybeDetails.map(StatusDetails::getTrace).ifPresent(trace -> map.put("trace", trace));
-        maybeDetails.map(StatusDetails::getActual).ifPresent(actual -> map.put("actual", actual));
-        maybeDetails.map(StatusDetails::getExpected).ifPresent(expected -> map.put("expected", expected));
-        return map;
-    }
-
-    /**
-     * Returns the wrap.
-     *
-     * @param data the data map to wrap or process
-     * @return the wrap
-     */
-    @SuppressWarnings("PMD.InefficientEmptyStringCheck")
-    public Map<String, String> wrap(final Map<String, String> data) {
-        final Map<String, String> res = new HashMap<>();
-        data.forEach((key, value) -> {
-            if (Objects.isNull(value) || value.trim().isEmpty()) {
-                res.put(key, ALLURE_REPORT_ENTRY_BLANK_PREFIX + value);
-            } else {
-                res.put(key, value);
-            }
-        }
-        );
-        return res;
     }
 
     private boolean shouldHandle(final ExtensionContext extensionContext,

--- a/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiter.java
+++ b/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiter.java
@@ -52,8 +52,7 @@ public class AllureJupiter implements InvocationInterceptor {
     private static final String TEAR_DOWN = "tear_down";
 
     // parameterized class support requires the ParameterInfo API of junit-jupiter-params 6.x
-    private static final boolean CLASS_PARAMETERS_SUPPORTED =
-            isClassAvailableOnClasspath("org.junit.jupiter.params.ParameterInfo");
+    private static final boolean CLASS_PARAMETERS_SUPPORTED = isClassAvailableOnClasspath("org.junit.jupiter.params.ParameterInfo");
 
     /**
      * Returns the lifecycle. Resolved at call time, so the extension follows process-wide lifecycle swaps.
@@ -92,8 +91,7 @@ public class AllureJupiter implements InvocationInterceptor {
             invocation.proceed();
             return;
         }
-        final List<Parameter> testParameters
-                = new ArrayList<>(getClassParameters(invocationContext, extensionContext));
+        final List<Parameter> testParameters = new ArrayList<>(getClassParameters(invocationContext, extensionContext));
         testParameters.addAll(getArgumentParameters(invocationContext));
         addParameters(extensionContext, testParameters);
         invocation.proceed();

--- a/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiterParameterInfoSupport.java
+++ b/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiterParameterInfoSupport.java
@@ -77,11 +77,13 @@ import java.util.Set;
             if (index < 0 || index >= arguments.size()) {
                 continue;
             }
-            result.add(ParameterUtils.createParameter(
-                    declaration.getAnnotatedElement(),
-                    arguments.get(index),
-                    declaration.getParameterName().orElse("arg" + index)
-            ));
+            result.add(
+                    ParameterUtils.createParameter(
+                            declaration.getAnnotatedElement(),
+                            arguments.get(index),
+                            declaration.getParameterName().orElse("arg" + index)
+                    )
+            );
         }
         return result;
     }

--- a/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiterParameterInfoSupport.java
+++ b/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiterParameterInfoSupport.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jupiter;
+
+import io.qameta.allure.model.Parameter;
+import io.qameta.allure.util.ParameterUtils;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterInfo;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.support.ParameterDeclaration;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Reads the JUnit Jupiter {@link ParameterInfo} API to report parameterized class arguments. The API exists since
+ * junit-jupiter-params 6.0 — every reference to it stays inside this class, which is loaded only after a classpath
+ * check.
+ */
+/* package-private */ final class AllureJupiterParameterInfoSupport {
+
+    private AllureJupiterParameterInfoSupport() {
+        throw new IllegalStateException("do not instance");
+    }
+
+    /**
+     * Collects the arguments of every enclosing parameterized class invocation as Allure parameters, outermost
+     * first. The test method's own arguments are excluded: they are reported from the invocation context.
+     *
+     * @param extensionContext the extension context of the running test
+     * @param testMethod       the running test method
+     * @return the class-level Allure parameters, empty when the test runs outside parameterized classes
+     */
+    static List<Parameter> getClassParameters(final ExtensionContext extensionContext,
+                                              final Method testMethod) {
+        final List<Parameter> result = new ArrayList<>();
+        final Set<ParameterInfo> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        Optional<ExtensionContext> current = Optional.of(extensionContext);
+        while (current.isPresent()) {
+            final ParameterInfo info = ParameterInfo.get(current.get());
+            if (Objects.isNull(info)) {
+                break;
+            }
+            if (visited.add(info) && !testMethod.equals(info.getDeclarations().getSourceElement())) {
+                // contexts are walked inner to outer: prepend so outer class arguments come first
+                result.addAll(0, toParameters(info));
+            }
+            current = current.get().getParent();
+        }
+        return result;
+    }
+
+    private static List<Parameter> toParameters(final ParameterInfo info) {
+        final ArgumentsAccessor arguments = info.getArguments();
+        final List<Parameter> result = new ArrayList<>();
+        for (final ParameterDeclaration declaration : info.getDeclarations().getAll()) {
+            final int index = declaration.getParameterIndex();
+            if (index < 0 || index >= arguments.size()) {
+                continue;
+            }
+            result.add(ParameterUtils.createParameter(
+                    declaration.getAnnotatedElement(),
+                    arguments.get(index),
+                    declaration.getParameterName().orElse("arg" + index)
+            ));
+        }
+        return result;
+    }
+}

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/AllureJupiterTest.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/AllureJupiterTest.java
@@ -67,8 +67,10 @@ class AllureJupiterTest {
         final List<TestResultContainer> containers = results.getTestResultContainers();
 
         final TestResultContainer classScope = containers.stream()
-                .filter(container -> container.getChildren().contains(firstTest.getUuid())
-                        && container.getChildren().contains(secondTest.getUuid()))
+                .filter(
+                        container -> container.getChildren().contains(firstTest.getUuid())
+                                && container.getChildren().contains(secondTest.getUuid())
+                )
                 .findAny()
                 .orElseThrow(() -> new AssertionError("no scope references both tests"));
         assertThat(classScope.getBefores())

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/AllureJupiterTest.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/AllureJupiterTest.java
@@ -1,0 +1,249 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jupiter;
+
+import io.qameta.allure.Step;
+import io.qameta.allure.junitplatform.AllureJunitPlatform;
+import io.qameta.allure.jupiter.features.BrokenBeforeEachTests;
+import io.qameta.allure.jupiter.features.FixtureTests;
+import io.qameta.allure.jupiter.features.NestedTemplatesTests;
+import io.qameta.allure.jupiter.features.ParamAnnotationTests;
+import io.qameta.allure.jupiter.features.ParameterizedClassTests;
+import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.Parameter;
+import io.qameta.allure.model.Status;
+import io.qameta.allure.model.TestResult;
+import io.qameta.allure.model.TestResultContainer;
+import io.qameta.allure.test.AllureFeatures;
+import io.qameta.allure.test.AllureResults;
+import io.qameta.allure.test.IsolatedLifecycle;
+import io.qameta.allure.test.RunUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.discovery.ClassSelector;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherConfig;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+@IsolatedLifecycle
+class AllureJupiterTest {
+
+    @Test
+    @AllureFeatures.Fixtures
+    void shouldReportClassAndMethodFixtures() {
+        final AllureResults results = runClasses(FixtureTests.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactlyInAnyOrder(
+                        tuple("firstTest()", Status.PASSED),
+                        tuple("secondTest()", Status.PASSED)
+                );
+
+        final TestResult firstTest = findTest(testResults, "firstTest()");
+        final TestResult secondTest = findTest(testResults, "secondTest()");
+        final List<TestResultContainer> containers = results.getTestResultContainers();
+
+        final TestResultContainer classScope = containers.stream()
+                .filter(container -> container.getChildren().contains(firstTest.getUuid())
+                        && container.getChildren().contains(secondTest.getUuid()))
+                .findAny()
+                .orElseThrow(() -> new AssertionError("no scope references both tests"));
+        assertThat(classScope.getBefores())
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .containsExactly(tuple("setUpAll", Status.PASSED));
+        assertThat(classScope.getAfters())
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .containsExactly(tuple("tearDownAll", Status.PASSED));
+
+        final TestResultContainer firstScope = findMethodScope(containers, firstTest);
+        assertThat(firstScope.getBefores())
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .containsExactly(tuple("setUp", Status.PASSED));
+        assertThat(firstScope.getAfters())
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .containsExactly(tuple("tearDown", Status.PASSED));
+
+        final TestResultContainer secondScope = findMethodScope(containers, secondTest);
+        assertThat(secondScope.getBefores())
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .containsExactly(tuple("setUp", Status.PASSED));
+        assertThat(secondScope.getAfters())
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .containsExactly(tuple("tearDown", Status.PASSED));
+    }
+
+    @Test
+    @AllureFeatures.Fixtures
+    void shouldReportFailedBeforeEachFixture() {
+        final AllureResults results = runClasses(BrokenBeforeEachTests.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1);
+
+        final TestResult testResult = testResults.get(0);
+        assertThat(testResult)
+                .hasFieldOrPropertyWithValue("name", "testWithBrokenBeforeEach()")
+                .hasFieldOrPropertyWithValue("status", Status.BROKEN);
+
+        final List<FixtureResult> befores = results.getTestResultContainers().stream()
+                .flatMap(container -> container.getBefores().stream())
+                .collect(Collectors.toList());
+        assertThat(befores)
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .containsExactly(tuple("setUp", Status.BROKEN));
+
+        final FixtureResult setUp = befores.get(0);
+        assertThat(setUp.getStatusDetails().getMessage())
+                .isEqualTo("fail in beforeEach");
+        assertThat(setUp.getStatusDetails().getTrace())
+                .contains("IllegalStateException");
+
+        final TestResultContainer methodScope = results.getTestResultContainers().stream()
+                .filter(container -> !container.getBefores().isEmpty())
+                .findAny()
+                .orElseThrow(() -> new AssertionError("no scope with the broken fixture"));
+        assertThat(methodScope.getChildren())
+                .containsExactly(testResult.getUuid());
+    }
+
+    @Test
+    @AllureFeatures.Parameters
+    void shouldReportParamAnnotationNamesAndModes() {
+        final AllureResults results = runClasses(ParamAnnotationTests.class);
+
+        final List<Parameter> parameters = results.getTestResults().stream()
+                .flatMap(testResult -> testResult.getParameters().stream())
+                .filter(parameter -> !"UniqueId".equals(parameter.getName()))
+                .collect(Collectors.toList());
+
+        assertThat(parameters)
+                .filteredOn(parameter -> !"plain value".equals(parameter.getValue()))
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getMode, Parameter::getExcluded)
+                .containsExactlyInAnyOrder(
+                        tuple("custom name", "named value", Parameter.Mode.DEFAULT, false),
+                        tuple("secret", "masked value", Parameter.Mode.MASKED, false),
+                        tuple("history key", "excluded value", Parameter.Mode.DEFAULT, true)
+                );
+
+        final Parameter plain = parameters.stream()
+                .filter(parameter -> "plain value".equals(parameter.getValue()))
+                .findAny()
+                .orElseThrow(() -> new AssertionError("parameter without @Param not reported"));
+        assertThat(plain.getName()).isNotBlank();
+        assertThat(plain.getMode()).isNull();
+        assertThat(plain.getExcluded()).isNull();
+    }
+
+    @Test
+    @AllureFeatures.Parameters
+    void shouldReportParameterizedClassArguments() {
+        final AllureResults results = runClasses(ParameterizedClassTests.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(2);
+
+        assertThat(testResults)
+                .flatExtracting(TestResult::getParameters)
+                .filteredOn(parameter -> "class arg".equals(parameter.getName()))
+                .extracting(Parameter::getValue)
+                .containsExactlyInAnyOrder("a", "b");
+
+        assertThat(testResults)
+                .extracting(TestResult::getName)
+                .doesNotHaveDuplicates()
+                .allMatch(name -> name.endsWith("classTemplateTest()"));
+    }
+
+    @Test
+    @AllureFeatures.Parameters
+    void shouldReportClassAndMethodArgumentsForNestedTemplates() {
+        final AllureResults results = runClasses(NestedTemplatesTests.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(2);
+
+        // class arguments come first, method arguments second, nothing is duplicated
+        testResults.forEach(testResult -> {
+            final List<String> visibleParameterNames = testResult.getParameters().stream()
+                    .filter(parameter -> !"UniqueId".equals(parameter.getName()))
+                    .map(Parameter::getName)
+                    .collect(Collectors.toList());
+            assertThat(visibleParameterNames)
+                    .containsExactly("outer", "inner");
+        });
+
+        assertThat(testResults)
+                .flatExtracting(TestResult::getParameters)
+                .filteredOn(parameter -> "outer".equals(parameter.getName()))
+                .extracting(Parameter::getValue)
+                .containsExactlyInAnyOrder("x", "y");
+
+        assertThat(testResults)
+                .flatExtracting(TestResult::getParameters)
+                .filteredOn(parameter -> "inner".equals(parameter.getName()))
+                .extracting(Parameter::getValue)
+                .containsExactly("inner value", "inner value");
+    }
+
+    private static TestResult findTest(final List<TestResult> testResults, final String name) {
+        return testResults.stream()
+                .filter(testResult -> name.equals(testResult.getName()))
+                .findAny()
+                .orElseThrow(() -> new AssertionError("no test result named " + name));
+    }
+
+    private static TestResultContainer findMethodScope(final List<TestResultContainer> containers,
+                                                       final TestResult testResult) {
+        return containers.stream()
+                .filter(container -> container.getChildren().equals(List.of(testResult.getUuid())))
+                .findAny()
+                .orElseThrow(() -> new AssertionError("no method scope for " + testResult.getName()));
+    }
+
+    @Step("Run classes {classes}")
+    private AllureResults runClasses(final Class<?>... classes) {
+        return RunUtils.runTests(lifecycle -> {
+            final ClassSelector[] selectors = Stream.of(classes)
+                    .map(DiscoverySelectors::selectClass)
+                    .toArray(ClassSelector[]::new);
+
+            final LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                    .configurationParameter("junit.jupiter.extensions.autodetection.enabled", "true")
+                    .selectors(selectors)
+                    .build();
+
+            final LauncherConfig config = LauncherConfig.builder()
+                    .enableTestExecutionListenerAutoRegistration(false)
+                    .addTestExecutionListeners(new AllureJunitPlatform(lifecycle))
+                    .build();
+
+            LauncherFactory.create(config).execute(request);
+        });
+    }
+}

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/BrokenBeforeEachTests.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/BrokenBeforeEachTests.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jupiter.features;
+
+import io.qameta.allure.jupiter.AllureJupiter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AllureJupiter.class)
+public class BrokenBeforeEachTests {
+
+    @BeforeEach
+    void setUp() {
+        throw new IllegalStateException("fail in beforeEach");
+    }
+
+    @Test
+    void testWithBrokenBeforeEach() {
+    }
+}

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/FixtureTests.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/FixtureTests.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jupiter.features;
+
+import io.qameta.allure.jupiter.AllureJupiter;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AllureJupiter.class)
+public class FixtureTests {
+
+    @BeforeAll
+    static void setUpAll() {
+    }
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void firstTest() {
+    }
+
+    @Test
+    void secondTest() {
+    }
+
+    @AfterEach
+    void tearDown() {
+    }
+
+    @AfterAll
+    static void tearDownAll() {
+    }
+}

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/NestedTemplatesTests.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/NestedTemplatesTests.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jupiter.features;
+
+import io.qameta.allure.Param;
+import io.qameta.allure.jupiter.AllureJupiter;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@ParameterizedClass
+@ValueSource(strings = {"x", "y"})
+@ExtendWith(AllureJupiter.class)
+public class NestedTemplatesTests {
+
+    @SuppressWarnings("unused")
+    private final String outerValue;
+
+    public NestedTemplatesTests(@Param("outer") final String outerValue) {
+        this.outerValue = outerValue;
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = "inner value")
+    void innerTest(@Param("inner") final String innerValue) {
+    }
+}

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/ParamAnnotationTests.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/ParamAnnotationTests.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jupiter.features;
+
+import io.qameta.allure.Param;
+import io.qameta.allure.jupiter.AllureJupiter;
+import io.qameta.allure.model.Parameter;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@SuppressWarnings("unused")
+@ExtendWith(AllureJupiter.class)
+public class ParamAnnotationTests {
+
+    @ParameterizedTest
+    @ValueSource(strings = "named value")
+    void namedParameter(@Param("custom name") final String value) {
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = "masked value")
+    void maskedParameter(@Param(name = "secret", mode = Parameter.Mode.MASKED) final String value) {
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = "excluded value")
+    void excludedParameter(@Param(name = "history key", excluded = true) final String value) {
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = "plain value")
+    void defaultParameter(final String value) {
+    }
+}

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/ParamAnnotationTests.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/ParamAnnotationTests.java
@@ -33,12 +33,18 @@ public class ParamAnnotationTests {
 
     @ParameterizedTest
     @ValueSource(strings = "masked value")
-    void maskedParameter(@Param(name = "secret", mode = Parameter.Mode.MASKED) final String value) {
+    void maskedParameter(@Param(
+            name = "secret",
+            mode = Parameter.Mode.MASKED
+    ) final String value) {
     }
 
     @ParameterizedTest
     @ValueSource(strings = "excluded value")
-    void excludedParameter(@Param(name = "history key", excluded = true) final String value) {
+    void excludedParameter(@Param(
+            name = "history key",
+            excluded = true
+    ) final String value) {
     }
 
     @ParameterizedTest

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/ParameterizedClassTests.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/ParameterizedClassTests.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jupiter.features;
+
+import io.qameta.allure.Param;
+import io.qameta.allure.jupiter.AllureJupiter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@ParameterizedClass
+@ValueSource(strings = {"a", "b"})
+@ExtendWith(AllureJupiter.class)
+public class ParameterizedClassTests {
+
+    @SuppressWarnings("unused")
+    private final String value;
+
+    public ParameterizedClassTests(@Param("class arg") final String value) {
+        this.value = value;
+    }
+
+    @Test
+    void classTemplateTest() {
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->
Allure reports for JUnit Platform and Jupiter now capture more of the test execution shape users expect to see. Jupiter lifecycle methods are reported as fixtures on the correct scope, including failed setup methods, and parameterized class invocations now produce distinct, readable test results.

Parameterized Jupiter tests also get richer parameter reporting, including `@Param` metadata, class-level arguments, and nested template arguments without duplication. JUnit Platform published files are attached to the current test result, so artifacts emitted through `TestReporter.publishFile` are available directly in the report.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2