### PR TITLE
Let custom grouping labels override framework defaults

### DIFF
--- a/allure-citrus/src/main/java/io/qameta/allure/citrus/AllureCitrus.java
+++ b/allure-citrus/src/main/java/io/qameta/allure/citrus/AllureCitrus.java
@@ -40,6 +40,7 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -57,6 +58,7 @@ import static io.qameta.allure.util.ResultsUtils.createHostLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
 import static io.qameta.allure.util.ResultsUtils.createParameter;
 import static io.qameta.allure.util.ResultsUtils.createSuiteLabel;
+import static io.qameta.allure.util.ResultsUtils.createTestClassLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
 import static io.qameta.allure.util.ResultsUtils.createTitlePath;
 import static io.qameta.allure.util.ResultsUtils.getProvidedLabels;
@@ -241,6 +243,10 @@ public class AllureCitrus implements TestListener, TestSuiteListener, TestAction
         testClass.map(this::getLabels).ifPresent(result.getLabels()::addAll);
         testClass.map(this::getLinks).ifPresent(result.getLinks()::addAll);
 
+        // the test is represented by a class only when the test case is class-backed (java dsl);
+        // the test method stays unknown — the test case name may be customized by the user
+        testClass.ifPresent(aClass -> result.getLabels().add(createTestClassLabel(aClass.getName())));
+
         result.getLabels().addAll(
                 Arrays.asList(
                         createHostLabel(),
@@ -250,9 +256,10 @@ public class AllureCitrus implements TestListener, TestSuiteListener, TestAction
                 )
         );
 
+        final List<Label> defaultLabels = new ArrayList<>();
         testClass.ifPresent(aClass -> {
             final String suiteName = aClass.getCanonicalName();
-            result.getLabels().add(createSuiteLabel(suiteName));
+            defaultLabels.add(createSuiteLabel(suiteName));
         });
 
         final Optional<String> classDescription = testClass.flatMap(this::getDescription);
@@ -264,6 +271,7 @@ public class AllureCitrus implements TestListener, TestSuiteListener, TestAction
         result.setDescription(description);
 
         getLifecycle().scheduleTest(testKey, result);
+        getLifecycle().addDefaultLabels(testKey, defaultLabels);
         getLifecycle().startTest(testKey);
     }
 

--- a/allure-citrus/src/test/java/io/qameta/allure/citrus/AllureCitrusTest.java
+++ b/allure-citrus/src/test/java/io/qameta/allure/citrus/AllureCitrusTest.java
@@ -27,6 +27,7 @@ import com.consol.citrus.dsl.design.TestDesigner;
 import io.qameta.allure.Allure;
 import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.Step;
+import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Stage;
 import io.qameta.allure.model.Status;
@@ -61,6 +62,26 @@ class AllureCitrusTest {
                 .containsExactly("Simple test");
         assertThat(results.getTestResults().get(0).getTitlePath())
                 .containsExactly("com", "consol", "citrus", "dsl", "design", "DefaultTestDesigner");
+    }
+
+    @AllureFeatures.Base
+    @Test
+    void shouldSetTestClassLabelForClassBackedTests() {
+        final DefaultTestDesigner designer = new DefaultTestDesigner();
+        designer.name("Simple test");
+
+        final AllureResults results = run(designer);
+        assertThat(results.getTestResults())
+                .hasSize(1)
+                .flatExtracting(TestResult::getLabels)
+                .extracting(Label::getName, Label::getValue)
+                .contains(tuple("testClass", "com.consol.citrus.dsl.design.DefaultTestDesigner"));
+
+        // the test method is not a known code location for citrus test cases
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getLabels)
+                .extracting(Label::getName)
+                .doesNotContain("testMethod");
     }
 
     @AllureFeatures.PassedTests

--- a/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/AllureCucumber7Jvm.java
+++ b/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/AllureCucumber7Jvm.java
@@ -214,6 +214,7 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
 
         final AllureExternalKey testKey = testKey(testCaseUuid);
         lifecycle.scheduleTest(testKey, result);
+        lifecycle.addDefaultLabels(testKey, labelBuilder.getDefaultLabels());
         lifecycle.startTest(testKey);
     }
 

--- a/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/LabelBuilder.java
+++ b/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/LabelBuilder.java
@@ -42,7 +42,6 @@ import static io.qameta.allure.util.ResultsUtils.createLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
 import static io.qameta.allure.util.ResultsUtils.createStoryLabel;
 import static io.qameta.allure.util.ResultsUtils.createSuiteLabel;
-import static io.qameta.allure.util.ResultsUtils.createTestClassLabel;
 import static io.qameta.allure.util.ResultsUtils.createThreadLabel;
 
 /**
@@ -60,6 +59,7 @@ final class LabelBuilder {
     private static final String OWNER = "@OWNER";
 
     private final List<Label> scenarioLabels = new ArrayList<>();
+    private final List<Label> defaultLabels = new ArrayList<>();
     private final List<Link> scenarioLinks = new ArrayList<>();
 
     LabelBuilder(final Feature feature, final TestCase scenario, final Deque<String> tags) {
@@ -121,13 +121,17 @@ final class LabelBuilder {
                 Arrays.asList(
                         createHostLabel(),
                         createThreadLabel(),
-                        createFeatureLabel(featureName),
-                        createStoryLabel(scenario.getName()),
-                        createSuiteLabel(featureName),
-                        createTestClassLabel(scenario.getName()),
                         createFrameworkLabel("cucumber7jvm"),
                         createLanguageLabel("java"),
                         createLabel("gherkin_uri", uri.toString())
+                )
+        );
+
+        defaultLabels.addAll(
+                Arrays.asList(
+                        createFeatureLabel(featureName),
+                        createStoryLabel(scenario.getName()),
+                        createSuiteLabel(featureName)
                 )
         );
 
@@ -138,6 +142,10 @@ final class LabelBuilder {
 
     List<Label> getScenarioLabels() {
         return scenarioLabels;
+    }
+
+    List<Label> getDefaultLabels() {
+        return defaultLabels;
     }
 
     List<Link> getScenarioLinks() {

--- a/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
+++ b/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
@@ -57,6 +57,7 @@ import java.util.function.Supplier;
 import static io.qameta.allure.util.ResultsUtils.PACKAGE_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.SUITE_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.TEST_CLASS_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.TEST_METHOD_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.md5;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -429,9 +430,14 @@ class AllureCucumber7JvmTest {
                 .extracting(Label::getName, Label::getValue)
                 .contains(
                         tuple(PACKAGE_LABEL_NAME, "src.test.resources.features.tags_feature.Test Simple Scenarios"),
-                        tuple(SUITE_LABEL_NAME, "Test Simple Scenarios"),
-                        tuple(TEST_CLASS_LABEL_NAME, "Add a to b")
+                        tuple(SUITE_LABEL_NAME, "Test Simple Scenarios")
                 );
+
+        // scenarios are not represented by code, so the code-location labels stay unknown
+        assertThat(testResults)
+                .flatExtracting(TestResult::getLabels)
+                .extracting(Label::getName)
+                .doesNotContain(TEST_CLASS_LABEL_NAME, TEST_METHOD_LABEL_NAME);
     }
 
     @AllureFeatures.Steps

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
@@ -24,6 +24,7 @@ import io.qameta.allure.listener.StepLifecycleListener;
 import io.qameta.allure.listener.TestLifecycleListener;
 import io.qameta.allure.model.Attachment;
 import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.ScopeFixtureResult;
 import io.qameta.allure.model.ScopeFixtureType;
@@ -47,6 +48,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +60,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -329,10 +332,34 @@ public class AllureLifecycle {
     }
 
     /**
-     * Stops test by given key. The test must be running; scope metadata is merged into the test here. If the test has
-     * a test case id but no history id, a compatibility history id is generated from the test case id and the final
-     * parameters. A history id supplied by a {@link TestLifecycleListener#beforeTestStop(TestResult)} listener is
-     * preserved. Unbinds the calling thread only if the test is the calling thread's root.
+     * Registers default labels for the test with given key. Default labels do not appear on the test result until
+     * the test stops: {@link #stopTest(AllureExternalKey)} merges them after scope metadata, adding, for each
+     * distinct label name, the default labels with that name only when the test has no labels with that name by
+     * then. Labels provided by the user — through annotations, the runtime API, or before fixtures — thus take
+     * precedence over defaults instead of being duplicated by them. Repeated calls accumulate.
+     *
+     * <p>Intended for the framework-computed grouping labels a user may legitimately override: the suite family
+     * and BDD structure labels. System labels — framework, language, host, thread, package, testClass, testMethod
+     * — are facts about the run, not defaults: set them eagerly on the result (host and thread are overridable
+     * only through their dedicated properties, see {@code ResultsUtils}).</p>
+     *
+     * @param key    the external test key
+     * @param labels the default labels
+     */
+    public void addDefaultLabels(final AllureExternalKey key, final Collection<Label> labels) {
+        final TestItem item = getItem(key, TestItem.class, "add default labels");
+        if (Objects.isNull(item)) {
+            return;
+        }
+        item.defaultLabels().addAll(labels);
+    }
+
+    /**
+     * Stops test by given key. The test must be running; scope metadata is merged into the test here, then default
+     * labels are applied for each label name the test still has no labels for. If the test has a test case id but
+     * no history id, a compatibility history id is generated from the test case id and the final parameters. A
+     * history id supplied by a {@link TestLifecycleListener#beforeTestStop(TestResult)} listener is preserved.
+     * Unbinds the calling thread only if the test is the calling thread's root.
      *
      * @param key the external test key
      */
@@ -357,6 +384,7 @@ public class AllureLifecycle {
             testResult.setParameters(new ArrayList<>());
         }
         applyScopeMetadata(item);
+        applyDefaultLabels(item);
         if (Objects.isNull(testResult.getHistoryId()) && Objects.nonNull(testResult.getTestCaseId())) {
             testResult.setHistoryId(calculateHistoryId(testResult.getTestCaseId(), testResult.getParameters()));
         }
@@ -1312,6 +1340,34 @@ public class AllureLifecycle {
         }
     }
 
+    /**
+     * Adds the test's registered default labels — for each distinct label name, only when the test has no labels
+     * with that name. Runs after scope metadata is merged, so labels set from before fixtures also take precedence
+     * over defaults.
+     */
+    private static void applyDefaultLabels(final TestItem item) {
+        if (item.defaultLabels().isEmpty()) {
+            return;
+        }
+        final TestResult testResult = item.result();
+        // the result may carry an immutable label list, so merge into a mutable copy
+        final List<Label> labels = Objects.isNull(testResult.getLabels())
+                ? new ArrayList<>()
+                : new ArrayList<>(testResult.getLabels());
+        final Set<String> presentNames = new HashSet<>();
+        for (final Label label : labels) {
+            if (Objects.nonNull(label)) {
+                presentNames.add(label.getName());
+            }
+        }
+        for (final Label label : item.defaultLabels()) {
+            if (Objects.nonNull(label) && !presentNames.contains(label.getName())) {
+                labels.add(label);
+            }
+        }
+        testResult.setLabels(labels);
+    }
+
     private static void mergeScopeMetadata(final ScopeResult scope, final TestResult testResult) {
         testResult.getLabels().addAll(scope.getLabels());
         testResult.getLinks().addAll(scope.getLinks());
@@ -1360,12 +1416,14 @@ public class AllureLifecycle {
 
     /**
      * Internal item of a scheduled or running test: the result model, the scopes the test is linked to (their
-     * metadata is merged into the test at stop), and the async attachment futures awaited before the test is written.
+     * metadata is merged into the test at stop), the default labels (applied at stop for label names the test has
+     * no labels for), and the async attachment futures awaited before the test is written.
      */
-    private record TestItem(TestResult result, Set<AllureExternalKey> scopes, Set<CompletableFuture<?>> futures) {
+    private record TestItem(TestResult result, Set<AllureExternalKey> scopes, List<Label> defaultLabels,
+            Set<CompletableFuture<?>> futures) {
 
         private TestItem(final TestResult result) {
-            this(result, ConcurrentHashMap.newKeySet(), ConcurrentHashMap.newKeySet());
+            this(result, ConcurrentHashMap.newKeySet(), new CopyOnWriteArrayList<>(), ConcurrentHashMap.newKeySet());
         }
     }
 

--- a/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
@@ -624,6 +624,175 @@ class AllureLifecycleTest {
     }
 
     @Test
+    void shouldApplyDefaultLabelsWhenTestStops() {
+        final String testUuid = randomId();
+        final AllureExternalKey testKey = testKey(testUuid);
+        lifecycle.scheduleTest(testKey, new TestResult().setUuid(testUuid).setName(randomName()));
+        lifecycle.addDefaultLabels(
+                testKey, List.of(
+                        new Label().setName("suite").setValue("default suite"),
+                        new Label().setName("story").setValue("default story")
+                )
+        );
+        lifecycle.startTest(testKey);
+
+        final List<Label> labelsBeforeStop = new ArrayList<>();
+        lifecycle.updateTest(testKey, result -> labelsBeforeStop.addAll(result.getLabels()));
+
+        lifecycle.stopTest(testKey);
+        lifecycle.writeTest(testKey);
+
+        final ArgumentCaptor<TestResult> captor = forClass(TestResult.class);
+        verify(writer, times(1)).write(captor.capture());
+
+        Allure.step("Verify default labels appear only on the stopped test", step -> {
+            step.parameter("test uuid", testUuid);
+            assertThat(labelsBeforeStop)
+                    .as("default labels should not be visible while the test is running")
+                    .isEmpty();
+            assertThat(captor.getValue().getLabels())
+                    .extracting(Label::getName, Label::getValue)
+                    .containsExactly(
+                            tuple("suite", "default suite"),
+                            tuple("story", "default story")
+                    );
+        });
+    }
+
+    @Test
+    void shouldPreferUserLabelsOverDefaultLabels() {
+        final String testUuid = randomId();
+        final AllureExternalKey testKey = testKey(testUuid);
+        lifecycle.scheduleTest(testKey, new TestResult().setUuid(testUuid).setName(randomName()));
+        lifecycle.addDefaultLabels(
+                testKey, List.of(
+                        new Label().setName("suite").setValue("default suite a"),
+                        new Label().setName("suite").setValue("default suite b"),
+                        new Label().setName("story").setValue("default story")
+                )
+        );
+        lifecycle.startTest(testKey);
+        lifecycle.updateTest(
+                testKey,
+                result -> result.getLabels().add(new Label().setName("suite").setValue("custom suite"))
+        );
+        lifecycle.stopTest(testKey);
+        lifecycle.writeTest(testKey);
+
+        final ArgumentCaptor<TestResult> captor = forClass(TestResult.class);
+        verify(writer, times(1)).write(captor.capture());
+
+        Allure.step("Verify the user label suppresses all same-name defaults", step -> {
+            step.parameter("test uuid", testUuid);
+            assertThat(captor.getValue().getLabels())
+                    .extracting(Label::getName, Label::getValue)
+                    .containsExactly(
+                            tuple("suite", "custom suite"),
+                            tuple("story", "default story")
+                    );
+        });
+    }
+
+    @Test
+    void shouldApplyDefaultLabelsToImmutableLabelList() {
+        final String testUuid = randomId();
+        final AllureExternalKey testKey = testKey(testUuid);
+        lifecycle.scheduleTest(
+                testKey,
+                new TestResult()
+                        .setUuid(testUuid)
+                        .setName(randomName())
+                        .setLabels(List.of(new Label().setName("suite").setValue("user suite")))
+        );
+        lifecycle.addDefaultLabels(
+                testKey, List.of(
+                        new Label().setName("suite").setValue("default suite"),
+                        new Label().setName("story").setValue("default story")
+                )
+        );
+        lifecycle.startTest(testKey);
+        lifecycle.stopTest(testKey);
+        lifecycle.writeTest(testKey);
+
+        final ArgumentCaptor<TestResult> captor = forClass(TestResult.class);
+        verify(writer, times(1)).write(captor.capture());
+
+        Allure.step("Verify defaults merge even when the test labels list is immutable", step -> {
+            step.parameter("test uuid", testUuid);
+            assertThat(captor.getValue().getLabels())
+                    .extracting(Label::getName, Label::getValue)
+                    .containsExactly(
+                            tuple("suite", "user suite"),
+                            tuple("story", "default story")
+                    );
+        });
+    }
+
+    @Test
+    void shouldApplyAllSameNameDefaultLabelsWhenNonePresent() {
+        final String testUuid = randomId();
+        final AllureExternalKey testKey = testKey(testUuid);
+        lifecycle.scheduleTest(testKey, new TestResult().setUuid(testUuid).setName(randomName()));
+        lifecycle.addDefaultLabels(
+                testKey, List.of(
+                        new Label().setName("feature").setValue("first feature"),
+                        new Label().setName("feature").setValue("second feature")
+                )
+        );
+        lifecycle.startTest(testKey);
+        lifecycle.stopTest(testKey);
+        lifecycle.writeTest(testKey);
+
+        final ArgumentCaptor<TestResult> captor = forClass(TestResult.class);
+        verify(writer, times(1)).write(captor.capture());
+
+        Allure.step("Verify multi-valued defaults are applied together", step -> {
+            step.parameter("test uuid", testUuid);
+            assertThat(captor.getValue().getLabels())
+                    .extracting(Label::getName, Label::getValue)
+                    .containsExactly(
+                            tuple("feature", "first feature"),
+                            tuple("feature", "second feature")
+                    );
+        });
+    }
+
+    @Test
+    void shouldPreferBeforeFixtureLabelsOverDefaultLabels() {
+        final String scopeUuid = randomUuid();
+        final AllureExternalKey scopeKey = scopeKey(scopeUuid);
+        lifecycle.registerScope(scopeKey);
+
+        final String fixtureUuid = randomId();
+        final AllureExternalKey fixtureKey = fixtureKey(fixtureUuid);
+        Allure.step("Set the suite label from a before fixture", step -> {
+            step.parameter("scope uuid", scopeUuid);
+            step.parameter("fixture uuid", fixtureUuid);
+            lifecycle.startBeforeFixture(scopeKey, fixtureKey, new FixtureResult().setName(randomName()));
+            applyMetadata(metadata -> metadata.getLabels().add(new Label().setName("suite").setValue("fixture suite")));
+            lifecycle.stopFixture(fixtureKey);
+        });
+
+        final String testUuid = randomId();
+        final AllureExternalKey testKey = testKey(testUuid);
+        lifecycle.scheduleTest(List.of(scopeKey), testKey, new TestResult().setUuid(testUuid).setName(randomName()));
+        lifecycle.addDefaultLabels(testKey, List.of(new Label().setName("suite").setValue("default suite")));
+        lifecycle.startTest(testKey);
+        lifecycle.stopTest(testKey);
+        lifecycle.writeTest(testKey);
+
+        final ArgumentCaptor<TestResult> captor = forClass(TestResult.class);
+        verify(writer, times(1)).write(captor.capture());
+
+        Allure.step("Verify the fixture label suppresses the default one", step -> {
+            step.parameter("test uuid", testUuid);
+            assertThat(captor.getValue().getLabels())
+                    .extracting(Label::getName, Label::getValue)
+                    .containsExactly(tuple("suite", "fixture suite"));
+        });
+    }
+
+    @Test
     void shouldNotMergeAfterFixtureMetadataIntoLinkedTest() {
         final String scopeUuid = randomUuid();
         final AllureExternalKey scopeKey = scopeKey(scopeUuid);

--- a/allure-jbehave5/src/main/java/io/qameta/allure/jbehave5/AllureJbehave5.java
+++ b/allure-jbehave5/src/main/java/io/qameta/allure/jbehave5/AllureJbehave5.java
@@ -282,9 +282,10 @@ public class AllureJbehave5 extends NullStoryReporter {
                 .map(entry -> createParameter(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
 
+        final List<Label> defaultLabels = List.of(createStoryLabel(story.getName()));
+
         final List<Label> labels = new ArrayList<>(
                 Arrays.asList(
-                        createStoryLabel(story.getName()),
                         createHostLabel(),
                         createThreadLabel(),
                         createFrameworkLabel("jbehave"),
@@ -304,6 +305,7 @@ public class AllureJbehave5 extends NullStoryReporter {
                 .setDescription(story.getDescription().asString());
 
         getLifecycle().scheduleTest(testKey, result);
+        getLifecycle().addDefaultLabels(testKey, defaultLabels);
         getLifecycle().startTest(testKey);
     }
 

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
@@ -595,9 +595,10 @@ public class AllureJunitPlatform implements TestExecutionListener {
                 )
         );
 
+        final List<Label> defaultLabels = new ArrayList<>();
         testSource.flatMap(AllureJunitPlatformUtils::getFullName).ifPresent(result::setFullName);
         testSource.map(this::getSourceLabels).ifPresent(result.getLabels()::addAll);
-        testClass.map(this::getSuiteLabels).ifPresent(result.getLabels()::addAll);
+        testClass.map(this::getSuiteLabels).ifPresent(defaultLabels::addAll);
 
         final Optional<String> classDescription = testClass.flatMap(this::getDescription);
         final Optional<String> methodDescription = testMethod.flatMap(this::getDescription);
@@ -626,6 +627,7 @@ public class AllureJunitPlatform implements TestExecutionListener {
 
         final AllureExternalKey testKey = testKey(testIdentifier.getUniqueId());
         getLifecycle().scheduleTest(scopeKeys, testKey, result);
+        getLifecycle().addDefaultLabels(testKey, defaultLabels);
         getLifecycle().startTest(testKey);
     }
 

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -41,6 +41,8 @@ import io.qameta.allure.junitplatform.features.PassedTests;
 import io.qameta.allure.junitplatform.features.RepeatedTests;
 import io.qameta.allure.junitplatform.features.ReportEntryParameter;
 import io.qameta.allure.junitplatform.features.RuntimeParametersTest;
+import io.qameta.allure.junitplatform.features.RuntimeSuiteLabelTest;
+import io.qameta.allure.junitplatform.features.RuntimeSystemLabelsTest;
 import io.qameta.allure.junitplatform.features.SeverityTest;
 import io.qameta.allure.junitplatform.features.SkippedInBeforeAllTests;
 import io.qameta.allure.junitplatform.features.SkippedTests;
@@ -710,6 +712,63 @@ public class AllureJunitPlatformTest {
                         tuple(SUITE_LABEL_NAME, "io.qameta.allure.junitplatform.features.OneTest"),
                         tuple(TEST_CLASS_LABEL_NAME, "io.qameta.allure.junitplatform.features.OneTest"),
                         tuple(TEST_METHOD_LABEL_NAME, "single")
+                );
+    }
+
+    @AllureFeatures.Base
+    @Test
+    void shouldPreferRuntimeApiSuiteLabelOverDefault() {
+        final AllureResults results = runClasses(RuntimeSuiteLabelTest.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults).hasSize(1);
+        final List<Label> labels = testResults.get(0).getLabels();
+
+        // the default suite label is applied at test stop only when the user has not set one
+        assertThat(labels)
+                .filteredOn(label -> SUITE_LABEL_NAME.equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactly("Runtime Suite");
+
+        // system labels are unaffected by the runtime api suite value
+        assertThat(labels)
+                .extracting(Label::getName, Label::getValue)
+                .contains(tuple(TEST_CLASS_LABEL_NAME, "io.qameta.allure.junitplatform.features.RuntimeSuiteLabelTest"));
+    }
+
+    @AllureFeatures.Base
+    @Test
+    void shouldKeepSystemLabelsWhenSetThroughRuntimeApi() {
+        final AllureResults results = runClasses(RuntimeSystemLabelsTest.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults).hasSize(1);
+        final List<Label> labels = testResults.get(0).getLabels();
+
+        // package, testClass, and testMethod are system labels: they are set eagerly
+        // and are not replaced by user values
+        assertThat(labels)
+                .filteredOn(label -> PACKAGE_LABEL_NAME.equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactlyInAnyOrder(
+                        "io.qameta.allure.junitplatform.features.RuntimeSystemLabelsTest",
+                        "Runtime Package"
+                );
+
+        assertThat(labels)
+                .filteredOn(label -> TEST_CLASS_LABEL_NAME.equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactlyInAnyOrder(
+                        "io.qameta.allure.junitplatform.features.RuntimeSystemLabelsTest",
+                        "Runtime Test Class"
+                );
+
+        assertThat(labels)
+                .filteredOn(label -> TEST_METHOD_LABEL_NAME.equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactlyInAnyOrder(
+                        "testWithRuntimeSystemLabels",
+                        "Runtime Test Method"
                 );
     }
 

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/RuntimeSuiteLabelTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/RuntimeSuiteLabelTest.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import io.qameta.allure.Allure;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Sample with a test that sets the suite label through the runtime api: the user value must replace the default
+ * suite label instead of being duplicated by it.
+ */
+public class RuntimeSuiteLabelTest {
+
+    @Test
+    void testWithRuntimeSuite() {
+        Allure.suite("Runtime Suite");
+    }
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/RuntimeSystemLabelsTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/RuntimeSystemLabelsTest.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import io.qameta.allure.Allure;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Sample with a test that sets the package, testClass, and testMethod labels through the runtime api: these are
+ * system labels, so the framework-computed values must stay on the result instead of being replaced by the user
+ * values.
+ */
+public class RuntimeSystemLabelsTest {
+
+    @Test
+    void testWithRuntimeSystemLabels() {
+        Allure.label("package", "Runtime Package");
+        Allure.label("testClass", "Runtime Test Class");
+        Allure.label("testMethod", "Runtime Test Method");
+    }
+}

--- a/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
+++ b/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
@@ -119,6 +119,7 @@ public class AllureJunit4 extends RunListener {
         final AllureExternalKey testKey = getTestKey(description);
         final TestResult result = createTestResult(description);
         getLifecycle().scheduleTest(testKey, result);
+        getLifecycle().addDefaultLabels(testKey, createDefaultLabels(description));
         getLifecycle().startTest(testKey);
     }
 
@@ -186,6 +187,7 @@ public class AllureJunit4 extends RunListener {
         result.setStatusDetails(getIgnoredMessage(description));
 
         getLifecycle().scheduleTest(testKey, result);
+        getLifecycle().addDefaultLabels(testKey, createDefaultLabels(description));
         getLifecycle().startTest(testKey);
         stopAndWriteTest(testKey);
     }
@@ -296,14 +298,16 @@ public class AllureJunit4 extends RunListener {
                 Arrays.asList(
                         createPackageLabel(getPackage(description.getTestClass())),
                         createTestClassLabel(className),
-                        createTestMethodLabel(name),
-                        createSuiteLabel(suite),
                         createHostLabel(),
                         createThreadLabel(),
                         createFrameworkLabel("junit4"),
                         createLanguageLabel("java")
                 )
         );
+        // the test method is unknown for class-level descriptions
+        if (Objects.nonNull(methodName)) {
+            testResult.getLabels().add(createTestMethodLabel(methodName));
+        }
         testResult.getLabels().addAll(extractLabels(description));
         testResult.getLinks().addAll(extractLinks(description));
 
@@ -311,6 +315,15 @@ public class AllureJunit4 extends RunListener {
 
         getDescription(description).ifPresent(testResult::setDescription);
         return testResult;
+    }
+
+    private List<Label> createDefaultLabels(final Description description) {
+        final String className = description.getClassName();
+        final String suite = Optional.ofNullable(description.getTestClass())
+                .map(it -> it.getAnnotation(DisplayName.class))
+                .map(DisplayName::value).orElse(className);
+
+        return List.of(createSuiteLabel(suite));
     }
 
     private boolean shouldIgnore(final Description description) {

--- a/allure-karate/src/main/java/io/qameta/allure/karate/AllureKarate.java
+++ b/allure-karate/src/main/java/io/qameta/allure/karate/AllureKarate.java
@@ -135,9 +135,7 @@ public class AllureKarate implements RunListener {
                 .setTitlePath(titlePath);
 
         final List<String> labels = getTagTexts(scenario);
-        final List<Label> allLabels = getLabels(labels);
-        allLabels.add(ResultsUtils.createFeatureLabel(featureName));
-        result.setLabels(allLabels);
+        result.setLabels(getLabels(labels));
 
         final List<Link> links = getLinks(labels);
         if (!links.isEmpty()) {
@@ -146,6 +144,7 @@ public class AllureKarate implements RunListener {
 
         final AllureExternalKey testKey = testKey(uuid);
         lifecycle.scheduleTest(testKey, result);
+        lifecycle.addDefaultLabels(testKey, List.of(ResultsUtils.createFeatureLabel(featureName)));
         lifecycle.startTest(testKey);
         return true;
     }

--- a/allure-scalatest/src/main/scala/io/qameta/allure/scalatest/AllureScalatest.scala
+++ b/allure-scalatest/src/main/scala/io/qameta/allure/scalatest/AllureScalatest.scala
@@ -181,8 +181,10 @@ class AllureScalatest(val lifecycle: AllureLifecycle) extends Reporter {
 
   private def startTest(suiteId: String, suiteName: String, suiteClassName: Option[String], location: Option[Location], testName: String, threadId: Option[String]): Unit = {
     val uuid = UUID.randomUUID().toString
+    val defaultLabels = mutable.ListBuffer(
+      createSuiteLabel(suiteName)
+    )
     var labels = mutable.ListBuffer(
-      createSuiteLabel(suiteName),
       createLabel(THREAD_LABEL_NAME, getScalaTestThreadName(threadId)),
       createHostLabel(),
       createLanguageLabel("scala"),
@@ -227,6 +229,7 @@ class AllureScalatest(val lifecycle: AllureLifecycle) extends Reporter {
 
     val key = testKey(uuid)
     lifecycle.scheduleTest(key, result)
+    lifecycle.addDefaultLabels(key, defaultLabels.asJava)
     lifecycle.startTest(key)
 
     // this should be called after test case scheduled

--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -47,6 +47,7 @@ import org.spockframework.runtime.model.TestTag;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -173,27 +174,21 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         final String packageName = specInfo.getPackage();
         final String specName = specInfo.getName();
         final String testClassName = feature.getSpec().getReflection().getName();
-        final String testMethodName = iteration.getDisplayName();
+        // the declared feature name is the source-level identity of the feature method,
+        // stable across data-driven iterations, unlike the resolved iteration display name
+        final String testMethodName = feature.getName();
+        final String displayName = iteration.getDisplayName();
 
-        final List<Label> labels = new ArrayList<>(
-                Arrays.asList(
-                        createPackageLabel(packageName),
-                        createTestClassLabel(testClassName),
-                        createTestMethodLabel(testMethodName),
-                        createSuiteLabel(specName),
-                        createHostLabel(),
-                        createThreadLabel(),
-                        createFrameworkLabel("spock"),
-                        createLanguageLabel("java")
-                )
+        final List<Label> defaultLabels = new ArrayList<>(
+                Collections.singletonList(createSuiteLabel(specName))
         );
 
         if (Objects.nonNull(subSpec)) {
-            labels.add(createSubSuiteLabel(subSpec.getName()));
+            defaultLabels.add(createSubSuiteLabel(subSpec.getName()));
         }
 
         if (Objects.nonNull(superSpec)) {
-            labels.add(createParentSuiteLabel(superSpec.getName()));
+            defaultLabels.add(createParentSuiteLabel(superSpec.getName()));
         }
 
         final List<Label> testTags = feature.getTestTags().stream()
@@ -201,6 +196,17 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
                 .map(ResultsUtils::createTagLabel)
                 .collect(Collectors.toList());
 
+        final List<Label> labels = new ArrayList<>(
+                Arrays.asList(
+                        createPackageLabel(packageName),
+                        createTestClassLabel(testClassName),
+                        createTestMethodLabel(testMethodName),
+                        createHostLabel(),
+                        createThreadLabel(),
+                        createFrameworkLabel("spock"),
+                        createLanguageLabel("java")
+                )
+        );
         labels.addAll(testTags);
         labels.addAll(featureLabels);
         labels.addAll(specLabels);
@@ -225,7 +231,7 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
                 .setFullName(qualifiedName)
                 .setTitlePath(titlePath)
                 .setName(
-                        firstNonEmpty(testMethodName, iteration.getName(), qualifiedName)
+                        firstNonEmpty(displayName, iteration.getName(), qualifiedName)
                                 .orElse("Unknown")
                 )
                 .setStatusDetails(
@@ -247,6 +253,7 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         testResults.set(uuid);
         final AllureExternalKey testKey = testKey(uuid);
         getLifecycle().scheduleTest(testKey, result);
+        getLifecycle().addDefaultLabels(testKey, defaultLabels);
         getLifecycle().startTest(testKey);
 
     }

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
@@ -453,6 +453,14 @@ class AllureSpock2Test {
                                 "467474802fdf5bc788ff9b009ac7a20b"
                         )
                 );
+
+        // the testMethod label is the declared feature name — a code location,
+        // stable across iterations, unlike the resolved iteration names above
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(label -> "testMethod".equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactly("Simple Test", "Simple Test", "Simple Test");
     }
 
     @Test

--- a/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
+++ b/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
@@ -492,17 +492,13 @@ public class AllureTestNg
         final ITestClass testClass = method.getTestClass();
         final List<Label> labels = new ArrayList<>();
         labels.addAll(getProvidedLabels());
+        labels.addAll(getLabels(method, iClass));
         labels.addAll(
                 Arrays.asList(
                         //Packages grouping
                         createPackageLabel(testClass.getName()),
                         createTestClassLabel(testClass.getName()),
                         createTestMethodLabel(method.getMethodName()),
-
-                        //xUnit grouping
-                        createParentSuiteLabel(safeExtractSuiteName(testClass)),
-                        createSuiteLabel(safeExtractTestTag(testClass)),
-                        createSubSuiteLabel(safeExtractTestClassName(testClass)),
 
                         //Timeline grouping
                         createHostLabel(),
@@ -512,7 +508,12 @@ public class AllureTestNg
                         createLanguageLabel("java")
                 )
         );
-        labels.addAll(getLabels(method, iClass));
+        final List<Label> defaultLabels = Arrays.asList(
+                //xUnit grouping
+                createParentSuiteLabel(safeExtractSuiteName(testClass)),
+                createSuiteLabel(safeExtractTestTag(testClass)),
+                createSubSuiteLabel(safeExtractTestClassName(testClass))
+        );
         final List<Parameter> parameters = getParameters(context, method, params);
         final TestResult result = new TestResult()
                 .setUuid(uuid)
@@ -542,6 +543,7 @@ public class AllureTestNg
                 testCaseKey,
                 result
         );
+        getLifecycle().addDefaultLabels(testCaseKey, defaultLabels);
         getLifecycle().startTest(testCaseKey);
     }
 

--- a/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
@@ -621,6 +621,80 @@ public class AllureTestNgTest {
                 .containsExactly("rest");
     }
 
+    @AllureFeatures.Base
+    @Test
+    @DisplayName("Suite label from the runtime api replaces the default suite label")
+    public void runtimeApiSuiteLabelReplacesDefault() {
+        final AllureResults results = runTestNgSuites("suites/runtime-suite-label.xml");
+
+        assertThat(results.getTestResults()).hasSize(1);
+        final List<Label> labels = results.getTestResults().get(0).getLabels();
+
+        // the default suite label is applied at test stop only when the user has not set one
+        assertThat(labels)
+                .filteredOn(label -> "suite".equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactly("Runtime Suite");
+
+        // defaults for names the user did not touch are still applied
+        assertThat(labels)
+                .filteredOn(label -> "parentSuite".equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactly("Runtime suite label suite");
+    }
+
+    @AllureFeatures.Fixtures
+    @Test
+    @DisplayName("Suite label from a before method fixture replaces the default suite label")
+    public void beforeMethodSuiteLabelReplacesDefault() {
+        final AllureResults results = runTestNgSuites("suites/before-method-runtime-suite-label.xml");
+
+        // the per-method scope metadata is merged into the test before default labels apply,
+        // so the fixture-provided suite wins over the default one
+        assertThat(results.getTestResults())
+                .hasSize(1)
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(label -> "suite".equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactly("Fixture Suite");
+    }
+
+    @AllureFeatures.Base
+    @Test
+    @DisplayName("Labels from the runtime api do not replace the system labels")
+    public void runtimeApiLabelsKeepSystemLabels() {
+        final AllureResults results = runTestNgSuites("suites/runtime-system-labels.xml");
+
+        assertThat(results.getTestResults()).hasSize(1);
+        final List<Label> labels = results.getTestResults().get(0).getLabels();
+
+        // package, testClass, and testMethod are system labels: they are set eagerly
+        // and are not replaced by user values
+        assertThat(labels)
+                .filteredOn(label -> "package".equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactlyInAnyOrder(
+                        "io.qameta.allure.testng.samples.RuntimeSystemLabels",
+                        "Runtime Package"
+                );
+
+        assertThat(labels)
+                .filteredOn(label -> "testClass".equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactlyInAnyOrder(
+                        "io.qameta.allure.testng.samples.RuntimeSystemLabels",
+                        "Runtime Test Class"
+                );
+
+        assertThat(labels)
+                .filteredOn(label -> "testMethod".equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactlyInAnyOrder(
+                        "testWithRuntimeSystemLabels",
+                        "Runtime Test Method"
+                );
+    }
+
     @AllureFeatures.Fixtures
     @ParameterizedTest
     @MethodSource("parallelConfiguration")

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/BeforeMethodRuntimeSuiteLabel.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/BeforeMethodRuntimeSuiteLabel.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import io.qameta.allure.Allure;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Sample with a before-method fixture that sets the suite label through the runtime api: the fixture value must
+ * replace the default suite label instead of being duplicated by it.
+ */
+public class BeforeMethodRuntimeSuiteLabel {
+
+    @BeforeMethod
+    public void beforeMethod() {
+        Allure.suite("Fixture Suite");
+    }
+
+    @Test
+    public void testWithFixtureSuite() {
+    }
+}

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/RuntimeSuiteLabel.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/RuntimeSuiteLabel.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import io.qameta.allure.Allure;
+import org.testng.annotations.Test;
+
+/**
+ * Sample with a test that sets the suite label through the runtime api: the user value must replace the default
+ * suite label instead of being duplicated by it.
+ */
+public class RuntimeSuiteLabel {
+
+    @Test
+    public void testWithRuntimeSuite() {
+        Allure.suite("Runtime Suite");
+    }
+}

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/RuntimeSystemLabels.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/RuntimeSystemLabels.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import io.qameta.allure.Allure;
+import org.testng.annotations.Test;
+
+/**
+ * Sample with a test that sets the package, testClass, and testMethod labels through the runtime api: these are
+ * system labels, so the framework-computed values must stay on the result instead of being replaced by the user
+ * values.
+ */
+public class RuntimeSystemLabels {
+
+    @Test
+    public void testWithRuntimeSystemLabels() {
+        Allure.label("package", "Runtime Package");
+        Allure.label("testClass", "Runtime Test Class");
+        Allure.label("testMethod", "Runtime Test Method");
+    }
+}

--- a/allure-testng/src/test/resources/suites/before-method-runtime-suite-label.xml
+++ b/allure-testng/src/test/resources/suites/before-method-runtime-suite-label.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Before method runtime suite label suite">
+    <test name="Before method runtime suite label test">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.BeforeMethodRuntimeSuiteLabel">
+            </class>
+        </classes>
+    </test>
+</suite>

--- a/allure-testng/src/test/resources/suites/runtime-suite-label.xml
+++ b/allure-testng/src/test/resources/suites/runtime-suite-label.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Runtime suite label suite">
+    <test name="Runtime suite label test">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.RuntimeSuiteLabel">
+            </class>
+        </classes>
+    </test>
+</suite>

--- a/allure-testng/src/test/resources/suites/runtime-system-labels.xml
+++ b/allure-testng/src/test/resources/suites/runtime-system-labels.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Runtime system labels suite">
+    <test name="Runtime system labels test">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.RuntimeSystemLabels">
+            </class>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Framework-provided suite hierarchy and BDD labels now behave as fallbacks across supported Java integrations. Matching labels supplied through annotations, the runtime API, or before-test fixtures take precedence, preventing duplicate or conflicting suite, parent suite, sub-suite, feature, and story values while preserving untouched defaults.

Source and execution metadata—including package, test class, test method, framework, language, host, and thread—remains additive. For example, a runtime suite replaces the automatically derived suite, while runtime package, test-class, and test-method labels coexist with the values reported by the test framework.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2