### PR TITLE
Preserve manually assigned step statuses

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
@@ -175,7 +175,11 @@ public final class Allure {
 
         try {
             final T result = runnable.run(new DefaultStepContext(key));
-            getLifecycle().updateStep(key, step -> step.setStatus(Status.PASSED));
+            getLifecycle().updateStep(key, step -> {
+                if (Objects.isNull(step.getStatus())) {
+                    step.setStatus(Status.PASSED);
+                }
+            });
             return result;
         } catch (Throwable throwable) {
             getLifecycle().updateStep(

--- a/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/aspects/StepsAspects.java
@@ -130,7 +130,11 @@ public class StepsAspects {
         if (Objects.isNull(key)) {
             return;
         }
-        getLifecycle().updateStep(key, s -> s.setStatus(Status.PASSED));
+        getLifecycle().updateStep(key, step -> {
+            if (Objects.isNull(step.getStatus())) {
+                step.setStatus(Status.PASSED);
+            }
+        });
         getLifecycle().stopStep();
     }
 

--- a/allure-java-commons/src/test/java/io/qameta/allure/AllureTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AllureTest.java
@@ -109,6 +109,38 @@ class AllureTest {
                 );
     }
 
+    @Issue("1133")
+    @Test
+    void shouldPreserveManuallySetStatusWhenLambdaStepReturns() {
+        final AllureResults results = runWithinTestContext(
+                () -> step(
+                        "step with manually set status",
+                        () -> getLifecycle().updateStep(step -> step.setStatus(Status.FAILED))
+                )
+        );
+
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getSteps)
+                .extracting(StepResult::getStatus)
+                .containsExactly(Status.FAILED);
+    }
+
+    @Issue("1133")
+    @Test
+    void shouldOverrideManuallySetStatusWhenLambdaStepThrows() {
+        final AllureResults results = runWithinTestContext(
+                () -> step("failing step with manually set status", () -> {
+                    getLifecycle().updateStep(step -> step.setStatus(Status.SKIPPED));
+                    throw new AssertionError("some assertion");
+                })
+        );
+
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getSteps)
+                .extracting(StepResult::getStatus)
+                .containsExactly(Status.FAILED);
+    }
+
     void doSomething() {
     }
 

--- a/allure-java-commons/src/test/java/io/qameta/allure/aspects/StepsAspectsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/aspects/StepsAspectsTest.java
@@ -55,6 +55,28 @@ class StepsAspectsTest {
                 .containsExactly("Simple step", "Simple step");
     }
 
+    @Issue("1133")
+    @Test
+    void shouldPreserveManuallySetStatusWhenAnnotatedStepReturns() {
+        final AllureResults results = runWithinTestContext(this::stepWithManuallySetStatus);
+
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getSteps)
+                .extracting(StepResult::getStatus)
+                .containsExactly(Status.FAILED);
+    }
+
+    @Issue("1133")
+    @Test
+    void shouldOverrideManuallySetStatusWhenAnnotatedStepThrows() {
+        final AllureResults results = runWithinTestContext(this::failingStepWithManuallySetStatus);
+
+        assertThat(results.getTestResults())
+                .flatExtracting(TestResult::getSteps)
+                .extracting(StepResult::getStatus)
+                .containsExactly(Status.FAILED);
+    }
+
     @Test
     void shouldKeepStepStatusWithTrailingOpenStage() {
         final AllureResults results = runWithinTestContext(() -> stepWithTrailingStage());
@@ -352,6 +374,17 @@ class StepsAspectsTest {
 
     @Step("Simple step")
     void simpleStep() {
+    }
+
+    @Step
+    void stepWithManuallySetStatus() {
+        Allure.getLifecycle().updateStep(step -> step.setStatus(Status.FAILED));
+    }
+
+    @Step
+    void failingStepWithManuallySetStatus() {
+        Allure.getLifecycle().updateStep(step -> step.setStatus(Status.SKIPPED));
+        throw new AssertionError("some assertion");
     }
 
     @Step("Method {method}")


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Steps created with `@Step` or `Allure.step` now retain a status explicitly assigned while the step is running. For example, a step that sets its status to `FAILED` and then returns normally remains failed instead of being reported as passed.

Steps that throw continue to use the existing exception-based status and failure details, preserving current failure behavior.

fixes #1133

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2