### PR TITLE
Preserve test failures when stack traces cannot be fully rendered

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -870,7 +870,18 @@ public final class ResultsUtils {
 
     private static String getStackTraceAsString(final Throwable throwable) {
         final StringWriter stringWriter = new StringWriter();
-        throwable.printStackTrace(new PrintWriter(stringWriter));
+        try {
+            throwable.printStackTrace(new PrintWriter(stringWriter));
+        } catch (RuntimeException e) {
+            if (stringWriter.getBuffer().length() == 0) {
+                stringWriter.append(throwable.getClass().getName());
+            }
+            stringWriter
+                    .append(System.lineSeparator())
+                    .append("[Unable to render the complete stack trace: ")
+                    .append(e.getClass().getName())
+                    .append(']');
+        }
         return stringWriter.toString();
     }
 

--- a/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.ValueWrapper;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.List;
@@ -48,6 +49,10 @@ import static io.qameta.allure.util.ResultsUtils.createTitlePathFromSourcePath;
 import static io.qameta.allure.util.ResultsUtils.createTmsLink;
 import static io.qameta.allure.util.ResultsUtils.getLinkTypePatternPropertyName;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 @ExtendWith(SystemPropertyExtension.class)
 class ResultsUtilsTest {
 
@@ -397,6 +402,27 @@ class ResultsUtilsTest {
 
         assertThat(details.getActual()).startsWith("actual value (");
         assertThat(details.getExpected()).startsWith("expected value (");
+    }
+
+    @Test
+    @Issue("1035")
+    void shouldCreateStatusDetailsWhenNestedStackTraceCannotBeRendered() {
+        final RuntimeException cause = mock(RuntimeException.class);
+        when(cause.getSuppressed()).thenReturn(null);
+        final AssertionFailedError error = assertThrows(
+                AssertionFailedError.class,
+                () -> assertThrows(IOException.class, () -> {
+                    throw cause;
+                })
+        );
+
+        final StatusDetails details = getStatusDetailsFor("malformed nested throwable", error);
+
+        assertThat(details.getMessage()).startsWith("Unexpected exception type thrown");
+        assertThat(details.getTrace())
+                .contains(AssertionFailedError.class.getName())
+                .contains("Caused by:")
+                .contains("[Unable to render the complete stack trace: java.lang.NullPointerException]");
     }
 
     @Test


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure now keeps the original test failure and available stack trace when Java cannot completely render a nested exception. This prevents malformed or mocked exceptions from causing an additional `NullPointerException` in Allure and hiding the test’s real status details.

When rendering is incomplete, the report preserves the partial stack trace and clearly identifies the rendering failure so users can still diagnose the original assertion error.

fixes #1035

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2