### PR TITLE
Support direct HTTP and HTTPS URLs in link annotations

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -636,7 +636,11 @@ public final class ResultsUtils {
                                   final String url, final String type) {
         final String resolvedName = firstNonEmpty(value).orElse(name);
         final String resolvedUrl = firstNonEmpty(url)
-                .orElseGet(() -> getLinkUrl(resolvedName, type));
+                .orElseGet(
+                        () -> isHttpOrHttpsUrl(resolvedName)
+                                ? resolvedName
+                                : getLinkUrl(resolvedName, type)
+                );
         return new Link()
                 .setName(resolvedName)
                 .setUrl(resolvedUrl)
@@ -845,6 +849,21 @@ public final class ResultsUtils {
             return null;
         }
         return pattern.replaceAll("\\{}", Objects.isNull(name) ? "" : name);
+    }
+
+    private static boolean isHttpOrHttpsUrl(final String value) {
+        if (Objects.isNull(value)) {
+            return false;
+        }
+
+        try {
+            final URI uri = URI.create(value);
+            final String scheme = uri.getScheme();
+            return nonNull(uri.getHost())
+                    && ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme));
+        } catch (IllegalArgumentException ignored) {
+            return false;
+        }
     }
 
     private static String getRealHostName() {

--- a/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
@@ -338,8 +338,44 @@ class ResultsUtilsTest {
         return Stream.of(
                 Arguments.of("a", "b", "c", "d", "e", link("a", "c", "d")),
                 Arguments.of("a", "b", "c", "d", null, link("a", "c", "d")),
+                Arguments.of(
+                        "https://example.org/path?query=value#fragment",
+                        null,
+                        null,
+                        "d",
+                        "pattern/{}/some",
+                        link(
+                                "https://example.org/path?query=value#fragment",
+                                "https://example.org/path?query=value#fragment",
+                                "d"
+                        )
+                ),
+                Arguments.of(
+                        "http://example.org/path",
+                        null,
+                        null,
+                        "d",
+                        null,
+                        link("http://example.org/path", "http://example.org/path", "d")
+                ),
                 Arguments.of("a", "b", null, "d", "invalid-pattern", link("a", "invalid-pattern", "d")),
                 Arguments.of("a", "b", null, "d", "pattern/{}/some", link("a", "pattern/a/some", "d")),
+                Arguments.of(
+                        "ftp://example.org/path",
+                        null,
+                        null,
+                        "d",
+                        "pattern/{}/some",
+                        link("ftp://example.org/path", "pattern/ftp://example.org/path/some", "d")
+                ),
+                Arguments.of(
+                        "https:path-without-host",
+                        null,
+                        null,
+                        "d",
+                        "pattern/{}/some",
+                        link("https:path-without-host", "pattern/https:path-without-host/some", "d")
+                ),
                 Arguments.of(null, null, null, "d", "pattern/{}/some", link(null, "pattern//some", "d")),
                 Arguments.of(null, null, null, null, "pattern/{}/some", link(null, null, null)),
                 Arguments.of(null, "b", null, "d", "pattern/{}/some/{}/and-more", link("b", "pattern/b/some/b/and-more", "d")),

--- a/allure-java-commons/src/test/java/io/qameta/allure/util/AnnotationUtilsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/util/AnnotationUtilsTest.java
@@ -227,7 +227,10 @@ class AnnotationUtilsTest {
                         name = "LINK-2",
                         url = "https://example.org/link/2"
                 ),
-                @Link(url = "https://example.org/some-custom-link")
+                @Link(url = "https://example.org/some-custom-link"),
+                @Link("https://example.org/direct-link"),
+                @Link("http://example.org/direct-link"),
+                @Link("ftp://example.org/pattern-link")
         }
     )
     @TmsLink("TMS-1")
@@ -275,6 +278,13 @@ class AnnotationUtilsTest {
                         tuple("LINK-1", "custom", "https://example.org/custom/LINK-1"),
                         tuple("LINK-2", "custom", "https://example.org/link/2"),
                         tuple("", "custom", "https://example.org/some-custom-link"),
+                        tuple("https://example.org/direct-link", "custom", "https://example.org/direct-link"),
+                        tuple("http://example.org/direct-link", "custom", "http://example.org/direct-link"),
+                        tuple(
+                                "ftp://example.org/pattern-link",
+                                "custom",
+                                "https://example.org/custom/ftp://example.org/pattern-link"
+                        ),
                         tuple("ISSUE-1", "issue", "https://example.org/issue/ISSUE-1"),
                         tuple("ISSUE-2", "issue", "https://example.org/issue/ISSUE-2"),
                         tuple("ISSUE-3", "issue", "https://example.org/issue/ISSUE-3"),


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Link annotations can now use complete HTTP or HTTPS URLs directly without requiring an `allure.link.<type>.pattern` setting. For example, `@Link("https://example.org")` records the supplied value as both the link name and destination.

Configured patterns are bypassed only for valid HTTP(S) URLs. Identifiers, malformed URLs, and unsupported schemes such as FTP continue through the existing pattern resolution.

fixes #480

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2