### PR TITLE
Report metadata from inherited JUnit Jupiter test methods

### DIFF
--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatformUtils.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatformUtils.java
@@ -15,6 +15,7 @@
  */
 package io.qameta.allure.junitplatform;
 
+import org.junit.platform.commons.JUnitException;
 import org.junit.platform.engine.TestSource;
 import org.junit.platform.engine.support.descriptor.ClassSource;
 import org.junit.platform.engine.support.descriptor.ClasspathResourceSource;
@@ -24,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.Optional;
-import java.util.stream.Stream;
 /* package-private */ final class AllureJunitPlatformUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AllureJunitPlatformUtils.class);
@@ -81,11 +81,10 @@ import java.util.stream.Stream;
 
     static Optional<Method> getTestMethod(final MethodSource source) {
         try {
-            final Class<?> aClass = Class.forName(source.getClassName());
-            return Stream.of(aClass.getDeclaredMethods())
-                    .filter(method -> MethodSource.from(method).equals(source))
-                    .findAny();
-        } catch (ClassNotFoundException e) {
+            // resolves the method in the whole class hierarchy, including
+            // test methods inherited from super classes
+            return Optional.ofNullable(source.getJavaMethod());
+        } catch (JUnitException e) {
             LOGGER.trace("Could not get test method from method source {}", source, e);
         }
         return Optional.empty();

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -51,8 +51,11 @@ import io.qameta.allure.junitplatform.features.TestWithClassLabels;
 import io.qameta.allure.junitplatform.features.TestWithClassLinks;
 import io.qameta.allure.junitplatform.features.TestWithDescription;
 import io.qameta.allure.junitplatform.features.TestWithDisplayName;
+import io.qameta.allure.junitplatform.features.TestWithInheritedMetadata;
+import io.qameta.allure.junitplatform.features.TestWithInterfaceDefaultMetadata;
 import io.qameta.allure.junitplatform.features.TestWithMethodLabels;
 import io.qameta.allure.junitplatform.features.TestWithMethodLinks;
+import io.qameta.allure.junitplatform.features.TestWithOverriddenMetadata;
 import io.qameta.allure.junitplatform.features.TestWithPublishedFile;
 import io.qameta.allure.junitplatform.features.TestWithSteps;
 import io.qameta.allure.junitplatform.features.TestWithSystemErr;
@@ -94,6 +97,7 @@ import static io.qameta.allure.junitplatform.features.TaggedTests.METHOD_TAG;
 import static io.qameta.allure.test.AllurePredicates.hasLabel;
 import static io.qameta.allure.test.AllurePredicates.hasStatus;
 import static io.qameta.allure.util.ResultsUtils.ALLURE_ID_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.EPIC_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.FEATURE_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.HOST_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.OWNER_LABEL_NAME;
@@ -446,6 +450,89 @@ public class AllureJunitPlatformTest {
                         "story1", "story2", "story3",
                         "some-owner"
                 );
+    }
+
+    @Test
+    @AllureFeatures.MarkerAnnotations
+    @Issue("1032")
+    void shouldProcessAnnotationsOnInheritedTestMethods() {
+        final AllureResults results = runClasses(TestWithInheritedMetadata.class);
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1);
+
+        final TestResult testResult = testResults.get(0);
+        assertThat(testResult.getDescription())
+                .isEqualTo("Inherited test description");
+
+        assertThat(testResult.getLabels())
+                .extracting(Label::getName, Label::getValue)
+                .contains(
+                        tuple(EPIC_LABEL_NAME, "inherited-epic"),
+                        tuple(FEATURE_LABEL_NAME, "inherited-feature"),
+                        tuple(STORY_LABEL_NAME, "inherited-story"),
+                        tuple(OWNER_LABEL_NAME, "inherited-owner"),
+                        tuple(SEVERITY_LABEL_NAME, "critical")
+                );
+
+        assertThat(testResult.getLinks())
+                .extracting(Link::getName, Link::getUrl)
+                .contains(tuple("INHERITED-LINK", "https://example.org/inherited"));
+    }
+
+    @Test
+    @AllureFeatures.MarkerAnnotations
+    @Issue("1032")
+    void shouldProcessAnnotationsOnInterfaceDefaultTestMethods() {
+        final AllureResults results = runClasses(TestWithInterfaceDefaultMetadata.class);
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1);
+
+        final TestResult testResult = testResults.get(0);
+        assertThat(testResult.getDescription())
+                .isEqualTo("Interface default test description");
+
+        assertThat(testResult.getLabels())
+                .extracting(Label::getName, Label::getValue)
+                .contains(
+                        tuple(STORY_LABEL_NAME, "interface-story"),
+                        tuple(OWNER_LABEL_NAME, "interface-owner"),
+                        tuple(SEVERITY_LABEL_NAME, "minor")
+                );
+
+        assertThat(testResult.getLinks())
+                .extracting(Link::getName, Link::getUrl)
+                .contains(tuple("INTERFACE-LINK", "https://example.org/interface"));
+    }
+
+    @Test
+    @AllureFeatures.MarkerAnnotations
+    @Issue("1032")
+    void shouldUseOverriddenTestMethodAnnotations() {
+        final AllureResults results = runClasses(TestWithOverriddenMetadata.class);
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(1);
+
+        // the overriding method fully replaces the inherited one, so only
+        // the annotations declared on the override are reported
+        final TestResult testResult = testResults.get(0);
+        assertThat(testResult.getDescription())
+                .isEqualTo("Overridden test description");
+
+        assertThat(testResult.getLabels())
+                .extracting(Label::getName, Label::getValue)
+                .contains(tuple(STORY_LABEL_NAME, "overridden-story"))
+                .doesNotContain(
+                        tuple(STORY_LABEL_NAME, "interface-story"),
+                        tuple(OWNER_LABEL_NAME, "interface-owner"),
+                        tuple(SEVERITY_LABEL_NAME, "minor")
+                );
+
+        assertThat(testResult.getLinks())
+                .extracting(Link::getName)
+                .doesNotContain("INTERFACE-LINK");
     }
 
     @Test

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/AbstractTestWithMetadata.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/AbstractTestWithMetadata.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Epic;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Link;
+import io.qameta.allure.Owner;
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
+import io.qameta.allure.Story;
+import org.junit.jupiter.api.Test;
+
+public abstract class AbstractTestWithMetadata {
+
+    @Test
+    @Description("Inherited test description")
+    @Epic("inherited-epic")
+    @Feature("inherited-feature")
+    @Story("inherited-story")
+    @Owner("inherited-owner")
+    @Severity(SeverityLevel.CRITICAL)
+    @Link(
+            name = "INHERITED-LINK",
+            url = "https://example.org/inherited"
+    )
+    void inheritedTest() {
+    }
+
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/InterfaceWithMetadata.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/InterfaceWithMetadata.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Link;
+import io.qameta.allure.Owner;
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
+import io.qameta.allure.Story;
+import org.junit.jupiter.api.Test;
+
+public interface InterfaceWithMetadata {
+
+    @Test
+    @Description("Interface default test description")
+    @Story("interface-story")
+    @Owner("interface-owner")
+    @Severity(SeverityLevel.MINOR)
+    @Link(
+            name = "INTERFACE-LINK",
+            url = "https://example.org/interface"
+    )
+    default void interfaceDefaultTest() {
+    }
+
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/TestWithInheritedMetadata.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/TestWithInheritedMetadata.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+public class TestWithInheritedMetadata extends AbstractTestWithMetadata {
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/TestWithInterfaceDefaultMetadata.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/TestWithInterfaceDefaultMetadata.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+public class TestWithInterfaceDefaultMetadata implements InterfaceWithMetadata {
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/TestWithOverriddenMetadata.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/TestWithOverriddenMetadata.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import io.qameta.allure.Description;
+import io.qameta.allure.Story;
+import org.junit.jupiter.api.Test;
+
+public class TestWithOverriddenMetadata implements InterfaceWithMetadata {
+
+    @Test
+    @Override
+    @Description("Overridden test description")
+    @Story("overridden-story")
+    public void interfaceDefaultTest() {
+    }
+
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure JUnit Platform now preserves metadata declared on inherited Jupiter test methods. Tests inherited from abstract base classes or provided by interface default methods can report their descriptions, labels, severity, owner, and links in the generated Allure results.

When a test method is overridden, Allure now reports the metadata declared on the overriding method, so reports reflect the test that actually ran instead of leaking metadata from the inherited declaration.

fixes #1032

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2