### PR TITLE
Support composed flaky, muted, and severity annotations across Java test adapters

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/util/AnnotationUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/AnnotationUtils.java
@@ -19,6 +19,8 @@ import io.qameta.allure.Flaky;
 import io.qameta.allure.LabelAnnotation;
 import io.qameta.allure.LinkAnnotation;
 import io.qameta.allure.Muted;
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import org.slf4j.Logger;
@@ -32,6 +34,7 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
@@ -46,6 +49,7 @@ import static java.util.Arrays.asList;
  * test cases via reflection.
  *
  */
+@SuppressWarnings("PMD.GodClass")
 public final class AnnotationUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AnnotationUtils.class);
@@ -57,23 +61,77 @@ public final class AnnotationUtils {
     }
 
     /**
-     * Returns true if {@link io.qameta.allure.Flaky} annotation is present.
+     * Returns true if {@link io.qameta.allure.Flaky} annotation is present. The annotation is
+     * also discovered when used as a meta annotation on other (custom) annotations.
      *
      * @param annotatedElement the element to search annotations on.
      * @return true if {@link io.qameta.allure.Flaky} annotation is present, false otherwise.
      */
     public static boolean isFlaky(final AnnotatedElement annotatedElement) {
-        return annotatedElement.isAnnotationPresent(Flaky.class);
+        return isFlaky(asList(annotatedElement.getAnnotations()));
     }
 
     /**
-     * Returns true if {@link io.qameta.allure.Muted} annotation is present.
+     * Returns true if {@link io.qameta.allure.Flaky} annotation is present within given annotations,
+     * either directly or as a meta annotation.
+     *
+     * @param annotations annotations to analyse.
+     * @return true if {@link io.qameta.allure.Flaky} annotation is present, false otherwise.
+     */
+    public static boolean isFlaky(final Collection<Annotation> annotations) {
+        return findMetaAnnotations(Flaky.class, annotations).findAny().isPresent();
+    }
+
+    /**
+     * Returns true if {@link io.qameta.allure.Muted} annotation is present. The annotation is
+     * also discovered when used as a meta annotation on other (custom) annotations.
      *
      * @param annotatedElement the element to search annotations on.
      * @return true if {@link io.qameta.allure.Muted} annotation is present, false otherwise.
      */
     public static boolean isMuted(final AnnotatedElement annotatedElement) {
-        return annotatedElement.isAnnotationPresent(Muted.class);
+        return isMuted(asList(annotatedElement.getAnnotations()));
+    }
+
+    /**
+     * Returns true if {@link io.qameta.allure.Muted} annotation is present within given annotations,
+     * either directly or as a meta annotation.
+     *
+     * @param annotations annotations to analyse.
+     * @return true if {@link io.qameta.allure.Muted} annotation is present, false otherwise.
+     */
+    public static boolean isMuted(final Collection<Annotation> annotations) {
+        return findMetaAnnotations(Muted.class, annotations).findAny().isPresent();
+    }
+
+    /**
+     * Returns the severity specified by the {@link io.qameta.allure.Severity} annotation. The
+     * annotation is also discovered when used as a meta annotation on other (custom) annotations.
+     *
+     * @param annotatedElement the element to search annotations on.
+     * @return the discovered severity, if any.
+     */
+    public static Optional<SeverityLevel> getSeverity(final AnnotatedElement annotatedElement) {
+        return getSeverity(asList(annotatedElement.getAnnotations()));
+    }
+
+    /**
+     * Returns the severity specified by the {@link io.qameta.allure.Severity} annotation within
+     * given annotations. A directly declared {@link io.qameta.allure.Severity} takes precedence;
+     * otherwise the annotation is also discovered when used as a meta annotation on other (custom)
+     * annotations.
+     *
+     * @param annotations annotations to analyse.
+     * @return the discovered severity, if any.
+     */
+    public static Optional<SeverityLevel> getSeverity(final Collection<Annotation> annotations) {
+        return annotations.stream()
+                .filter(Severity.class::isInstance)
+                .map(Severity.class::cast)
+                .findFirst()
+                .map(Optional::of)
+                .orElseGet(() -> findMetaAnnotations(Severity.class, annotations).findFirst())
+                .map(Severity::value);
     }
 
     /**
@@ -167,6 +225,33 @@ public final class AnnotationUtils {
             return Stream.concat(current, children);
         }
         return Stream.empty();
+    }
+
+    // Unlike AnnotatedElement#getAnnotationsByType, discovers annotations of the given type even
+    // when they are used as a meta annotation on another (custom) annotation.
+    private static <T extends Annotation> Stream<T> findMetaAnnotations(
+                                                                        final Class<T> annotationType,
+                                                                        final Collection<Annotation> candidates) {
+        final Set<Annotation> visited = new HashSet<>();
+        return candidates.stream()
+                .flatMap(AnnotationUtils::extractRepeatable)
+                .flatMap(candidate -> findMetaAnnotations(annotationType, candidate, visited));
+    }
+
+    private static <T extends Annotation> Stream<T> findMetaAnnotations(
+                                                                        final Class<T> annotationType,
+                                                                        final Annotation candidate,
+                                                                        final Set<Annotation> visited) {
+        if (isInJavaLangAnnotationPackage(candidate.annotationType()) || !visited.add(candidate)) {
+            return Stream.empty();
+        }
+        final Stream<T> current = annotationType.equals(candidate.annotationType())
+                ? Stream.of(annotationType.cast(candidate))
+                : Stream.empty();
+        final Stream<T> children = Stream.of(candidate.annotationType().getAnnotations())
+                .flatMap(AnnotationUtils::extractRepeatable)
+                .flatMap(annotation -> findMetaAnnotations(annotationType, annotation, visited));
+        return Stream.concat(current, children);
     }
 
     private static Stream<Label> extractLabels(final LabelAnnotation m, final Annotation annotation) {

--- a/allure-java-commons/src/test/java/io/qameta/allure/util/AnnotationUtilsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/util/AnnotationUtilsTest.java
@@ -19,13 +19,17 @@ import io.github.glytching.junit.extension.system.SystemProperty;
 import io.qameta.allure.Epic;
 import io.qameta.allure.Epics;
 import io.qameta.allure.Feature;
+import io.qameta.allure.Flaky;
 import io.qameta.allure.Issue;
 import io.qameta.allure.Issues;
 import io.qameta.allure.LabelAnnotation;
 import io.qameta.allure.Link;
 import io.qameta.allure.LinkAnnotation;
 import io.qameta.allure.Links;
+import io.qameta.allure.Muted;
 import io.qameta.allure.Owner;
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
 import io.qameta.allure.Story;
 import io.qameta.allure.TmsLink;
 import io.qameta.allure.TmsLinks;
@@ -42,6 +46,9 @@ import java.util.Set;
 import static io.qameta.allure.Allure.step;
 import static io.qameta.allure.util.AnnotationUtils.getLabels;
 import static io.qameta.allure.util.AnnotationUtils.getLinks;
+import static io.qameta.allure.util.AnnotationUtils.getSeverity;
+import static io.qameta.allure.util.AnnotationUtils.isFlaky;
+import static io.qameta.allure.util.AnnotationUtils.isMuted;
 import static io.qameta.allure.util.ResultsUtils.EPIC_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.FEATURE_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.STORY_LABEL_NAME;
@@ -495,6 +502,99 @@ class AnnotationUtilsTest {
                         tuple("i-2", "issue"),
                         tuple("example", "custom")
                 );
+    }
+
+    @Flaky
+    @Muted
+    @Severity(SeverityLevel.MINOR)
+    static class WithDirectStatusAnnotations {
+    }
+
+    static class WithoutStatusAnnotations {
+    }
+
+    @Test
+    void shouldDetectDirectFlakyMutedSeverity() {
+        assertThat(isFlaky(WithDirectStatusAnnotations.class)).isTrue();
+        assertThat(isMuted(WithDirectStatusAnnotations.class)).isTrue();
+        assertThat(getSeverity(WithDirectStatusAnnotations.class)).contains(SeverityLevel.MINOR);
+    }
+
+    @Test
+    void shouldReturnDefaultsWhenStatusAnnotationsAbsent() {
+        assertThat(isFlaky(WithoutStatusAnnotations.class)).isFalse();
+        assertThat(isMuted(WithoutStatusAnnotations.class)).isFalse();
+        assertThat(getSeverity(WithoutStatusAnnotations.class)).isEmpty();
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD, ElementType.TYPE})
+    @Flaky
+    @Muted
+    @Severity(SeverityLevel.CRITICAL)
+    @interface CriticalUnstable {
+    }
+
+    @CriticalUnstable
+    static class WithComposedStatusAnnotation {
+    }
+
+    @Test
+    void shouldDetectFlakyMutedSeverityViaMetaAnnotation() {
+        assertThat(isFlaky(WithComposedStatusAnnotation.class)).isTrue();
+        assertThat(isMuted(WithComposedStatusAnnotation.class)).isTrue();
+        assertThat(getSeverity(WithComposedStatusAnnotation.class)).contains(SeverityLevel.CRITICAL);
+    }
+
+    @CriticalUnstable
+    @Severity(SeverityLevel.MINOR)
+    static class ComposedBeforeDirectSeverity {
+    }
+
+    @Severity(SeverityLevel.MINOR)
+    @CriticalUnstable
+    static class DirectBeforeComposedSeverity {
+    }
+
+    @Test
+    void directSeverityShouldTakePrecedenceOverMetaAnnotation() {
+        // regardless of declaration order, the directly declared @Severity(MINOR) must win over
+        // the CRITICAL severity contributed by the @CriticalUnstable meta annotation
+        assertThat(getSeverity(ComposedBeforeDirectSeverity.class)).contains(SeverityLevel.MINOR);
+        assertThat(getSeverity(DirectBeforeComposedSeverity.class)).contains(SeverityLevel.MINOR);
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD, ElementType.TYPE})
+    @CriticalUnstable
+    @interface NestedUnstable {
+    }
+
+    @NestedUnstable
+    static class WithNestedComposedStatusAnnotation {
+    }
+
+    @Test
+    void shouldDetectFlakyMutedSeverityViaNestedMetaAnnotation() {
+        assertThat(isFlaky(WithNestedComposedStatusAnnotation.class)).isTrue();
+        assertThat(isMuted(WithNestedComposedStatusAnnotation.class)).isTrue();
+        assertThat(getSeverity(WithNestedComposedStatusAnnotation.class)).contains(SeverityLevel.CRITICAL);
+    }
+
+    @Flaky
+    @Muted
+    @Severity(SeverityLevel.BLOCKER)
+    static class UnstableParent {
+    }
+
+    static class UnstableChild extends UnstableParent {
+    }
+
+    @Test
+    void shouldInheritStatusAnnotationsFromSuperclass() {
+        assertThat(isFlaky(UnstableChild.class)).isTrue();
+        assertThat(isMuted(UnstableChild.class)).isTrue();
+        assertThat(getSeverity(UnstableChild.class)).contains(SeverityLevel.BLOCKER);
     }
 
     private static Set<Label> getLabelsFor(final Class<?> annotatedClass) {

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
@@ -20,8 +20,6 @@ import io.qameta.allure.AllureExternalKey;
 import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.AttachmentOptions;
 import io.qameta.allure.Description;
-import io.qameta.allure.Severity;
-import io.qameta.allure.SeverityLevel;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Status;
@@ -610,11 +608,21 @@ public class AllureJunitPlatform implements TestExecutionListener {
 
         result.setDescription(description);
 
-        testMethod.map(this::getSeverity)
+        testMethod.map(AnnotationUtils::getSeverity)
                 .filter(Optional::isPresent)
-                .orElse(testClass.flatMap(this::getSeverity))
+                .orElse(testClass.flatMap(AnnotationUtils::getSeverity))
                 .map(ResultsUtils::createSeverityLabel)
                 .ifPresent(result.getLabels()::add);
+
+        final boolean flaky = testMethod.map(AnnotationUtils::isFlaky).orElse(false)
+                || testClass.map(AnnotationUtils::isFlaky).orElse(false);
+        final boolean muted = testMethod.map(AnnotationUtils::isMuted).orElse(false)
+                || testClass.map(AnnotationUtils::isMuted).orElse(false);
+        result.setStatusDetails(
+                new StatusDetails()
+                        .setFlaky(flaky)
+                        .setMuted(muted)
+        );
 
         testMethod.ifPresent(
                 method -> ResultsUtils.processDescription(
@@ -779,12 +787,6 @@ public class AllureJunitPlatform implements TestExecutionListener {
         }
         Collections.reverse(result);
         return result;
-    }
-
-    private Optional<SeverityLevel> getSeverity(final AnnotatedElement annotatedElement) {
-        return getAnnotations(annotatedElement, Severity.class)
-                .map(Severity::value)
-                .findAny();
     }
 
     private Optional<String> getDisplayName(final AnnotatedElement annotatedElement) {

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -27,8 +27,10 @@ import io.qameta.allure.junitplatform.features.DisabledRepeatedTests;
 import io.qameta.allure.junitplatform.features.DisabledTests;
 import io.qameta.allure.junitplatform.features.DynamicTests;
 import io.qameta.allure.junitplatform.features.FailedTests;
+import io.qameta.allure.junitplatform.features.FlakyMutedTest;
 import io.qameta.allure.junitplatform.features.JupiterUniqueIdTest;
 import io.qameta.allure.junitplatform.features.MarkerAnnotationSupport;
+import io.qameta.allure.junitplatform.features.MetaAnnotationTest;
 import io.qameta.allure.junitplatform.features.NestedDisplayNameTests;
 import io.qameta.allure.junitplatform.features.NestedTests;
 import io.qameta.allure.junitplatform.features.OneTest;
@@ -807,6 +809,47 @@ public class AllureJunitPlatformTest {
                 .filteredOn("name", SEVERITY_LABEL_NAME)
                 .extracting(Label::getValue)
                 .contains("trivial");
+    }
+
+    @AllureFeatures.MarkerAnnotations
+    @Test
+    void shouldSetFlakyAndMuted() {
+        final AllureResults results = runClasses(FlakyMutedTest.class);
+        assertThat(results.getTestResults())
+                .filteredOn("name", "passedFlakyMuted()")
+                .extracting(tr -> tr.getStatusDetails().isFlaky(), tr -> tr.getStatusDetails().isMuted())
+                .containsExactly(tuple(true, true));
+    }
+
+    @AllureFeatures.MarkerAnnotations
+    @Test
+    void shouldKeepFlakyAndMutedForFailedTest() {
+        final AllureResults results = runClasses(FlakyMutedTest.class);
+        assertThat(results.getTestResults())
+                .filteredOn("name", "failedFlakyMuted()")
+                .extracting(
+                        TestResult::getStatus,
+                        tr -> tr.getStatusDetails().isFlaky(),
+                        tr -> tr.getStatusDetails().isMuted()
+                )
+                .containsExactly(tuple(Status.FAILED, true, true));
+    }
+
+    @AllureFeatures.MarkerAnnotations
+    @Test
+    void shouldSupportFlakyMutedSeverityAsMetaAnnotation() {
+        final AllureResults results = runClasses(MetaAnnotationTest.class);
+        final List<TestResult> testResults = results.getTestResults();
+
+        assertThat(testResults)
+                .extracting(tr -> tr.getStatusDetails().isFlaky(), tr -> tr.getStatusDetails().isMuted())
+                .containsExactly(tuple(true, true));
+
+        assertThat(testResults)
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn("name", SEVERITY_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly("critical");
     }
 
     @AllureFeatures.MarkerAnnotations

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/CriticalUnstable.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/CriticalUnstable.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import io.qameta.allure.Flaky;
+import io.qameta.allure.Muted;
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Custom annotation composed of {@link Flaky}, {@link Muted} and {@link Severity} to verify that
+ * these annotations are discovered when used as meta annotations.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Flaky
+@Muted
+@Severity(SeverityLevel.CRITICAL)
+public @interface CriticalUnstable {
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/FlakyMutedTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/FlakyMutedTest.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import io.qameta.allure.Flaky;
+import io.qameta.allure.Muted;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FlakyMutedTest {
+
+    @Flaky
+    @Muted
+    @Test
+    void passedFlakyMuted() {
+    }
+
+    @Flaky
+    @Muted
+    @Test
+    void failedFlakyMuted() {
+        Assertions.fail("expected failure");
+    }
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/MetaAnnotationTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/MetaAnnotationTest.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import org.junit.jupiter.api.Test;
+
+public class MetaAnnotationTest {
+
+    @CriticalUnstable
+    @Test
+    void metaAnnotatedTest() {
+    }
+}

--- a/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
+++ b/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
@@ -18,6 +18,7 @@ package io.qameta.allure.junit4;
 import io.qameta.allure.Allure;
 import io.qameta.allure.AllureExternalKey;
 import io.qameta.allure.AllureLifecycle;
+import io.qameta.allure.SeverityLevel;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Status;
@@ -45,6 +46,7 @@ import static io.qameta.allure.util.ResultsUtils.createFrameworkLabel;
 import static io.qameta.allure.util.ResultsUtils.createHostLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
 import static io.qameta.allure.util.ResultsUtils.createPackageLabel;
+import static io.qameta.allure.util.ResultsUtils.createSeverityLabel;
 import static io.qameta.allure.util.ResultsUtils.createSuiteLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestClassLabel;
 import static io.qameta.allure.util.ResultsUtils.createTestMethodLabel;
@@ -151,9 +153,10 @@ public class AllureJunit4 extends RunListener {
         }
         final AllureExternalKey testKey = getTestKey(failure.getDescription());
         getLifecycle().updateTest(
-                testKey, testResult -> testResult
-                        .setStatus(getStatus(failure.getException()).orElse(null))
-                        .setStatusDetails(getStatusDetails(failure.getException()).orElse(null))
+                testKey, testResult -> {
+                    testResult.setStatus(getStatus(failure.getException()).orElse(null));
+                    mergeStatusDetails(testResult, getStatusDetails(failure.getException()).orElse(null));
+                }
         );
     }
 
@@ -167,8 +170,10 @@ public class AllureJunit4 extends RunListener {
         }
         final AllureExternalKey testKey = getTestKey(failure.getDescription());
         getLifecycle().updateTest(
-                testKey, testResult -> testResult.setStatus(Status.SKIPPED)
-                        .setStatusDetails(getStatusDetails(failure.getException()).orElse(null))
+                testKey, testResult -> {
+                    testResult.setStatus(Status.SKIPPED);
+                    mergeStatusDetails(testResult, getStatusDetails(failure.getException()).orElse(null));
+                }
         );
     }
 
@@ -184,7 +189,7 @@ public class AllureJunit4 extends RunListener {
 
         final TestResult result = createTestResult(description);
         result.setStatus(Status.SKIPPED);
-        result.setStatusDetails(getIgnoredMessage(description));
+        result.getStatusDetails().setMessage(getIgnoredMessage(description));
 
         getLifecycle().scheduleTest(testKey, result);
         getLifecycle().addDefaultLabels(testKey, createDefaultLabels(description));
@@ -266,12 +271,11 @@ public class AllureJunit4 extends RunListener {
                 .orElse("");
     }
 
-    private StatusDetails getIgnoredMessage(final Description description) {
+    private String getIgnoredMessage(final Description description) {
         final Ignore ignore = description.getAnnotation(Ignore.class);
-        final String message = Objects.nonNull(ignore) && !ignore.value().isEmpty()
+        return Objects.nonNull(ignore) && !ignore.value().isEmpty()
                 ? ignore.value()
                 : "Test ignored (without reason)!";
-        return new StatusDetails().setMessage(message);
     }
 
     private AllureExternalKey getTestKey(final Description description) {
@@ -309,12 +313,61 @@ public class AllureJunit4 extends RunListener {
             testResult.getLabels().add(createTestMethodLabel(methodName));
         }
         testResult.getLabels().addAll(extractLabels(description));
+        getSeverity(description)
+                .map(severity -> createSeverityLabel(severity))
+                .ifPresent(testResult.getLabels()::add);
         testResult.getLinks().addAll(extractLinks(description));
+
+        testResult.setStatusDetails(
+                new StatusDetails()
+                        .setFlaky(isFlaky(description))
+                        .setMuted(isMuted(description))
+        );
 
         getDisplayName(description).ifPresent(testResult::setName);
 
         getDescription(description).ifPresent(testResult::setDescription);
         return testResult;
+    }
+
+    private boolean isFlaky(final Description description) {
+        return AnnotationUtils.isFlaky(description.getAnnotations())
+                || Optional.ofNullable(description.getTestClass())
+                        .map(AnnotationUtils::isFlaky)
+                        .orElse(false);
+    }
+
+    private boolean isMuted(final Description description) {
+        return AnnotationUtils.isMuted(description.getAnnotations())
+                || Optional.ofNullable(description.getTestClass())
+                        .map(AnnotationUtils::isMuted)
+                        .orElse(false);
+    }
+
+    private Optional<SeverityLevel> getSeverity(final Description description) {
+        final Optional<SeverityLevel> methodSeverity = AnnotationUtils.getSeverity(description.getAnnotations());
+        if (methodSeverity.isPresent()) {
+            return methodSeverity;
+        }
+        return Optional.ofNullable(description.getTestClass())
+                .flatMap(AnnotationUtils::getSeverity);
+    }
+
+    private static void mergeStatusDetails(final TestResult testResult, final StatusDetails details) {
+        if (Objects.isNull(details)) {
+            return;
+        }
+        // merge the exception details into the existing status details so that
+        // the flaky/muted flags set at test start are not overwritten
+        final StatusDetails current = testResult.getStatusDetails();
+        if (Objects.isNull(current)) {
+            testResult.setStatusDetails(details);
+        } else {
+            current.setMessage(details.getMessage())
+                    .setTrace(details.getTrace())
+                    .setActual(details.getActual())
+                    .setExpected(details.getExpected());
+        }
     }
 
     private List<Label> createDefaultLabels(final Description description) {

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
@@ -23,10 +23,14 @@ import io.qameta.allure.junit4.samples.BrokenWithoutMessageTest;
 import io.qameta.allure.junit4.samples.DescriptionsJavadoc;
 import io.qameta.allure.junit4.samples.FailedTest;
 import io.qameta.allure.junit4.samples.FilterSimpleTests;
+import io.qameta.allure.junit4.samples.FlakyMutedOnClassTest;
+import io.qameta.allure.junit4.samples.FlakyMutedTest;
 import io.qameta.allure.junit4.samples.IgnoredClassTest;
 import io.qameta.allure.junit4.samples.IgnoredTests;
+import io.qameta.allure.junit4.samples.MetaAnnotationTest;
 import io.qameta.allure.junit4.samples.OneTest;
 import io.qameta.allure.junit4.samples.RuntimeParametersTest;
+import io.qameta.allure.junit4.samples.SeverityTest;
 import io.qameta.allure.junit4.samples.TaggedTests;
 import io.qameta.allure.junit4.samples.TestBasedOnSampleRunner;
 import io.qameta.allure.junit4.samples.TestWithAnnotations;
@@ -60,6 +64,7 @@ import static io.qameta.allure.junit4.samples.TaggedTests.METHOD_TAG1;
 import static io.qameta.allure.junit4.samples.TaggedTests.METHOD_TAG2;
 import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
 import static io.qameta.allure.util.ResultsUtils.HOST_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.SEVERITY_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.THREAD_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.md5;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -321,6 +326,84 @@ class AllureJunit4Test {
                         "story1", "story2", "story3",
                         "some-owner"
                 );
+    }
+
+    @Test
+    @AllureFeatures.Severity
+    void shouldProcessSeverityAnnotation() {
+        final AllureResults results = runClasses(SeverityTest.class);
+        final List<TestResult> testResults = results.getTestResults();
+
+        assertThat(testResults)
+                .filteredOn(TestResult::getName, "criticalSeverityTest")
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(Label::getName, SEVERITY_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly("critical");
+
+        assertThat(testResults)
+                .filteredOn(TestResult::getName, "defaultSeverityTest")
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(Label::getName, SEVERITY_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly("trivial");
+    }
+
+    @Test
+    @AllureFeatures.MarkerAnnotations
+    void shouldProcessFlakyAndMutedAnnotations() {
+        final AllureResults results = runClasses(FlakyMutedTest.class);
+        assertThat(results.getTestResults())
+                .extracting(
+                        TestResult::getName,
+                        tr -> tr.getStatusDetails().isFlaky(),
+                        tr -> tr.getStatusDetails().isMuted()
+                )
+                .contains(tuple("passedFlakyMutedTest", true, true));
+    }
+
+    @Test
+    @AllureFeatures.MarkerAnnotations
+    void shouldKeepFlakyAndMutedForFailedTest() {
+        final AllureResults results = runClasses(FlakyMutedTest.class);
+        assertThat(results.getTestResults())
+                .filteredOn(TestResult::getName, "failedFlakyMutedTest")
+                .extracting(
+                        TestResult::getStatus,
+                        tr -> tr.getStatusDetails().isFlaky(),
+                        tr -> tr.getStatusDetails().isMuted()
+                )
+                .containsExactly(tuple(Status.FAILED, true, true));
+    }
+
+    @Test
+    @AllureFeatures.MarkerAnnotations
+    void shouldProcessFlakyAndMutedAnnotationsOnClass() {
+        final AllureResults results = runClasses(FlakyMutedOnClassTest.class);
+        assertThat(results.getTestResults())
+                .extracting(
+                        TestResult::getName,
+                        tr -> tr.getStatusDetails().isFlaky(),
+                        tr -> tr.getStatusDetails().isMuted()
+                )
+                .containsExactly(tuple("someTest", true, true));
+    }
+
+    @Test
+    @AllureFeatures.MarkerAnnotations
+    void shouldSupportFlakyMutedSeverityAsMetaAnnotation() {
+        final AllureResults results = runClasses(MetaAnnotationTest.class);
+        final List<TestResult> testResults = results.getTestResults();
+
+        assertThat(testResults)
+                .extracting(tr -> tr.getStatusDetails().isFlaky(), tr -> tr.getStatusDetails().isMuted())
+                .containsExactly(tuple(true, true));
+
+        assertThat(testResults)
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(Label::getName, SEVERITY_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly("critical");
     }
 
     @Test

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/CriticalUnstable.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/CriticalUnstable.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import io.qameta.allure.Flaky;
+import io.qameta.allure.Muted;
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Flaky
+@Muted
+@Severity(SeverityLevel.CRITICAL)
+public @interface CriticalUnstable {
+}

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/FlakyMutedOnClassTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/FlakyMutedOnClassTest.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import io.qameta.allure.Flaky;
+import io.qameta.allure.Muted;
+import org.junit.Test;
+
+@Flaky
+@Muted
+public class FlakyMutedOnClassTest {
+
+    @Test
+    public void someTest() {
+    }
+}

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/FlakyMutedTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/FlakyMutedTest.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import io.qameta.allure.Flaky;
+import io.qameta.allure.Muted;
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class FlakyMutedTest {
+
+    @Flaky
+    @Muted
+    @Test
+    public void passedFlakyMutedTest() {
+    }
+
+    @Flaky
+    @Muted
+    @Test
+    public void failedFlakyMutedTest() {
+        fail("expected failure");
+    }
+}

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/MetaAnnotationTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/MetaAnnotationTest.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import org.junit.Test;
+
+public class MetaAnnotationTest {
+
+    @CriticalUnstable
+    @Test
+    public void metaAnnotatedTest() {
+    }
+}

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/SeverityTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/SeverityTest.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
+import org.junit.Test;
+
+@Severity(SeverityLevel.TRIVIAL)
+public class SeverityTest {
+
+    @Severity(SeverityLevel.CRITICAL)
+    @Test
+    public void criticalSeverityTest() {
+    }
+
+    @Test
+    public void defaultSeverityTest() {
+    }
+}

--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -210,6 +211,11 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         labels.addAll(testTags);
         labels.addAll(featureLabels);
         labels.addAll(specLabels);
+        AnnotationUtils.getSeverity(method)
+                .map(Optional::of)
+                .orElseGet(() -> AnnotationUtils.getSeverity(clazz))
+                .map(ResultsUtils::createSeverityLabel)
+                .ifPresent(labels::add);
         labels.addAll(getProvidedLabels());
 
         final List<Link> links = new ArrayList<>(featureLinks);

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
@@ -34,6 +34,7 @@ import io.qameta.allure.spock2.samples.FailedTest;
 import io.qameta.allure.spock2.samples.FailedTestWithAnnotations;
 import io.qameta.allure.spock2.samples.FixturesTest;
 import io.qameta.allure.spock2.samples.HelloSpockSpec;
+import io.qameta.allure.spock2.samples.MetaAnnotatedTest;
 import io.qameta.allure.spock2.samples.OneTest;
 import io.qameta.allure.spock2.samples.ParametersTest;
 import io.qameta.allure.spock2.samples.RuntimeParameterTest;
@@ -43,6 +44,7 @@ import io.qameta.allure.spock2.samples.StepsAndBlocks;
 import io.qameta.allure.spock2.samples.TestWithAnnotations;
 import io.qameta.allure.spock2.samples.TestWithAnnotationsOnClass;
 import io.qameta.allure.spock2.samples.TestWithCustomAnnotations;
+import io.qameta.allure.spock2.samples.TestWithSeverity;
 import io.qameta.allure.spock2.samples.TestWithSteps;
 import io.qameta.allure.spock2.samples.TestsWithIdForFilter;
 import io.qameta.allure.test.AllureFeatures;
@@ -78,6 +80,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
+import static io.qameta.allure.util.ResultsUtils.SEVERITY_LABEL_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
@@ -335,6 +338,42 @@ class AllureSpock2Test {
                 .contains(
                         "epic", "feature", "story", "AS-1", "XRT-1"
                 );
+    }
+
+    @Test
+    void shouldProcessSeverityAnnotation() {
+        final AllureResults results = runClasses(TestWithSeverity.class);
+        final List<TestResult> testResults = results.getTestResults();
+
+        assertThat(testResults)
+                .filteredOn(TestResult::getName, "criticalSeverityTest")
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(Label::getName, SEVERITY_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly("critical");
+
+        assertThat(testResults)
+                .filteredOn(TestResult::getName, "defaultSeverityTest")
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(Label::getName, SEVERITY_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly("trivial");
+    }
+
+    @Test
+    void shouldSupportFlakyMutedSeverityAsMetaAnnotation() {
+        final AllureResults results = runClasses(MetaAnnotatedTest.class);
+        final List<TestResult> testResults = results.getTestResults();
+
+        assertThat(testResults)
+                .extracting(tr -> tr.getStatusDetails().isFlaky(), tr -> tr.getStatusDetails().isMuted())
+                .containsExactly(tuple(true, true));
+
+        assertThat(testResults)
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(Label::getName, SEVERITY_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly("critical");
     }
 
     @Test

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/CriticalUnstable.java
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/CriticalUnstable.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.spock2.samples;
+
+import io.qameta.allure.Flaky;
+import io.qameta.allure.Muted;
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Flaky
+@Muted
+@Severity(SeverityLevel.CRITICAL)
+public @interface CriticalUnstable {
+}

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/MetaAnnotatedTest.groovy
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/MetaAnnotatedTest.groovy
@@ -1,0 +1,27 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.spock2.samples
+
+import spock.lang.Specification
+
+class MetaAnnotatedTest extends Specification {
+
+    @CriticalUnstable
+    def "metaAnnotatedTest"() {
+        expect:
+        true
+    }
+}

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/TestWithSeverity.groovy
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/TestWithSeverity.groovy
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.spock2.samples
+
+import io.qameta.allure.Severity
+import io.qameta.allure.SeverityLevel
+import spock.lang.Specification
+
+@Severity(SeverityLevel.TRIVIAL)
+class TestWithSeverity extends Specification {
+
+    @Severity(SeverityLevel.CRITICAL)
+    def "criticalSeverityTest"() {
+        expect:
+        true
+    }
+
+    def "defaultSeverityTest"() {
+        expect:
+        true
+    }
+}

--- a/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
+++ b/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
@@ -18,10 +18,6 @@ package io.qameta.allure.testng;
 import io.qameta.allure.Allure;
 import io.qameta.allure.AllureExternalKey;
 import io.qameta.allure.AllureLifecycle;
-import io.qameta.allure.Flaky;
-import io.qameta.allure.Muted;
-import io.qameta.allure.Severity;
-import io.qameta.allure.SeverityLevel;
 import io.qameta.allure.model.FixtureResult;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
@@ -59,7 +55,6 @@ import org.testng.internal.ConstructorOrMethod;
 import org.testng.xml.XmlSuite;
 import org.testng.xml.XmlTest;
 
-import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -929,18 +924,12 @@ public class AllureTestNg
                 .ifPresent(labels::addAll);
 
         getMethod(method)
-                .map(this::getSeverity)
+                .map(AnnotationUtils::getSeverity)
                 .filter(Optional::isPresent)
-                .orElse(getClass(iClass).flatMap(this::getSeverity))
+                .orElse(getClass(iClass).flatMap(AnnotationUtils::getSeverity))
                 .map(ResultsUtils::createSeverityLabel)
                 .ifPresent(labels::add);
         return labels;
-    }
-
-    private Optional<SeverityLevel> getSeverity(final AnnotatedElement annotatedElement) {
-        return Stream.of(annotatedElement.getAnnotationsByType(Severity.class))
-                .map(Severity::value)
-                .findAny();
     }
 
     private List<Link> getLinks(final ITestNGMethod method, final IClass iClass) {
@@ -956,20 +945,20 @@ public class AllureTestNg
 
     private boolean isFlaky(final ITestNGMethod method, final IClass iClass) {
         final boolean flakyMethod = getMethod(method)
-                .map(m -> m.isAnnotationPresent(Flaky.class))
+                .map(AnnotationUtils::isFlaky)
                 .orElse(false);
         final boolean flakyClass = getClass(iClass)
-                .map(clazz -> clazz.isAnnotationPresent(Flaky.class))
+                .map(AnnotationUtils::isFlaky)
                 .orElse(false);
         return flakyMethod || flakyClass;
     }
 
     private boolean isMuted(final ITestNGMethod method, final IClass iClass) {
         final boolean mutedMethod = getMethod(method)
-                .map(m -> m.isAnnotationPresent(Muted.class))
+                .map(AnnotationUtils::isMuted)
                 .orElse(false);
         final boolean mutedClass = getClass(iClass)
-                .map(clazz -> clazz.isAnnotationPresent(Muted.class))
+                .map(AnnotationUtils::isMuted)
                 .orElse(false);
         return mutedMethod || mutedClass;
     }

--- a/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
@@ -1172,6 +1172,24 @@ public class AllureTestNgTest {
                 .hasSize(2);
     }
 
+    @AllureFeatures.MarkerAnnotations
+    @Test
+    @DisplayName("Should support flaky, muted and severity as meta annotations")
+    public void shouldSupportFlakyMutedSeverityAsMetaAnnotation() {
+        final AllureResults results = runTestNgSuites("suites/meta-annotation.xml");
+        final List<TestResult> testResults = results.getTestResults();
+
+        assertThat(testResults)
+                .extracting(tr -> tr.getStatusDetails().isFlaky(), tr -> tr.getStatusDetails().isMuted())
+                .containsExactly(tuple(true, true));
+
+        assertThat(testResults)
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(label -> "severity".equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactly("critical");
+    }
+
     @AllureFeatures.Severity
     @Test
     @DisplayName("Should add severity for tests")

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/CriticalUnstable.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/CriticalUnstable.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import io.qameta.allure.Flaky;
+import io.qameta.allure.Muted;
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Flaky
+@Muted
+@Severity(SeverityLevel.CRITICAL)
+public @interface CriticalUnstable {
+}

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/MetaAnnotationTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/MetaAnnotationTest.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import org.testng.annotations.Test;
+
+public class MetaAnnotationTest {
+
+    @CriticalUnstable
+    @Test
+    public void metaAnnotatedTest() {
+    }
+}

--- a/allure-testng/src/test/resources/suites/meta-annotation.xml
+++ b/allure-testng/src/test/resources/suites/meta-annotation.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Meta annotation suite">
+    <test name="Meta annotation tests">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.MetaAnnotationTest"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure Java now recognizes `@Flaky`, `@Muted`, and `@Severity` when they are composed into custom annotations, including nested compositions. These annotations work at method and class level with JUnit Platform, JUnit 4, Spock 2, and TestNG. An explicitly declared `@Severity` continues to take precedence over a composed value.

```java
@Retention(RetentionPolicy.RUNTIME)
@Target({ElementType.METHOD, ElementType.TYPE})
@Flaky
@Muted
@Severity(SeverityLevel.CRITICAL)
public @interface CriticalUnstable {
}
```

The custom annotation can then provide consistent reporting metadata across a test suite:

```java
@CriticalUnstable
@Test
void retriesPaymentAfterTransientFailure() {
    // ...
}

@CriticalUnstable
class ExperimentalCheckoutTests {
    // ...
}
```

JUnit Platform and JUnit 4 also retain flaky and muted flags when failed tests add exception details, while JUnit 4 and Spock 2 now report severity consistently with the other adapters.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2