### PR TITLE
Generate consistent history IDs from final test parameters

### DIFF
--- a/allure-citrus/src/main/java/io/qameta/allure/citrus/AllureCitrus.java
+++ b/allure-citrus/src/main/java/io/qameta/allure/citrus/AllureCitrus.java
@@ -60,6 +60,7 @@ import static io.qameta.allure.util.ResultsUtils.createSuiteLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
 import static io.qameta.allure.util.ResultsUtils.createTitlePath;
 import static io.qameta.allure.util.ResultsUtils.getProvidedLabels;
+import static io.qameta.allure.util.ResultsUtils.md5;
 
 /**
  * Reports Citrus test execution to Allure.
@@ -187,7 +188,10 @@ public class AllureCitrus implements TestListener, TestSuiteListener, TestAction
      */
     @Override
     public void onTestSkipped(final TestCase test) {
-        //do nothing
+        if (!isTestStarted(test)) {
+            startTest(test);
+        }
+        stopTest(test, Status.SKIPPED, null);
     }
 
     /**
@@ -217,9 +221,15 @@ public class AllureCitrus implements TestListener, TestSuiteListener, TestAction
     private void startTest(final TestCase testCase) {
         final AllureExternalKey testKey = createTestKey(testCase);
         final Optional<? extends Class<?>> testClass = Optional.ofNullable(testCase.getTestClass());
+        final String fullName = testClass
+                .map(Class::getName)
+                .map(className -> className + "." + testCase.getName())
+                .orElseGet(testCase::getName);
 
         final TestResult result = new TestResult()
                 .setName(testCase.getName())
+                .setFullName(fullName)
+                .setTestCaseId(md5(fullName))
                 .setTitlePath(
                         testClass
                                 .map(ResultsUtils::createTitlePathFromJavaClass)
@@ -267,7 +277,7 @@ public class AllureCitrus implements TestListener, TestSuiteListener, TestAction
                 .collect(Collectors.toList());
 
         getLifecycle().updateTest(testKey, result -> {
-            result.setParameters(parameters);
+            result.getParameters().addAll(parameters);
             result.setStatus(status);
             result.setStatusDetails(details);
         });
@@ -284,6 +294,15 @@ public class AllureCitrus implements TestListener, TestSuiteListener, TestAction
             lock.writeLock().unlock();
         }
         return testKey;
+    }
+
+    private boolean isTestStarted(final TestCase testCase) {
+        try {
+            lock.readLock().lock();
+            return testKeys.containsKey(testCase);
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     private AllureExternalKey removeTestKey(final TestCase testCase) {

--- a/allure-citrus/src/test/java/io/qameta/allure/citrus/AllureCitrusTest.java
+++ b/allure-citrus/src/test/java/io/qameta/allure/citrus/AllureCitrusTest.java
@@ -18,6 +18,7 @@ package io.qameta.allure.citrus;
 import com.consol.citrus.Citrus;
 import com.consol.citrus.CitrusContext;
 import com.consol.citrus.TestCase;
+import com.consol.citrus.TestCaseMetaInfo;
 import com.consol.citrus.actions.AbstractTestAction;
 import com.consol.citrus.actions.FailAction;
 import com.consol.citrus.context.TestContext;
@@ -27,6 +28,7 @@ import io.qameta.allure.Allure;
 import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.Step;
 import io.qameta.allure.model.Parameter;
+import io.qameta.allure.model.Stage;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.model.StepResult;
@@ -40,6 +42,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
+import static io.qameta.allure.util.ResultsUtils.md5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 @SuppressWarnings("unchecked")
@@ -201,6 +204,60 @@ class AllureCitrusTest {
                         tuple("a", "first"),
                         tuple("b", "123")
                 );
+    }
+
+    @AllureFeatures.History
+    @AllureFeatures.Parameters
+    @Test
+    void shouldCalculateIdsFromFinalNativeAndRuntimeParameters() {
+        final DefaultTestDesigner designer = new DefaultTestDesigner();
+        designer.name("Runtime parameters");
+        designer.variable("native", "example");
+        designer.action(new AbstractTestAction() {
+            @Override
+            public void doExecute(final TestContext context) {
+                Allure.parameter("runtime", "value");
+                Allure.parameter("excluded", "ignored", true);
+            }
+        });
+
+        final AllureResults results = run(designer);
+        final TestResult testResult = results.getTestResults().get(0);
+        assertThat(testResult.getParameters())
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getExcluded)
+                .containsExactlyInAnyOrder(
+                        tuple("native", "example", null),
+                        tuple("runtime", "value", null),
+                        tuple("excluded", "ignored", true)
+                );
+
+        final String fullName = DefaultTestDesigner.class.getName() + ".Runtime parameters";
+        assertThat(testResult.getTestCaseId())
+                .isEqualTo(md5(fullName));
+        assertThat(testResult.getHistoryId())
+                .isEqualTo(md5(md5(fullName) + "native" + "example" + "runtime" + "value"));
+    }
+
+    @AllureFeatures.SkippedTests
+    @AllureFeatures.History
+    @Test
+    void shouldReportDisabledTestsWithIds() {
+        final DefaultTestDesigner designer = new DefaultTestDesigner();
+        designer.name("Disabled test");
+        designer.variable("native", "value");
+        designer.status(TestCaseMetaInfo.Status.DISABLED);
+
+        final AllureResults results = run(designer);
+        final String fullName = DefaultTestDesigner.class.getName() + ".Disabled test";
+        final String testCaseId = md5(fullName);
+        assertThat(results.getTestResults())
+                .singleElement()
+                .satisfies(result -> {
+                    assertThat(result.getStatus()).isEqualTo(Status.SKIPPED);
+                    assertThat(result.getStage()).isEqualTo(Stage.FINISHED);
+                    assertThat(result.getTestCaseId()).isEqualTo(testCaseId);
+                    assertThat(result.getHistoryId()).isEqualTo(md5(testCaseId + "native" + "value"));
+                });
     }
 
     @Step("Run test case {testDesigner}")

--- a/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/AllureCucumber7Jvm.java
+++ b/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/AllureCucumber7Jvm.java
@@ -178,11 +178,7 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
         // the same way full name is generated for
         // org.junit.platform.engine.support.descriptor.ClasspathResourceSource
         // to support io.qameta.allure.junitplatform.AllurePostDiscoveryFilter
-        final String fullName = String.format(
-                "%s:%d",
-                getTestCaseUri(testCase),
-                testCase.getLocation().getLine()
-        );
+        final String fullName = getTestCaseLocation(testCase);
 
         final String testCaseUuid = testCase.getId().toString();
 
@@ -192,7 +188,6 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
         final TestResult result = new TestResult()
                 .setUuid(testCaseUuid)
                 .setTestCaseId(getTestCaseId(testCase))
-                .setHistoryId(getHistoryId(testCase))
                 .setFullName(fullName)
                 .setTitlePath(titlePath)
                 .setName(name)
@@ -205,9 +200,7 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
         );
 
         if (scenarioDefinition.getExamples() != null) {
-            result.setParameters(
-                    getExamplesAsParameters(scenarioDefinition, testCase)
-            );
+            result.getParameters().addAll(getExamplesAsParameters(scenarioDefinition, testCase));
         }
 
         final String description = Stream.of(feature.getDescription(), scenarioDefinition.getDescription())
@@ -364,9 +357,8 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
         );
     }
 
-    private String getHistoryId(final TestCase testCase) {
-        final String testCaseLocation = getTestCaseUri(testCase) + COLON + testCase.getLocation().getLine();
-        return md5(testCaseLocation);
+    private String getTestCaseLocation(final TestCase testCase) {
+        return getTestCaseUri(testCase) + COLON + testCase.getLocation().getLine();
     }
 
     private String getTestCaseId(final TestCase testCase) {

--- a/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
+++ b/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
@@ -539,7 +539,7 @@ class AllureCucumber7JvmTest {
 
         final List<TestResult> testResults = results.getTestResults();
         assertThat(testResults.get(0).getHistoryId())
-                .isEqualTo("892e5eabe51184301cf1358453c9f052");
+                .isEqualTo(md5(md5("src/test/resources/features/simple.feature:Add a to b")));
     }
 
     @AllureFeatures.History
@@ -550,7 +550,16 @@ class AllureCucumber7JvmTest {
         final List<TestResult> testResults = results.getTestResults();
         assertThat(testResults)
                 .extracting(TestResult::getHistoryId)
-                .containsExactlyInAnyOrder("c0f824814a130048e9f86358363cf23e", "646aca5d0775cd4f13161e1ea1a68c39");
+                .containsExactlyInAnyOrder(
+                        md5(
+                                md5("src/test/resources/features/examples.feature:Scenario with Positive Examples")
+                                        + "a1b3result4"
+                        ),
+                        md5(
+                                md5("src/test/resources/features/examples.feature:Scenario with Positive Examples")
+                                        + "a2b4result6"
+                        )
+                );
     }
 
     @AllureFeatures.History
@@ -779,6 +788,35 @@ class AllureCucumber7JvmTest {
                         tuple("step3", "https://example.org/step3"),
                         tuple("step4", "https://example.org/step4"),
                         tuple("step5", "https://example.org/step5")
+                );
+    }
+
+    @AllureFeatures.History
+    @AllureFeatures.Parameters
+    @Test
+    void shouldCalculateIdsFromRuntimeParametersAtTestEnd() {
+        final AllureResults results = runFeature("features/runtimeapi.feature");
+
+        final TestResult testResult = results.getTestResults().get(0);
+        assertThat(testResult.getParameters())
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getExcluded)
+                .containsExactlyInAnyOrder(
+                        tuple("runtime", "value", null),
+                        tuple("excluded", "ignored", true)
+                );
+        assertThat(testResult.getTestCaseId())
+                .isEqualTo(
+                        md5(
+                                "src/test/resources/features/runtimeapi.feature:Scenario with Runtime API usage"
+                        )
+                );
+        assertThat(testResult.getHistoryId())
+                .isEqualTo(
+                        md5(
+                                md5(
+                                        "src/test/resources/features/runtimeapi.feature:Scenario with Runtime API usage"
+                                ) + "runtimevalue"
+                        )
                 );
     }
 

--- a/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/samples/RuntimeApiSteps.java
+++ b/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/samples/RuntimeApiSteps.java
@@ -34,6 +34,8 @@ public class RuntimeApiSteps {
 
     @When("^step 1$")
     public void step1() {
+        Allure.parameter("runtime", "value");
+        Allure.parameter("excluded", "ignored", true);
         Allure.step("step1 nested");
         Allure.link("step1", "https://example.org/step1");
         Allure.getLifecycle().getCurrentRootKey().ifPresent(key -> {

--- a/allure-java-commons-test/src/main/java/io/qameta/allure/test/AllureTestCommonsUtils.java
+++ b/allure-java-commons-test/src/main/java/io/qameta/allure/test/AllureTestCommonsUtils.java
@@ -32,10 +32,15 @@ import io.qameta.allure.model.Status;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
 import static com.fasterxml.jackson.databind.MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME;
+import static io.qameta.allure.util.ResultsUtils.md5;
 
 /**
  * Provides utility methods for Allure Java test support support.
@@ -103,6 +108,31 @@ public final class AllureTestCommonsUtils {
                                 attachmentOptions(fileName)
                         )
         );
+    }
+
+    /**
+     * Calculates the compatibility history id expected in adapter tests.
+     *
+     * @param testCaseId the test case id
+     * @param parameters the final parameters
+     * @return the expected history id
+     */
+    public static String expectedHistoryId(final String testCaseId, final List<Parameter> parameters) {
+        final StringBuilder source = new StringBuilder(testCaseId);
+        final Stream<Parameter> parameterStream = Objects.isNull(parameters) ? Stream.empty() : parameters.stream();
+        parameterStream
+                .filter(Objects::nonNull)
+                .filter(parameter -> !Boolean.TRUE.equals(parameter.getExcluded()))
+                .sorted(
+                        Comparator.comparing((Parameter parameter) -> Objects.toString(parameter.getName(), ""))
+                                .thenComparing(parameter -> Objects.toString(parameter.getValue(), ""))
+                )
+                .forEachOrdered(
+                        parameter -> source
+                                .append(Objects.toString(parameter.getName(), ""))
+                                .append(Objects.toString(parameter.getValue(), ""))
+                );
+        return md5(source.toString());
     }
 
     private static AttachmentOptions attachmentOptions(final String fileName) {

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
@@ -24,6 +24,7 @@ import io.qameta.allure.listener.StepLifecycleListener;
 import io.qameta.allure.listener.TestLifecycleListener;
 import io.qameta.allure.model.Attachment;
 import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.ScopeFixtureResult;
 import io.qameta.allure.model.ScopeFixtureType;
 import io.qameta.allure.model.ScopeResult;
@@ -45,6 +46,7 @@ import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -59,11 +61,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static io.qameta.allure.AllureConstants.ATTACHMENT_FILE_SUFFIX;
 import static io.qameta.allure.util.ResultsUtils.firstNonEmpty;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
+import static io.qameta.allure.util.ResultsUtils.md5;
 import static io.qameta.allure.util.ServiceLoaderUtils.load;
 
 /**
@@ -325,8 +329,10 @@ public class AllureLifecycle {
     }
 
     /**
-     * Stops test by given key. The test must be running; scope metadata is merged into the test here. Unbinds the
-     * calling thread only if the test is the calling thread's root.
+     * Stops test by given key. The test must be running; scope metadata is merged into the test here. If the test has
+     * a test case id but no history id, a compatibility history id is generated from the test case id and the final
+     * parameters. A history id supplied by a {@link TestLifecycleListener#beforeTestStop(TestResult)} listener is
+     * preserved. Unbinds the calling thread only if the test is the calling thread's root.
      *
      * @param key the external test key
      */
@@ -347,11 +353,35 @@ public class AllureLifecycle {
         testResult
                 .setStage(Stage.FINISHED)
                 .setStop(System.currentTimeMillis());
+        if (Objects.isNull(testResult.getParameters())) {
+            testResult.setParameters(new ArrayList<>());
+        }
         applyScopeMetadata(item);
+        if (Objects.isNull(testResult.getHistoryId()) && Objects.nonNull(testResult.getTestCaseId())) {
+            testResult.setHistoryId(calculateHistoryId(testResult.getTestCaseId(), testResult.getParameters()));
+        }
         if (isCurrentRoot(key)) {
             threadContext.clear();
         }
         notifier.afterTestStop(testResult);
+    }
+
+    private static String calculateHistoryId(final String testCaseId, final List<Parameter> parameters) {
+        final StringBuilder source = new StringBuilder(testCaseId);
+        final Stream<Parameter> parameterStream = Objects.isNull(parameters) ? Stream.empty() : parameters.stream();
+        parameterStream
+                .filter(Objects::nonNull)
+                .filter(parameter -> !Boolean.TRUE.equals(parameter.getExcluded()))
+                .sorted(
+                        Comparator.comparing((Parameter parameter) -> Objects.toString(parameter.getName(), ""))
+                                .thenComparing(parameter -> Objects.toString(parameter.getValue(), ""))
+                )
+                .forEachOrdered(
+                        parameter -> source
+                                .append(Objects.toString(parameter.getName(), ""))
+                                .append(Objects.toString(parameter.getValue(), ""))
+                );
+        return md5(source.toString());
     }
 
     /**

--- a/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
@@ -15,11 +15,14 @@
  */
 package io.qameta.allure;
 
+import io.qameta.allure.listener.LifecycleNotifier;
+import io.qameta.allure.listener.TestLifecycleListener;
 import io.qameta.allure.model.Attachment;
 import io.qameta.allure.model.FixtureResult;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Parameter;
+import io.qameta.allure.model.Stage;
 import io.qameta.allure.model.StepResult;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
@@ -27,6 +30,7 @@ import io.qameta.allure.model.WithMetadata;
 import io.qameta.allure.test.AllureResults;
 import io.qameta.allure.test.IsolatedLifecycle;
 import io.qameta.allure.test.RunUtils;
+import io.qameta.allure.util.ResultsUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -189,6 +193,152 @@ class AllureLifecycleTest {
         assertThat(captor.getValue().getLabels())
                 .extracting(Label::getName, Label::getValue)
                 .containsExactly(tuple("layer", "rest"));
+    }
+
+    @Test
+    void shouldCalculateHistoryIdAfterScopeMergeForAfterStopListeners() {
+        final String testCaseId = randomId();
+        final Parameter scopeParameter = new Parameter().setName("first").setValue(randomString(10));
+        final Parameter runtimeParameter = new Parameter().setName("second").setValue(randomString(10));
+        final Parameter excludedParameter = new Parameter()
+                .setName("excluded")
+                .setValue(randomString(10))
+                .setExcluded(true);
+        final String expectedHistoryId = ResultsUtils.md5(
+                testCaseId
+                        + scopeParameter.getName() + scopeParameter.getValue()
+                        + runtimeParameter.getName() + runtimeParameter.getValue()
+        );
+        final List<String> historyIdsBeforeStop = new ArrayList<>();
+        final List<TestResult> resultsAfterStop = new ArrayList<>();
+        final TestLifecycleListener listener = new TestLifecycleListener() {
+            @Override
+            public void beforeTestStop(final TestResult result) {
+                historyIdsBeforeStop.add(result.getHistoryId());
+            }
+
+            @Override
+            public void afterTestStop(final TestResult result) {
+                resultsAfterStop.add(result);
+            }
+        };
+        lifecycle = new AllureLifecycle(
+                writer,
+                new LifecycleNotifier(List.of(), List.of(listener), List.of(), List.of())
+        );
+
+        final AllureExternalKey scopeKey = scopeKey(randomId());
+        final AllureExternalKey fixtureKey = fixtureKey(randomId());
+        final AllureExternalKey testKey = testKey(randomId());
+        lifecycle.registerScope(scopeKey);
+        lifecycle.startBeforeFixture(scopeKey, fixtureKey, new FixtureResult().setName(randomName()));
+        lifecycle.updateTestMetadata(metadata -> metadata.getParameters().add(scopeParameter));
+        lifecycle.stopFixture(fixtureKey);
+
+        lifecycle.scheduleTest(
+                List.of(scopeKey),
+                testKey,
+                new TestResult().setName(randomName()).setTestCaseId(testCaseId)
+        );
+        lifecycle.startTest(testKey);
+        lifecycle.updateTest(
+                testKey, result -> result.getParameters().addAll(
+                        List.of(runtimeParameter, excludedParameter)
+                )
+        );
+        lifecycle.stopTest(testKey);
+
+        assertThat(historyIdsBeforeStop)
+                .hasSize(1)
+                .first()
+                .isNull();
+        assertThat(resultsAfterStop)
+                .singleElement()
+                .satisfies(result -> {
+                    assertThat(result.getStage()).isEqualTo(Stage.FINISHED);
+                    assertThat(result.getParameters())
+                            .containsExactly(runtimeParameter, excludedParameter, scopeParameter);
+                    assertThat(result.getHistoryId()).isEqualTo(expectedHistoryId);
+                });
+        assertThat(lifecycle.getCurrentRootKey()).isEmpty();
+    }
+
+    @Test
+    void shouldPreserveHistoryIdProvidedByBeforeTestStopListener() {
+        final String providedHistoryId = randomId();
+        final TestLifecycleListener listener = new TestLifecycleListener() {
+            @Override
+            public void beforeTestStop(final TestResult result) {
+                result.setHistoryId(providedHistoryId);
+            }
+        };
+        lifecycle = new AllureLifecycle(
+                writer,
+                new LifecycleNotifier(List.of(), List.of(listener), List.of(), List.of())
+        );
+        final AllureExternalKey testKey = testKey(randomId());
+        lifecycle.scheduleTest(
+                testKey,
+                new TestResult()
+                        .setName(randomName())
+                        .setTestCaseId(randomId())
+        );
+        lifecycle.startTest(testKey);
+        lifecycle.updateTest(result -> result.getParameters().add(new Parameter().setName("runtime").setValue("1")));
+        lifecycle.stopTest(testKey);
+        lifecycle.writeTest(testKey);
+
+        final ArgumentCaptor<TestResult> captor = forClass(TestResult.class);
+        verify(writer).write(captor.capture());
+        assertThat(captor.getValue().getHistoryId()).isEqualTo(providedHistoryId);
+    }
+
+    @Test
+    void shouldIgnoreExcludedAndTolerateNullHistoryParameters() {
+        final String testCaseId = randomId();
+        final List<Parameter> parameters = new ArrayList<>();
+        parameters.add(null);
+        parameters.add(new Parameter());
+        parameters.add(new Parameter().setName("ignored").setValue("value").setExcluded(true));
+        parameters.add(new Parameter().setName("name"));
+        final AllureExternalKey testKey = testKey(randomId());
+        lifecycle.scheduleTest(
+                testKey,
+                new TestResult()
+                        .setName(randomName())
+                        .setTestCaseId(testCaseId)
+                        .setParameters(parameters)
+        );
+        lifecycle.startTest(testKey);
+        lifecycle.stopTest(testKey);
+        lifecycle.writeTest(testKey);
+
+        final ArgumentCaptor<TestResult> captor = forClass(TestResult.class);
+        verify(writer).write(captor.capture());
+        assertThat(captor.getValue().getHistoryId()).isEqualTo(ResultsUtils.md5(testCaseId + "name"));
+    }
+
+    @Test
+    void shouldCalculateHistoryIdAndCompleteStopWhenParametersAreNull() {
+        final String testCaseId = randomId();
+        final AllureExternalKey testKey = testKey(randomId());
+        lifecycle.scheduleTest(
+                testKey,
+                new TestResult()
+                        .setName(randomName())
+                        .setTestCaseId(testCaseId)
+                        .setParameters(null)
+        );
+        lifecycle.startTest(testKey);
+        lifecycle.stopTest(testKey);
+        lifecycle.writeTest(testKey);
+
+        final ArgumentCaptor<TestResult> captor = forClass(TestResult.class);
+        verify(writer).write(captor.capture());
+        assertThat(captor.getValue())
+                .hasFieldOrPropertyWithValue("stage", Stage.FINISHED)
+                .hasFieldOrPropertyWithValue("historyId", ResultsUtils.md5(testCaseId));
+        assertThat(lifecycle.getCurrentRootKey()).isEmpty();
     }
 
     @Test

--- a/allure-jbehave5/src/main/java/io/qameta/allure/jbehave5/AllureJbehave5.java
+++ b/allure-jbehave5/src/main/java/io/qameta/allure/jbehave5/AllureJbehave5.java
@@ -34,7 +34,6 @@ import org.jbehave.core.reporters.NullStoryReporter;
 import org.jbehave.core.steps.StepCreator;
 import org.jbehave.core.steps.Timing;
 
-import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
@@ -46,7 +45,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
-import static io.qameta.allure.util.ResultsUtils.bytesToHex;
 import static io.qameta.allure.util.ResultsUtils.createFrameworkLabel;
 import static io.qameta.allure.util.ResultsUtils.createHostLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
@@ -54,14 +52,12 @@ import static io.qameta.allure.util.ResultsUtils.createParameter;
 import static io.qameta.allure.util.ResultsUtils.createStoryLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
 import static io.qameta.allure.util.ResultsUtils.createTitlePath;
-import static io.qameta.allure.util.ResultsUtils.getMd5Digest;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static io.qameta.allure.util.ResultsUtils.md5;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
-import static java.util.Comparator.comparing;
 
 /**
  * Reports JBehave 5 story execution to Allure.
@@ -298,16 +294,14 @@ public class AllureJbehave5 extends NullStoryReporter {
 
         labels.addAll(ResultsUtils.getProvidedLabels());
 
-        final String historyId = getHistoryId(fullName, parameters);
-
         final TestResult result = new TestResult()
                 .setName(name)
                 .setFullName(fullName)
+                .setTestCaseId(md5(fullName))
                 .setTitlePath(getTitlePath(story))
                 .setLabels(labels)
                 .setParameters(parameters)
-                .setDescription(story.getDescription().asString())
-                .setHistoryId(historyId);
+                .setDescription(story.getDescription().asString());
 
         getLifecycle().scheduleTest(testKey, result);
         getLifecycle().startTest(testKey);
@@ -338,26 +332,6 @@ public class AllureJbehave5 extends NullStoryReporter {
      */
     protected boolean notParameterised(final Scenario scenario) {
         return scenario.getExamplesTable().getRowCount() == 0;
-    }
-
-    /**
-     * Returns the history id.
-     *
-     * @param fullName the fully qualified test name
-     * @param parameters the Allure parameters associated with the test
-     * @return the history id
-     */
-    protected String getHistoryId(final String fullName, final List<Parameter> parameters) {
-        final MessageDigest digest = getMd5Digest();
-        digest.update(fullName.getBytes(UTF_8));
-        parameters.stream()
-                .sorted(comparing(Parameter::getName).thenComparing(Parameter::getValue))
-                .forEachOrdered(parameter -> {
-                    digest.update(parameter.getName().getBytes(UTF_8));
-                    digest.update(parameter.getValue().getBytes(UTF_8));
-                });
-        final byte[] bytes = digest.digest();
-        return bytesToHex(bytes);
     }
 
     private boolean isGivenStory() {

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/AllureJbehave5Test.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/AllureJbehave5Test.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static io.qameta.allure.Allure.step;
+import static io.qameta.allure.util.ResultsUtils.md5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -293,10 +294,18 @@ class AllureJbehave5Test {
         assertThat(results.getTestResults())
                 .filteredOn("name", "Runtime API")
                 .flatExtracting(TestResult::getParameters)
-                .extracting(Parameter::getName, Parameter::getValue)
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getExcluded)
                 .containsExactlyInAnyOrder(
-                        tuple("test param", "param value")
+                        tuple("test param", "param value", null),
+                        tuple("excluded param", "excluded value", true)
                 );
+
+        final TestResult testResult = results.getTestResults().get(0);
+        final String fullName = "runtimeapi.story: Runtime API";
+        assertThat(testResult.getTestCaseId())
+                .isEqualTo(md5(fullName));
+        assertThat(testResult.getHistoryId())
+                .isEqualTo(md5(md5(fullName) + "test param" + "param value"));
 
         assertThat(results.getTestResults())
                 .filteredOn("name", "Runtime API")

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
@@ -50,7 +50,6 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -79,7 +78,6 @@ import static io.qameta.allure.util.ResultsUtils.createSuiteLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestClassLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestMethodLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
-import static io.qameta.allure.util.ResultsUtils.getMd5Digest;
 import static io.qameta.allure.util.ResultsUtils.getProvidedLabels;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -555,12 +553,12 @@ public class AllureJunitPlatform implements TestExecutionListener {
                                 ? maybeParent.map(TestIdentifier::getDisplayName)
                                         .orElseGet(testIdentifier::getDisplayName)
                                 : testIdentifier.getDisplayName()
-                )
-                .setHistoryId(getHistoryId(testIdentifier));
+                );
 
         if (parameterized) {
-            // history id is ignored in Allure TestOps, so we add a hidden parameter
-            // to make sure results of different invocations are not considered as retries
+            // The platform listener cannot observe Jupiter invocation arguments without the Allure Jupiter
+            // extension. Keep the full invocation id as a hidden fallback parameter so invocations that share
+            // the logical test case id can still be distinguished.
             result.getParameters().add(
                     new Parameter()
                             .setMode(Parameter.Mode.HIDDEN)
@@ -779,21 +777,6 @@ public class AllureJunitPlatform implements TestExecutionListener {
         }
         Collections.reverse(result);
         return result;
-    }
-
-    /**
-     * Returns the history id.
-     *
-     * @param testIdentifier the test identifier
-     * @return the history id
-     */
-    protected String getHistoryId(final TestIdentifier testIdentifier) {
-        return md5(testIdentifier.getUniqueId());
-    }
-
-    private String md5(final String source) {
-        final byte[] bytes = getMd5Digest().digest(source.getBytes(UTF_8));
-        return new BigInteger(1, bytes).toString(16);
     }
 
     private Optional<SeverityLevel> getSeverity(final AnnotatedElement annotatedElement) {

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -40,6 +40,7 @@ import io.qameta.allure.junitplatform.features.ParameterisedTestsWithDisplayName
 import io.qameta.allure.junitplatform.features.PassedTests;
 import io.qameta.allure.junitplatform.features.RepeatedTests;
 import io.qameta.allure.junitplatform.features.ReportEntryParameter;
+import io.qameta.allure.junitplatform.features.RuntimeParametersTest;
 import io.qameta.allure.junitplatform.features.SeverityTest;
 import io.qameta.allure.junitplatform.features.SkippedInBeforeAllTests;
 import io.qameta.allure.junitplatform.features.SkippedTests;
@@ -77,6 +78,7 @@ import io.qameta.allure.test.RunUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.launcher.Launcher;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
@@ -96,6 +98,7 @@ import static io.qameta.allure.junitplatform.features.TaggedTests.CLASS_TAG;
 import static io.qameta.allure.junitplatform.features.TaggedTests.METHOD_TAG;
 import static io.qameta.allure.test.AllurePredicates.hasLabel;
 import static io.qameta.allure.test.AllurePredicates.hasStatus;
+import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
 import static io.qameta.allure.util.ResultsUtils.ALLURE_ID_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.EPIC_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.FEATURE_LABEL_NAME;
@@ -118,6 +121,25 @@ import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
 @SuppressWarnings("unchecked")
 @IsolatedLifecycle
 public class AllureJunitPlatformTest {
+
+    @Test
+    @AllureFeatures.History
+    @AllureFeatures.Parameters
+    void shouldCalculateHistoryIdFromRuntimeParametersAtTestEnd() {
+        final AllureResults results = runClasses(RuntimeParametersTest.class);
+        final String testIdentifier = "[engine:junit-jupiter]"
+                + "/[class:io.qameta.allure.junitplatform.features.RuntimeParametersTest]"
+                + "/[method:runtimeParameters()]";
+
+        assertThat(results.getTestResults())
+                .singleElement()
+                .satisfies(result -> {
+                    assertThat(result.getName()).isEqualTo("runtimeParameters()");
+                    assertThat(result.getTestCaseId()).isEqualTo(testIdentifier);
+                    assertThat(result.getHistoryId())
+                            .isEqualTo(expectedHistoryId(result.getTestCaseId(), result.getParameters()));
+                });
+    }
 
     @Test
     @AllureFeatures.FullName
@@ -365,6 +387,33 @@ public class AllureJunitPlatformTest {
                         "testWithStringParameter(String) [1] argument = \"Hello\"",
                         "testWithStringParameter(String) [2] argument = \"World\""
                 );
+    }
+
+    @Test
+    @AllureFeatures.History
+    @AllureFeatures.Parameters
+    void shouldUseTemplateIdAndHiddenInvocationIdForHistory() {
+        final AllureResults results = runClasses(ParameterisedTests.class);
+        final List<TestResult> testResults = results.getTestResults();
+
+        assertThat(testResults).hasSize(2);
+        testResults.forEach(testResult -> {
+            assertThat(testResult.getParameters()).hasSize(1);
+            final Parameter invocationId = testResult.getParameters().get(0);
+            assertThat(invocationId.getName()).isEqualTo("UniqueId");
+            assertThat(invocationId.getMode()).isEqualTo(Parameter.Mode.HIDDEN);
+            assertThat(invocationId.getExcluded()).isNotEqualTo(true);
+
+            final String templateId = UniqueId.parse(invocationId.getValue())
+                    .removeLastSegment()
+                    .toString();
+            assertThat(testResult.getTestCaseId()).isEqualTo(templateId);
+            assertThat(testResult.getHistoryId())
+                    .isEqualTo(expectedHistoryId(templateId, testResult.getParameters()));
+        });
+        assertThat(testResults)
+                .extracting(TestResult::getHistoryId)
+                .doesNotHaveDuplicates();
     }
 
     @Test
@@ -1234,6 +1283,7 @@ public class AllureJunitPlatformTest {
     }
 
     @Test
+    @AllureFeatures.History
     @AllureFeatures.Parameters
     void shouldProcessParameterizedClassInvocations() {
         final AllureResults results = runClasses(ParameterisedClassTests.class);
@@ -1278,9 +1328,17 @@ public class AllureJunitPlatformTest {
                 .collect(Collectors.toList());
         assertThat(uniqueIdParameters)
                 .hasSize(4)
-                .allMatch(parameter -> Parameter.Mode.HIDDEN.equals(parameter.getMode()));
+                .allMatch(parameter -> Parameter.Mode.HIDDEN.equals(parameter.getMode()))
+                .allMatch(parameter -> !Boolean.TRUE.equals(parameter.getExcluded()));
         assertThat(uniqueIdParameters)
                 .extracting(Parameter::getValue)
+                .doesNotHaveDuplicates();
+        testResults.forEach(
+                testResult -> assertThat(testResult.getHistoryId())
+                        .isEqualTo(expectedHistoryId(testResult.getTestCaseId(), testResult.getParameters()))
+        );
+        assertThat(testResults)
+                .extracting(TestResult::getHistoryId)
                 .doesNotHaveDuplicates();
     }
 

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/RuntimeParametersTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/RuntimeParametersTest.java
@@ -13,23 +13,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.jbehave5.samples;
+package io.qameta.allure.junitplatform.features;
 
 import io.qameta.allure.Allure;
-import org.jbehave.core.annotations.Given;
+import org.junit.jupiter.api.Test;
 
-public class RuntimeApiSteps {
+public class RuntimeParametersTest {
 
-    @Given("runtime api")
-    public void given() {
-        Allure.label("jbehave-test-label", "some-value");
-        Allure.parameter("test param", "param value");
-        Allure.parameter("excluded param", "excluded value", true);
-        Allure.step("sub step 1");
-        Allure.step("sub step 2", () -> {
-        });
-
-        Allure.attachment("some attachment", "some content");
+    @Test
+    void runtimeParameters() {
+        Allure.parameter("runtime", "included");
+        Allure.parameter("ignored", "excluded", true);
     }
-
 }

--- a/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
+++ b/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
@@ -137,8 +137,7 @@ public class AllureJunit4 extends RunListener {
             }
         });
 
-        getLifecycle().stopTest(testKey);
-        getLifecycle().writeTest(testKey);
+        stopAndWriteTest(testKey);
     }
 
     /**
@@ -185,11 +184,10 @@ public class AllureJunit4 extends RunListener {
         final TestResult result = createTestResult(description);
         result.setStatus(Status.SKIPPED);
         result.setStatusDetails(getIgnoredMessage(description));
-        result.setStart(System.currentTimeMillis());
 
         getLifecycle().scheduleTest(testKey, result);
-        getLifecycle().stopTest(testKey);
-        getLifecycle().writeTest(testKey);
+        getLifecycle().startTest(testKey);
+        stopAndWriteTest(testKey);
     }
 
     private Optional<String> getDisplayName(final Description result) {
@@ -250,8 +248,13 @@ public class AllureJunit4 extends RunListener {
         return result;
     }
 
-    private String getHistoryId(final Description description) {
-        return md5(description.getClassName() + description.getMethodName());
+    private String getTestIdentifier(final Description description) {
+        return description.getClassName() + description.getMethodName();
+    }
+
+    private void stopAndWriteTest(final AllureExternalKey testKey) {
+        getLifecycle().stopTest(testKey);
+        getLifecycle().writeTest(testKey);
     }
 
     private String getPackage(final Class<?> testClass) {
@@ -283,7 +286,7 @@ public class AllureJunit4 extends RunListener {
                 .map(DisplayName::value).orElse(className);
 
         final TestResult testResult = new TestResult()
-                .setHistoryId(getHistoryId(description))
+                .setTestCaseId(md5(getTestIdentifier(description)))
                 .setFullName(fullName)
                 .setName(name)
                 .setTitlePath(createTitlePathFromPackageAndClass(getPackage(description.getTestClass()), suite));

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
@@ -26,6 +26,7 @@ import io.qameta.allure.junit4.samples.FilterSimpleTests;
 import io.qameta.allure.junit4.samples.IgnoredClassTest;
 import io.qameta.allure.junit4.samples.IgnoredTests;
 import io.qameta.allure.junit4.samples.OneTest;
+import io.qameta.allure.junit4.samples.RuntimeParametersTest;
 import io.qameta.allure.junit4.samples.TaggedTests;
 import io.qameta.allure.junit4.samples.TestBasedOnSampleRunner;
 import io.qameta.allure.junit4.samples.TestWithAnnotations;
@@ -34,6 +35,7 @@ import io.qameta.allure.junit4.samples.TestWithTimeout;
 import io.qameta.allure.junit4.samples.TheoriesTest;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
+import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Stage;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
@@ -56,13 +58,35 @@ import static io.qameta.allure.junit4.samples.TaggedTests.CLASS_TAG1;
 import static io.qameta.allure.junit4.samples.TaggedTests.CLASS_TAG2;
 import static io.qameta.allure.junit4.samples.TaggedTests.METHOD_TAG1;
 import static io.qameta.allure.junit4.samples.TaggedTests.METHOD_TAG2;
+import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
 import static io.qameta.allure.util.ResultsUtils.HOST_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.THREAD_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.md5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 @IsolatedLifecycle
 class AllureJunit4Test {
+
+    @Test
+    @AllureFeatures.History
+    @AllureFeatures.Parameters
+    void shouldCalculateHistoryIdFromRuntimeParametersAtTestEnd() {
+        final AllureResults results = runClasses(RuntimeParametersTest.class);
+        final String testIdentifier = RuntimeParametersTest.class.getName() + "runtimeParameters";
+        final String testCaseId = md5(testIdentifier);
+        final String historyId = expectedHistoryId(
+                testCaseId,
+                List.of(
+                        new Parameter().setName("runtime").setValue("included"),
+                        new Parameter().setName("ignored").setValue("excluded").setExcluded(true)
+                )
+        );
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getTestCaseId, TestResult::getHistoryId)
+                .containsExactly(tuple("runtimeParameters", testCaseId, historyId));
+    }
 
     @Test
     @AllureFeatures.FullName
@@ -212,8 +236,24 @@ class AllureJunit4Test {
         List<TestResult> testResults = results.getTestResults();
         assertThat(testResults)
                 .hasSize(2)
-                .flatExtracting(TestResult::getStatus)
-                .containsExactly(Status.SKIPPED, Status.SKIPPED);
+                .allSatisfy(testResult -> {
+                    assertThat(testResult.getStatus()).isEqualTo(Status.SKIPPED);
+                    assertThat(testResult.getStage()).isEqualTo(Stage.FINISHED);
+                });
+        final String ignoredTestId = md5(IgnoredTests.class.getName() + "ignoredTest");
+        final String ignoredWithDescriptionTestId = md5(
+                IgnoredTests.class.getName() + "ignoredWithDescriptionTest"
+        );
+        assertThat(testResults)
+                .extracting(TestResult::getName, TestResult::getTestCaseId, TestResult::getHistoryId)
+                .containsExactlyInAnyOrder(
+                        tuple("ignoredTest", ignoredTestId, md5(ignoredTestId)),
+                        tuple(
+                                "ignoredWithDescriptionTest",
+                                ignoredWithDescriptionTestId,
+                                md5(ignoredWithDescriptionTestId)
+                        )
+                );
     }
 
     @Test

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/RuntimeParametersTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/RuntimeParametersTest.java
@@ -13,23 +13,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.jbehave5.samples;
+package io.qameta.allure.junit4.samples;
 
 import io.qameta.allure.Allure;
-import org.jbehave.core.annotations.Given;
+import org.junit.Test;
 
-public class RuntimeApiSteps {
+public class RuntimeParametersTest {
 
-    @Given("runtime api")
-    public void given() {
-        Allure.label("jbehave-test-label", "some-value");
-        Allure.parameter("test param", "param value");
-        Allure.parameter("excluded param", "excluded value", true);
-        Allure.step("sub step 1");
-        Allure.step("sub step 2", () -> {
-        });
-
-        Allure.attachment("some attachment", "some content");
+    @Test
+    public void runtimeParameters() {
+        Allure.parameter("runtime", "included");
+        Allure.parameter("ignored", "excluded", true);
     }
-
 }

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/AllureJupiterTest.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/AllureJupiterTest.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -179,6 +180,45 @@ class AllureJupiterTest {
                 .extracting(TestResult::getName)
                 .doesNotHaveDuplicates()
                 .allMatch(name -> name.endsWith("classTemplateTest()"));
+    }
+
+    @Test
+    @AllureFeatures.History
+    @AllureFeatures.Parameters
+    void shouldUseTemplateIdAndFinalJupiterParametersForHistory() {
+        final AllureResults results = runClasses(ParameterizedClassTests.class);
+        final List<TestResult> testResults = results.getTestResults();
+
+        assertThat(testResults).hasSize(2);
+        testResults.forEach(testResult -> {
+            assertThat(testResult.getParameters())
+                    .extracting(Parameter::getName)
+                    .containsExactlyInAnyOrder("UniqueId", "class arg", "runtime", "ignored");
+            final Parameter invocationId = testResult.getParameters().stream()
+                    .filter(parameter -> "UniqueId".equals(parameter.getName()))
+                    .findAny()
+                    .orElseThrow(() -> new AssertionError("no hidden invocation id parameter"));
+            assertThat(invocationId.getMode()).isEqualTo(Parameter.Mode.HIDDEN);
+            assertThat(invocationId.getExcluded()).isNotEqualTo(true);
+            assertThat(testResult.getParameters())
+                    .filteredOn(
+                            parameter -> "class arg".equals(parameter.getName())
+                                    || "runtime".equals(parameter.getName())
+                    )
+                    .allMatch(parameter -> !Boolean.TRUE.equals(parameter.getExcluded()));
+            assertThat(testResult.getParameters())
+                    .filteredOn(parameter -> "ignored".equals(parameter.getName()))
+                    .extracting(Parameter::getExcluded)
+                    .containsExactly(true);
+            assertThat(testResult.getHistoryId())
+                    .isEqualTo(expectedHistoryId(testResult.getTestCaseId(), testResult.getParameters()));
+        });
+        assertThat(testResults)
+                .extracting(TestResult::getTestCaseId)
+                .containsOnly(testResults.get(0).getTestCaseId());
+        assertThat(testResults)
+                .extracting(TestResult::getHistoryId)
+                .doesNotHaveDuplicates();
     }
 
     @Test

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/ParameterizedClassTests.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/ParameterizedClassTests.java
@@ -15,6 +15,7 @@
  */
 package io.qameta.allure.jupiter.features;
 
+import io.qameta.allure.Allure;
 import io.qameta.allure.Param;
 import io.qameta.allure.jupiter.AllureJupiter;
 import org.junit.jupiter.api.Test;
@@ -36,5 +37,7 @@ public class ParameterizedClassTests {
 
     @Test
     void classTemplateTest() {
+        Allure.parameter("runtime", "included");
+        Allure.parameter("ignored", "excluded", true);
     }
 }

--- a/allure-karate/src/main/java/io/qameta/allure/karate/AllureKarate.java
+++ b/allure-karate/src/main/java/io/qameta/allure/karate/AllureKarate.java
@@ -132,7 +132,6 @@ public class AllureKarate implements RunListener {
                 .setName(getName(scenario, fullName))
                 .setDescription(getDescription(scenario))
                 .setTestCaseId(testCaseId)
-                .setHistoryId(md5(getHistoryId(scenario)))
                 .setTitlePath(titlePath);
 
         final List<String> labels = getTagTexts(scenario);
@@ -189,16 +188,6 @@ public class AllureKarate implements RunListener {
         return sourceSetIndex < 0 ? path : path.substring(sourceSetIndex + 1);
     }
 
-    private static String getHistoryId(final Scenario scenario) {
-        final String uniqueId = scenario.getUniqueId();
-        final String prefix = BUILD_RESOURCES.replace('/', '.');
-        if (!uniqueId.startsWith(prefix)) {
-            return uniqueId;
-        }
-        final int sourceSetIndex = uniqueId.indexOf('.', prefix.length());
-        return sourceSetIndex < 0 ? uniqueId : uniqueId.substring(sourceSetIndex + 1);
-    }
-
     private void afterScenario(final ScenarioRunEvent event) {
         final ScenarioRuntime sr = event.source();
         final String uuid = testCaseUuids.remove(sr);
@@ -233,7 +222,7 @@ public class AllureKarate implements RunListener {
         lifecycle.updateTest(testKey, tr -> {
             tr.setStatus(status);
             tr.setStatusDetails(statusDetails);
-            tr.setParameters(list);
+            tr.getParameters().addAll(list);
         });
 
         lifecycle.stopTest(testKey);

--- a/allure-karate/src/test/java/io/qameta/allure/karate/AllureKarateTest.java
+++ b/allure-karate/src/test/java/io/qameta/allure/karate/AllureKarateTest.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import static io.qameta.allure.model.Status.BROKEN;
 import static io.qameta.allure.model.Status.FAILED;
 import static io.qameta.allure.model.Status.PASSED;
+import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
 import static io.qameta.allure.util.ResultsUtils.md5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -141,6 +142,12 @@ class AllureKarateTest extends TestRunner {
                         tuple(md5("testdata/description-and-name.feature:Some api* request # comment 1"), null),
                         tuple(md5("testdata/description-and-name.feature:8"), null)
                 );
+        assertThat(results.getTestResults())
+                .allSatisfy(result -> {
+                    assertThat(result.getParameters()).isEmpty();
+                    assertThat(result.getHistoryId())
+                            .isEqualTo(expectedHistoryId(result.getTestCaseId(), result.getParameters()));
+                });
     }
 
     @Test
@@ -175,12 +182,38 @@ class AllureKarateTest extends TestRunner {
         final AllureResults results = runApi("classpath:testdata/parametrized-test.feature");
 
         assertThat(results.getTestResults())
-                .extracting(TestResult::getName, TestResult::getHistoryId)
+                .extracting(TestResult::getName)
                 .containsExactlyInAnyOrder(
-                        tuple("/login should return 200", md5("testdata.parametrized-test_1_1")),
-                        tuple("/user should return 301", md5("testdata.parametrized-test_1_2")),
-                        tuple("/pages should return 404", md5("testdata.parametrized-test_1_3"))
+                        "/login should return 200",
+                        "/user should return 301",
+                        "/pages should return 404"
                 );
+        assertThat(results.getTestResults())
+                .allSatisfy(
+                        result -> assertThat(result.getHistoryId())
+                                .isEqualTo(expectedHistoryId(result.getTestCaseId(), result.getParameters()))
+                );
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getHistoryId)
+                .doesNotHaveDuplicates();
+    }
+
+    @Test
+    void shouldCalculateIdsFromFinalNativeAndRuntimeParameters() {
+        final AllureResults results = run("classpath:testdata/runtime-api.feature");
+
+        final TestResult testResult = results.getTestResults().get(0);
+        assertThat(testResult.getParameters())
+                .extracting(Parameter::getName, Parameter::getValue, Parameter::getExcluded)
+                .containsExactlyInAnyOrder(
+                        tuple("native", "example", null),
+                        tuple("runtime", "value", null),
+                        tuple("excluded", "ignored", true)
+                );
+        assertThat(testResult.getTestCaseId())
+                .isEqualTo(md5("testdata/runtime-api.feature:Runtime parameters for example"));
+        assertThat(testResult.getHistoryId())
+                .isEqualTo(expectedHistoryId(testResult.getTestCaseId(), testResult.getParameters()));
     }
 
     @Test

--- a/allure-karate/src/test/resources/testdata/runtime-api.feature
+++ b/allure-karate/src/test/resources/testdata/runtime-api.feature
@@ -1,0 +1,10 @@
+Feature: Runtime API parameters
+
+  Scenario Outline: Runtime parameters for <native>
+    * def Allure = Java.type('io.qameta.allure.Allure')
+    * def runtime = Allure.parameter('runtime', 'value')
+    * def excluded = Allure.parameter('excluded', 'ignored', true)
+
+    Examples:
+      | native  |
+      | example |

--- a/allure-scalatest/src/main/scala/io/qameta/allure/scalatest/AllureScalatest.scala
+++ b/allure-scalatest/src/main/scala/io/qameta/allure/scalatest/AllureScalatest.scala
@@ -94,6 +94,7 @@ class AllureScalatest(val lifecycle: AllureLifecycle) extends Reporter {
     case event: TestStarting   => startTest(event)
     case event: TestFailed     => failTestCase(event)
     case event: TestCanceled   => cancelTestCase(event)
+    case event: TestPending    => pendingTestCase(event)
     case event: TestSucceeded  => passTestCase(event)
     case event: TestIgnored    => ignoreTestCase(event)
     case _                     => ()
@@ -154,6 +155,14 @@ class AllureScalatest(val lifecycle: AllureLifecycle) extends Reporter {
     )
   }
 
+  def pendingTestCase(event: TestPending): Unit = {
+    stopTest(
+      Some(Status.SKIPPED),
+      Some(new StatusDetails().setMessage("Test pending")),
+      Some(event.threadName)
+    )
+  }
+
   def ignoreTestCase(event: TestIgnored): Unit = {
     startTest(
       event.suiteId,
@@ -188,7 +197,6 @@ class AllureScalatest(val lifecycle: AllureLifecycle) extends Reporter {
       .setName(testName)
       .setUuid(uuid)
       .setTestCaseId(md5(suiteId + testName))
-      .setHistoryId(md5(suiteId + testName))
       .setTitlePath(
         suiteClassName
           .map(createTitlePathFromQualifiedClassName)

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/AllureScalatestTest.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/AllureScalatestTest.scala
@@ -20,6 +20,8 @@ import io.qameta.allure.model.{Stage, Status}
 import io.qameta.allure.scalatest.testdata._
 import io.qameta.allure.test.IsolatedLifecycle
 import io.qameta.allure.test.{AllureResults, AllureResultsWriterStub, RunUtils}
+import io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId
+import io.qameta.allure.util.ResultsUtils.createParameter
 import io.qameta.allure.{Allure, AllureLifecycle}
 import org.junit.jupiter.api.Test
 import org.scalatest.matchers.should.Matchers._
@@ -125,6 +127,18 @@ class AllureScalatestTest {
   }
 
   @Test
+  def shouldProcessPendingTests(): Unit = {
+    val results = run(classOf[PendingSpec])
+
+    results.getTestResults should have length 1
+    val result = results.getTestResults.get(0)
+    result.getStatus shouldBe Status.SKIPPED
+    result.getStage shouldBe Stage.FINISHED
+    result.getTestCaseId should not be empty
+    result.getHistoryId should not be empty
+  }
+
+  @Test
   def shouldProcessSuiteAnnotations(): Unit = {
     val results = run(classOf[AnnotationsOnClassSpec])
 
@@ -191,6 +205,32 @@ class AllureScalatestTest {
       .flatMap(step => step.getSteps.asScala)
       .map(step => step.getName) should contain inOrder ("child1", "child2", "child3")
 
+  }
+
+  @Test
+  def shouldUseRuntimeParametersForHistoryId(): Unit = {
+    val originalValue = RuntimeParameterSpec.parameterValue
+    try {
+      RuntimeParameterSpec.parameterValue = "first"
+      val first = run(classOf[RuntimeParameterSpec]).getTestResults.asScala.head
+
+      RuntimeParameterSpec.parameterValue = "second"
+      val second = run(classOf[RuntimeParameterSpec]).getTestResults.asScala.head
+
+      first.getTestCaseId should not be empty
+      first.getTestCaseId shouldBe second.getTestCaseId
+      first.getHistoryId shouldBe expectedHistoryId(
+        first.getTestCaseId,
+        List(createParameter("runtime", "first")).asJava
+      )
+      second.getHistoryId shouldBe expectedHistoryId(
+        second.getTestCaseId,
+        List(createParameter("runtime", "second")).asJava
+      )
+      first.getHistoryId should not be second.getHistoryId
+    } finally {
+      RuntimeParameterSpec.parameterValue = originalValue
+    }
   }
 
   private def run(clazz: Class[_]): AllureResults = {

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/PendingSpec.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/PendingSpec.scala
@@ -13,23 +13,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.jbehave5.samples;
+package io.qameta.allure.scalatest.testdata
 
-import io.qameta.allure.Allure;
-import org.jbehave.core.annotations.Given;
+import io.qameta.allure.Allure
+import io.qameta.allure.scalatest.AllureScalatestContext
+import org.scalatest.flatspec.AnyFlatSpec
 
-public class RuntimeApiSteps {
+class PendingSpec extends AnyFlatSpec {
 
-    @Given("runtime api")
-    public void given() {
-        Allure.label("jbehave-test-label", "some-value");
-        Allure.parameter("test param", "param value");
-        Allure.parameter("excluded param", "excluded value", true);
-        Allure.step("sub step 1");
-        Allure.step("sub step 2", () -> {
-        });
-
-        Allure.attachment("some attachment", "some content");
-    }
-
+  "pending test" should "include runtime parameters" in new AllureScalatestContext {
+    Allure.parameter("runtime", "pending")
+    pending
+  }
 }

--- a/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/RuntimeParameterSpec.scala
+++ b/allure-scalatest/src/test/scala/io/qameta/allure/scalatest/testdata/RuntimeParameterSpec.scala
@@ -13,23 +13,20 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.jbehave5.samples;
+package io.qameta.allure.scalatest.testdata
 
-import io.qameta.allure.Allure;
-import org.jbehave.core.annotations.Given;
+import io.qameta.allure.Allure
+import io.qameta.allure.scalatest.AllureScalatestContext
+import org.scalatest.flatspec.AnyFlatSpec
 
-public class RuntimeApiSteps {
+object RuntimeParameterSpec {
+  @volatile var parameterValue: String = "default"
+}
 
-    @Given("runtime api")
-    public void given() {
-        Allure.label("jbehave-test-label", "some-value");
-        Allure.parameter("test param", "param value");
-        Allure.parameter("excluded param", "excluded value", true);
-        Allure.step("sub step 1");
-        Allure.step("sub step 2", () -> {
-        });
+class RuntimeParameterSpec extends AnyFlatSpec {
 
-        Allure.attachment("some attachment", "some content");
-    }
-
+  "runtime parameter" should "affect history id" in new AllureScalatestContext {
+    Allure.parameter("runtime", RuntimeParameterSpec.parameterValue)
+    Allure.parameter("ignored", RuntimeParameterSpec.parameterValue + "-excluded", true)
+  }
 }

--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -45,7 +45,6 @@ import org.spockframework.runtime.model.SpecInfo;
 import org.spockframework.runtime.model.TestTag;
 
 import java.lang.reflect.Method;
-import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -56,7 +55,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static io.qameta.allure.util.ResultsUtils.bytesToHex;
 import static io.qameta.allure.util.ResultsUtils.createFrameworkLabel;
 import static io.qameta.allure.util.ResultsUtils.createHostLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
@@ -71,13 +69,10 @@ import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
 import static io.qameta.allure.util.ResultsUtils.createTitlePath;
 import static io.qameta.allure.util.ResultsUtils.createTitlePathFromPackage;
 import static io.qameta.allure.util.ResultsUtils.firstNonEmpty;
-import static io.qameta.allure.util.ResultsUtils.getMd5Digest;
 import static io.qameta.allure.util.ResultsUtils.getProvidedLabels;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
 import static io.qameta.allure.util.ResultsUtils.md5;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Comparator.comparing;
 
 /**
  * Reports Spock 2 specifications to Allure.
@@ -225,7 +220,6 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         );
         final TestResult result = new TestResult()
                 .setUuid(uuid)
-                .setHistoryId(getHistoryId(qualifiedName, parameters))
                 .setTestCaseName(iteration.getName())
                 .setTestCaseId(md5(qualifiedName))
                 .setFullName(qualifiedName)
@@ -267,19 +261,6 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
 
     private String getQualifiedName(final String specName, final String testName) {
         return specName + "." + testName;
-    }
-
-    private String getHistoryId(final String name, final List<Parameter> parameters) {
-        final MessageDigest digest = getMd5Digest();
-        digest.update(name.getBytes(UTF_8));
-        parameters.stream()
-                .sorted(comparing(Parameter::getName).thenComparing(Parameter::getValue))
-                .forEachOrdered(parameter -> {
-                    digest.update(parameter.getName().getBytes(UTF_8));
-                    digest.update(parameter.getValue().getBytes(UTF_8));
-                });
-        final byte[] bytes = digest.digest();
-        return bytesToHex(bytes);
     }
 
     private boolean isSkipped(final FeatureInfo featureInfo) {

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
@@ -35,6 +35,7 @@ import io.qameta.allure.spock2.samples.FixturesTest;
 import io.qameta.allure.spock2.samples.HelloSpockSpec;
 import io.qameta.allure.spock2.samples.OneTest;
 import io.qameta.allure.spock2.samples.ParametersTest;
+import io.qameta.allure.spock2.samples.RuntimeParameterTest;
 import io.qameta.allure.spock2.samples.SpecFixtures;
 import io.qameta.allure.spock2.samples.SpockTags;
 import io.qameta.allure.spock2.samples.StepsAndBlocks;
@@ -75,6 +76,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
@@ -385,6 +387,39 @@ class AllureSpock2Test {
     }
 
     @Test
+    void shouldUseRuntimeParametersForHistoryId() {
+        final String originalValue = RuntimeParameterTest.getParameterValue();
+        try {
+            RuntimeParameterTest.setParameterValue("first");
+            final TestResult first = runClasses(RuntimeParameterTest.class).getTestResults().get(0);
+
+            RuntimeParameterTest.setParameterValue("second");
+            final TestResult second = runClasses(RuntimeParameterTest.class).getTestResults().get(0);
+
+            assertThat(first.getTestCaseId())
+                    .isNotBlank()
+                    .isEqualTo(second.getTestCaseId());
+            assertThat(first.getHistoryId())
+                    .isEqualTo(
+                            expectedHistoryId(
+                                    first.getTestCaseId(),
+                                    List.of(new Parameter().setName("runtime").setValue("first"))
+                            )
+                    );
+            assertThat(second.getHistoryId())
+                    .isEqualTo(
+                            expectedHistoryId(
+                                    second.getTestCaseId(),
+                                    List.of(new Parameter().setName("runtime").setValue("second"))
+                            )
+                    )
+                    .isNotEqualTo(first.getHistoryId());
+        } finally {
+            RuntimeParameterTest.setParameterValue(originalValue);
+        }
+    }
+
+    @Test
     void shouldSupportDataDrivenTests() {
         final AllureResults results = runClasses(DataDrivenTest.class);
         assertThat(results.getTestResults())
@@ -401,21 +436,21 @@ class AllureSpock2Test {
                                 "io.qameta.allure.spock2.samples.DataDrivenTest.Simple Test",
                                 "Simple Test",
                                 "c7d975849471fd7b3d9e6637744a3154",
-                                "8d0c81dcc577daba0013d9f64eac328b"
+                                "fb41e02ea1d24792a596aa10c0a6c2f8"
                         ),
                         tuple(
                                 "Simple Test [a: 7, b: 4, c: 7, #1]",
                                 "io.qameta.allure.spock2.samples.DataDrivenTest.Simple Test",
                                 "Simple Test",
                                 "c7d975849471fd7b3d9e6637744a3154",
-                                "29f09c26cfc058d5aa5e83cdf84f4e9d"
+                                "a8d02be1b8bdbed53aca643fac19776"
                         ),
                         tuple(
                                 "Simple Test [a: 0, b: 0, c: 0, #2]",
                                 "io.qameta.allure.spock2.samples.DataDrivenTest.Simple Test",
                                 "Simple Test",
                                 "c7d975849471fd7b3d9e6637744a3154",
-                                "e9a7c12cf7d0cf84d4a2ee322435c10f"
+                                "467474802fdf5bc788ff9b009ac7a20b"
                         )
                 );
     }

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/RuntimeParameterTest.groovy
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/RuntimeParameterTest.groovy
@@ -13,23 +13,21 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.jbehave5.samples;
+package io.qameta.allure.spock2.samples
 
-import io.qameta.allure.Allure;
-import org.jbehave.core.annotations.Given;
+import io.qameta.allure.Allure
+import spock.lang.Specification
 
-public class RuntimeApiSteps {
+class RuntimeParameterTest extends Specification {
 
-    @Given("runtime api")
-    public void given() {
-        Allure.label("jbehave-test-label", "some-value");
-        Allure.parameter("test param", "param value");
-        Allure.parameter("excluded param", "excluded value", true);
-        Allure.step("sub step 1");
-        Allure.step("sub step 2", () -> {
-        });
+    static String parameterValue = "default"
 
-        Allure.attachment("some attachment", "some content");
+    def "Runtime parameter"() {
+        given:
+        Allure.parameter("runtime", parameterValue)
+        Allure.parameter("ignored", "${parameterValue}-excluded", true)
+
+        expect:
+        true
     }
-
 }

--- a/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
+++ b/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
@@ -61,7 +61,6 @@ import org.testng.xml.XmlTest;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.security.MessageDigest;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,7 +82,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.qameta.allure.util.ResultsUtils.ALLURE_ID_LABEL_NAME;
-import static io.qameta.allure.util.ResultsUtils.bytesToHex;
 import static io.qameta.allure.util.ResultsUtils.createFrameworkLabel;
 import static io.qameta.allure.util.ResultsUtils.createHostLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
@@ -98,12 +96,10 @@ import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
 import static io.qameta.allure.util.ResultsUtils.createTitlePath;
 import static io.qameta.allure.util.ResultsUtils.createTitlePathFromQualifiedClassName;
 import static io.qameta.allure.util.ResultsUtils.firstNonEmpty;
-import static io.qameta.allure.util.ResultsUtils.getMd5Digest;
 import static io.qameta.allure.util.ResultsUtils.getProvidedLabels;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
+import static io.qameta.allure.util.ResultsUtils.md5;
 import static io.qameta.allure.util.ResultsUtils.processDescription;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Comparator.comparing;
 import static java.util.Objects.nonNull;
 
 /**
@@ -520,7 +516,7 @@ public class AllureTestNg
         final List<Parameter> parameters = getParameters(context, method, params);
         final TestResult result = new TestResult()
                 .setUuid(uuid)
-                .setHistoryId(getHistoryId(method, parameters))
+                .setTestCaseId(getTestCaseId(method))
                 .setName(getMethodName(method))
                 .setFullName(getQualifiedName(method))
                 .setTitlePath(getTitlePath(testClass))
@@ -566,10 +562,7 @@ public class AllureTestNg
             return;
         }
 
-        final AllureExternalKey testCaseKey = testKey(currentTest.get().uuid());
-        getLifecycle().updateTest(testCaseKey, setStatus(Status.PASSED));
-        getLifecycle().stopTest(testCaseKey);
-        getLifecycle().writeTest(testCaseKey);
+        stopTest(currentTest.get().uuid(), null, Status.PASSED);
     }
 
     @Override
@@ -617,7 +610,13 @@ public class AllureTestNg
 
     @Override
     public void onTestFailedButWithinSuccessPercentage(final ITestResult result) {
-        //do nothing
+        if (shouldSkipReportingFor(result)) {
+            return;
+        }
+
+        final String uuid = ensureTestStarted(result);
+        final Throwable throwable = result.getThrowable();
+        stopTest(uuid, throwable, getStatus(throwable));
     }
 
     @Override
@@ -895,21 +894,14 @@ public class AllureTestNg
         currentExecutable.remove();
     }
 
-    protected String getHistoryId(final ITestNGMethod method, final List<Parameter> parameters) {
-        final MessageDigest digest = getMd5Digest();
+    private String getTestCaseId(final ITestNGMethod method) {
+        return md5(getTestIdentifier(method));
+    }
+
+    private String getTestIdentifier(final ITestNGMethod method) {
         final String testClassName = method.getTestClass().getName();
         final String methodName = method.getMethodName();
-        digest.update(testClassName.getBytes(UTF_8));
-        digest.update(methodName.getBytes(UTF_8));
-        parameters.stream()
-                .filter(parameter -> !Boolean.TRUE.equals(parameter.getExcluded()))
-                .sorted(comparing(Parameter::getName).thenComparing(Parameter::getValue))
-                .forEachOrdered(parameter -> {
-                    digest.update(parameter.getName().getBytes(UTF_8));
-                    digest.update(parameter.getValue().getBytes(UTF_8));
-                });
-        final byte[] bytes = digest.digest();
-        return bytesToHex(bytes);
+        return testClassName + methodName;
     }
 
     protected Status getStatus(final Throwable throwable) {
@@ -1094,11 +1086,6 @@ public class AllureTestNg
                 method.getMethodName(),
                 getQualifiedName(method)
         ).orElse("Unknown");
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private Consumer<TestResult> setStatus(final Status status) {
-        return result -> result.setStatus(status);
     }
 
     private Consumer<TestResult> setStatus(final Status status, final StatusDetails details) {

--- a/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
@@ -41,6 +41,8 @@ import io.qameta.allure.testfilter.TestPlanV1_0;
 import io.qameta.allure.testng.config.AllureTestNgConfig;
 import io.qameta.allure.testng.samples.CustomListenerAttachments;
 import io.qameta.allure.testng.samples.PriorityTests;
+import io.qameta.allure.testng.samples.RuntimeParametersTest;
+import io.qameta.allure.testng.samples.SuccessPercentageTest;
 import io.qameta.allure.testng.samples.TestsWithIdForFilter;
 import org.assertj.core.api.Condition;
 import org.assertj.core.groups.Tuple;
@@ -77,7 +79,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
 import static io.qameta.allure.util.ResultsUtils.ALLURE_SEPARATE_LINES_SYSPROP;
+import static io.qameta.allure.util.ResultsUtils.md5;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -100,6 +104,55 @@ public class AllureTestNgTest {
             items -> items.stream().allMatch(item -> item.getSteps().size() == 1),
             "All items should have a step attached"
     );
+
+    @Test
+    @AllureFeatures.History
+    @AllureFeatures.Parameters
+    public void shouldCalculateHistoryIdFromRuntimeParametersAtTestEnd() {
+        final AllureResults results = runTestPlan(null, RuntimeParametersTest.class);
+        final String testIdentifier = RuntimeParametersTest.class.getName() + "runtimeParameters";
+        final String testCaseId = md5(testIdentifier);
+        final String historyId = expectedHistoryId(
+                testCaseId,
+                List.of(
+                        new Parameter().setName("runtime").setValue("included"),
+                        new Parameter().setName("ignored").setValue("excluded").setExcluded(true)
+                )
+        );
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getTestCaseId, TestResult::getHistoryId)
+                .containsExactly(tuple("runtimeParameters", testCaseId, historyId));
+    }
+
+    @Test
+    @AllureFeatures.History
+    public void shouldFinalizeFailuresWithinSuccessPercentage() {
+        SuccessPercentageTest.resetInvocations();
+        try {
+            final List<TestResult> testResults = runTestPlan(null, SuccessPercentageTest.class).getTestResults();
+
+            assertThat(testResults)
+                    .hasSize(3)
+                    .allSatisfy(result -> {
+                        assertThat(result.getStage()).isEqualTo(Stage.FINISHED);
+                        assertThat(result.getTestCaseId()).isNotBlank();
+                        assertThat(result.getHistoryId())
+                                .isEqualTo(expectedHistoryId(result.getTestCaseId(), result.getParameters()));
+                    });
+            assertThat(testResults)
+                    .extracting(TestResult::getStatus)
+                    .containsExactlyInAnyOrder(Status.FAILED, Status.PASSED, Status.PASSED);
+            assertThat(testResults)
+                    .extracting(TestResult::getTestCaseId)
+                    .containsOnly(testResults.get(0).getTestCaseId());
+            assertThat(testResults)
+                    .extracting(TestResult::getHistoryId)
+                    .doesNotHaveDuplicates();
+        } finally {
+            SuccessPercentageTest.resetInvocations();
+        }
+    }
 
     @SuppressWarnings("unused")
     private static Stream<Arguments> parallelConfiguration() {
@@ -1259,7 +1312,7 @@ public class AllureTestNgTest {
         assertThat(testResults)
                 .extracting(TestResult::getHistoryId)
                 .hasSize(2)
-                .containsOnly("45e3e2818aabf660b03908be12ba64f7");
+                .containsOnly("d3a93ece5b6ec2223df8676cf6e82509");
     }
 
     @SuppressWarnings("unchecked")

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/RuntimeParametersTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/RuntimeParametersTest.java
@@ -13,23 +13,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.jbehave5.samples;
+package io.qameta.allure.testng.samples;
 
 import io.qameta.allure.Allure;
-import org.jbehave.core.annotations.Given;
+import org.testng.annotations.Test;
 
-public class RuntimeApiSteps {
+public class RuntimeParametersTest {
 
-    @Given("runtime api")
-    public void given() {
-        Allure.label("jbehave-test-label", "some-value");
-        Allure.parameter("test param", "param value");
-        Allure.parameter("excluded param", "excluded value", true);
-        Allure.step("sub step 1");
-        Allure.step("sub step 2", () -> {
-        });
-
-        Allure.attachment("some attachment", "some content");
+    @Test
+    public void runtimeParameters() {
+        Allure.parameter("runtime", "included");
+        Allure.parameter("ignored", "excluded", true);
     }
-
 }

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/SuccessPercentageTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/SuccessPercentageTest.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import io.qameta.allure.Allure;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SuccessPercentageTest {
+
+    private static final AtomicInteger INVOCATIONS = new AtomicInteger();
+
+    public static void resetInvocations() {
+        INVOCATIONS.set(0);
+    }
+
+    @Test(
+            invocationCount = 3,
+            successPercentage = 66
+    )
+    public void succeedsWithinPercentage() {
+        final int invocation = INVOCATIONS.incrementAndGet();
+        Allure.parameter("invocation", invocation);
+        if (invocation == 1) {
+            throw new AssertionError("failed within success percentage");
+        }
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

All Allure Java integrations now provide a stable `testCaseId`, while the compatibility `historyId` is calculated when the test stops. This includes the complete set of non-excluded parameters, including values added through the runtime API, so parameterized executions are grouped and separated consistently.

JUnit template iterations use the template identity as their `testCaseId` and retain a hidden per-iteration UniqueId when framework parameter data is unavailable. Custom history calculation is supported through `TestLifecycleListener.beforeTestStop`; the legacy adapter-specific protected `getHistoryId` hooks have been removed.

fixes #349 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2