### PR TITLE
Preserve muted and flaky annotations for failed Spock tests

### DIFF
--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -311,11 +311,26 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         if (Objects.isNull(uuid)) {
             return;
         }
-        getLifecycle().updateTest(
-                testKey(uuid), testResult -> testResult
-                        .setStatus(getStatus(error.getException()).orElse(null))
-                        .setStatusDetails(getStatusDetails(error.getException()).orElse(null))
-        );
+        final Throwable exception = error.getException();
+        getLifecycle().updateTest(testKey(uuid), testResult -> {
+            testResult.setStatus(getStatus(exception).orElse(null));
+
+            final StatusDetails details = getStatusDetails(exception).orElse(null);
+            if (Objects.isNull(details)) {
+                return;
+            }
+            // merge the exception details into the existing status details so that
+            // the flaky/muted flags set in beforeIteration are not overwritten
+            final StatusDetails current = testResult.getStatusDetails();
+            if (Objects.isNull(current)) {
+                testResult.setStatusDetails(details);
+            } else {
+                current.setMessage(details.getMessage())
+                        .setTrace(details.getTrace())
+                        .setActual(details.getActual())
+                        .setExpected(details.getExpected());
+            }
+        });
     }
 
     /**

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
@@ -31,6 +31,7 @@ import io.qameta.allure.spock2.samples.BrokenTest;
 import io.qameta.allure.spock2.samples.DataDrivenTest;
 import io.qameta.allure.spock2.samples.DerivedSpec;
 import io.qameta.allure.spock2.samples.FailedTest;
+import io.qameta.allure.spock2.samples.FailedTestWithAnnotations;
 import io.qameta.allure.spock2.samples.FixturesTest;
 import io.qameta.allure.spock2.samples.HelloSpockSpec;
 import io.qameta.allure.spock2.samples.OneTest;
@@ -353,6 +354,21 @@ class AllureSpock2Test {
                 .extracting(TestResult::getName, tr -> tr.getStatusDetails().isMuted())
                 .containsExactlyInAnyOrder(
                         tuple("someTest", true)
+                );
+    }
+
+    @Test
+    void shouldKeepFlakyAndMutedForFailedTest() {
+        final AllureResults results = runClasses(FailedTestWithAnnotations.class);
+        assertThat(results.getTestResults())
+                .extracting(
+                        TestResult::getName,
+                        TestResult::getStatus,
+                        tr -> tr.getStatusDetails().isFlaky(),
+                        tr -> tr.getStatusDetails().isMuted()
+                )
+                .containsExactly(
+                        tuple("failedTest", Status.FAILED, true, true)
                 );
     }
 

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedTestWithAnnotations.groovy
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedTestWithAnnotations.groovy
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.spock2.samples
+
+import io.qameta.allure.Flaky
+import io.qameta.allure.Muted
+import spock.lang.Specification
+
+class FailedTestWithAnnotations extends Specification {
+
+    @Flaky
+    @Muted
+    def "failedTest"() {
+        expect:
+        false
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Failed Spock 2 tests now retain their `@Muted` and `@Flaky` annotations in Allure results. Failure details remain available without overwriting these flags, so reports correctly identify annotated tests even when they fail.

fixes #1303

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2