### PR TITLE
Report skipped Spock features when setupSpec fails

### DIFF
--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -44,7 +44,6 @@ import org.spockframework.runtime.model.BlockKind;
 import org.spockframework.runtime.model.ErrorInfo;
 import org.spockframework.runtime.model.FeatureInfo;
 import org.spockframework.runtime.model.IterationInfo;
-import org.spockframework.runtime.model.MethodInfo;
 import org.spockframework.runtime.model.MethodKind;
 import org.spockframework.runtime.model.SpecInfo;
 import org.spockframework.runtime.model.TestTag;
@@ -65,6 +64,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static io.qameta.allure.util.ResultsUtils.ALLURE_ID_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.createFrameworkLabel;
 import static io.qameta.allure.util.ResultsUtils.createHostLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
@@ -89,7 +89,7 @@ import static io.qameta.allure.util.ResultsUtils.md5;
  *
  * <p>Register this extension with Spock to convert specification, feature, iteration, fixture, and error events into Allure results. The constructor accepting a test plan enables Allure test plan filtering before execution.</p>
  */
-@SuppressWarnings("PMD.GodClass")
+@SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods"})
 public class AllureSpock2 extends AbstractRunListener implements IGlobalExtension, IBlockListener {
 
     private static final String BLOCK = "block";
@@ -173,44 +173,62 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
      */
     @Override
     public void beforeIteration(final IterationInfo iteration) {
-        final String uuid = UUID.randomUUID().toString();
-
         final FeatureInfo feature = iteration.getFeature();
-        final MethodInfo methodInfo = feature.getFeatureMethod();
-        final Method method = methodInfo.getReflection();
+        final List<Parameter> parameters = getParameters(feature.getDataVariables(), iteration.getDataValues());
+        final TestResult result = createTestResult(
+                feature,
+                iteration.getName(),
+                iteration.getDisplayName(),
+                parameters
+        );
+        final String uuid = result.getUuid();
+
+        testResults.set(uuid);
+        final AllureExternalKey testKey = testKey(uuid);
+        getLifecycle().scheduleTest(testKey, result);
+        getLifecycle().addDefaultLabels(testKey, getDefaultLabels(feature.getSpec()));
+        getLifecycle().startTest(testKey);
+        blockSteps.set(new IdentityHashMap<>());
+        activeBlockStep.remove();
+
+    }
+
+    private TestResult createTestResult(final FeatureInfo feature,
+                                        final String testCaseName,
+                                        final String displayName,
+                                        final List<Parameter> parameters) {
+        return createTestResult(
+                feature.getSpec(),
+                feature.getFeatureMethod().getReflection(),
+                feature.getTestTags(),
+                feature.getName(),
+                testCaseName,
+                displayName,
+                parameters
+        );
+    }
+
+    private TestResult createTestResult(final SpecInfo specInfo,
+                                        final Method method,
+                                        final Set<TestTag> testTags,
+                                        final String testMethodName,
+                                        final String testCaseName,
+                                        final String displayName,
+                                        final List<Parameter> parameters) {
         final Set<Label> featureLabels = AnnotationUtils.getLabels(method);
         final Set<Link> featureLinks = AnnotationUtils.getLinks(method);
-        final SpecInfo specInfo = feature.getSpec();
         final Class<?> clazz = specInfo.getReflection();
         final Set<Label> specLabels = AnnotationUtils.getLabels(clazz);
         final Set<Link> specLinks = AnnotationUtils.getLinks(clazz);
         final boolean flaky = AnnotationUtils.isFlaky(method) || AnnotationUtils.isFlaky(clazz);
         final boolean muted = AnnotationUtils.isMuted(method) || AnnotationUtils.isMuted(clazz);
 
-        final List<Parameter> parameters = getParameters(feature.getDataVariables(), iteration.getDataValues());
         final SpecInfo subSpec = specInfo.getSubSpec();
         final SpecInfo superSpec = specInfo.getSuperSpec();
         final String packageName = specInfo.getPackage();
-        final String specName = specInfo.getName();
-        final String testClassName = feature.getSpec().getReflection().getName();
-        // the declared feature name is the source-level identity of the feature method,
-        // stable across data-driven iterations, unlike the resolved iteration display name
-        final String testMethodName = feature.getName();
-        final String displayName = iteration.getDisplayName();
+        final String testClassName = specInfo.getReflection().getName();
 
-        final List<Label> defaultLabels = new ArrayList<>(
-                Collections.singletonList(createSuiteLabel(specName))
-        );
-
-        if (Objects.nonNull(subSpec)) {
-            defaultLabels.add(createSubSuiteLabel(subSpec.getName()));
-        }
-
-        if (Objects.nonNull(superSpec)) {
-            defaultLabels.add(createParentSuiteLabel(superSpec.getName()));
-        }
-
-        final List<Label> testTags = feature.getTestTags().stream()
+        final List<Label> tagLabels = testTags.stream()
                 .map(TestTag::getValue)
                 .map(ResultsUtils::createTagLabel)
                 .collect(Collectors.toList());
@@ -226,7 +244,7 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
                         createLanguageLabel("java")
                 )
         );
-        labels.addAll(testTags);
+        labels.addAll(tagLabels);
         labels.addAll(featureLabels);
         labels.addAll(specLabels);
         AnnotationUtils.getSeverity(method)
@@ -239,23 +257,23 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         final List<Link> links = new ArrayList<>(featureLinks);
         links.addAll(specLinks);
 
-        final String qualifiedName = getQualifiedName(iteration);
+        final String qualifiedName = getQualifiedName(specInfo.getReflection().getName(), testCaseName);
         final List<String> titlePath = new ArrayList<>(createTitlePathFromPackage(packageName));
         titlePath.addAll(
                 createTitlePath(
                         Objects.nonNull(superSpec) ? superSpec.getName() : null,
-                        specName,
+                        specInfo.getName(),
                         Objects.nonNull(subSpec) ? subSpec.getName() : null
                 )
         );
         final TestResult result = new TestResult()
-                .setUuid(uuid)
-                .setTestCaseName(iteration.getName())
+                .setUuid(UUID.randomUUID().toString())
+                .setTestCaseName(testCaseName)
                 .setTestCaseId(md5(qualifiedName))
                 .setFullName(qualifiedName)
                 .setTitlePath(titlePath)
                 .setName(
-                        firstNonEmpty(displayName, iteration.getName(), qualifiedName)
+                        firstNonEmpty(displayName, testCaseName, qualifiedName)
                                 .orElse("Unknown")
                 )
                 .setStatusDetails(
@@ -274,18 +292,91 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
                 result::setDescriptionHtml
         );
 
-        testResults.set(uuid);
-        final AllureExternalKey testKey = testKey(uuid);
-        getLifecycle().scheduleTest(testKey, result);
-        getLifecycle().addDefaultLabels(testKey, defaultLabels);
-        getLifecycle().startTest(testKey);
-        blockSteps.set(new IdentityHashMap<>());
-        activeBlockStep.remove();
-
+        return result;
     }
 
-    private String getQualifiedName(final IterationInfo iteration) {
-        return this.getQualifiedName(iteration.getFeature().getSpec().getReflection().getName(), iteration.getName());
+    private List<Label> getDefaultLabels(final SpecInfo specInfo) {
+        final List<Label> defaultLabels = new ArrayList<>(
+                Collections.singletonList(createSuiteLabel(specInfo.getName()))
+        );
+
+        final SpecInfo subSpec = specInfo.getSubSpec();
+        if (Objects.nonNull(subSpec)) {
+            defaultLabels.add(createSubSuiteLabel(subSpec.getName()));
+        }
+
+        final SpecInfo superSpec = specInfo.getSuperSpec();
+        if (Objects.nonNull(superSpec)) {
+            defaultLabels.add(createParentSuiteLabel(superSpec.getName()));
+        }
+
+        return defaultLabels;
+    }
+
+    private void reportSetupSpecFailure(final IMethodInvocation invocation,
+                                        final String containerUuid,
+                                        final String fixtureName,
+                                        final Throwable throwable) {
+        final StatusDetails failureDetails = getStatusDetails(throwable).orElse(null);
+        final SpecInfo fixtureSpec = invocation.getSpec();
+        final TestResult configurationResult = createTestResult(
+                fixtureSpec,
+                invocation.getMethod().getReflection(),
+                Collections.emptySet(),
+                fixtureName,
+                fixtureName,
+                fixtureName,
+                Collections.emptyList()
+        ).setStatus(getStatus(throwable).orElse(Status.BROKEN));
+        configurationResult.getLabels().add(
+                new Label().setName(ALLURE_ID_LABEL_NAME).setValue("-1")
+        );
+        copyFailureDetails(failureDetails, configurationResult.getStatusDetails());
+        writeCompletedTest(containerUuid, configurationResult, fixtureSpec);
+
+        fixtureSpec.getBottomSpec().getAllFeaturesInExecutionOrder().stream()
+                .filter(feature -> !feature.isExcluded())
+                .filter(feature -> !feature.isSkipped())
+                .forEach(feature -> {
+                    final TestResult skippedResult = createTestResult(
+                            feature,
+                            feature.getName(),
+                            feature.getDisplayName(),
+                            Collections.emptyList()
+                    ).setStatus(Status.SKIPPED);
+                    copyFailureDetails(failureDetails, skippedResult.getStatusDetails());
+                    final String failureMessage = skippedResult.getStatusDetails().getMessage();
+                    skippedResult.getStatusDetails().setMessage(
+                            Objects.isNull(failureMessage)
+                                    ? "Skipped because setup spec failed"
+                                    : "Skipped because setup spec failed: " + failureMessage
+                    );
+                    writeCompletedTest(containerUuid, skippedResult, feature.getSpec());
+                });
+    }
+
+    private void copyFailureDetails(final StatusDetails source, final StatusDetails target) {
+        if (Objects.nonNull(source)) {
+            target.setMessage(source.getMessage())
+                    .setTrace(source.getTrace())
+                    .setActual(source.getActual())
+                    .setExpected(source.getExpected());
+        }
+    }
+
+    private void writeCompletedTest(final String containerUuid,
+                                    final TestResult result,
+                                    final SpecInfo specInfo) {
+        final AllureExternalKey resultKey = testKey(result.getUuid());
+        getLifecycle().scheduleTest(
+                Collections.singletonList(scopeKey(containerUuid)),
+                resultKey,
+                result
+        );
+        getLifecycle().addDefaultLabels(resultKey, getDefaultLabels(specInfo));
+        getLifecycle().startTest(resultKey);
+        getLifecycle().stopTest(resultKey);
+        getLifecycle().writeTest(resultKey);
     }
 
     private String getQualifiedName(final FeatureInfo featureInfo) {
@@ -645,6 +736,7 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
                 );
             }
 
+            Throwable failure = null;
             try {
                 invocation.proceed();
                 getLifecycle().updateFixture(
@@ -658,9 +750,16 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
                                 .setStatus(getStatus(throwable).orElse(Status.BROKEN))
                                 .setStatusDetails(getStatusDetails(throwable).orElse(null))
                 );
-                throw ExceptionUtils.sneakyThrow(throwable);
+                failure = throwable;
             } finally {
                 getLifecycle().stopFixture(fixtureKey);
+            }
+
+            if (Objects.nonNull(failure)) {
+                if (MethodKind.SETUP_SPEC.equals(kind)) {
+                    reportSetupSpecFailure(invocation, containerUuid, fixtureName, failure);
+                }
+                throw ExceptionUtils.sneakyThrow(failure);
             }
         }
 

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
@@ -31,6 +31,10 @@ import io.qameta.allure.spock2.samples.BlockFailureTest;
 import io.qameta.allure.spock2.samples.BrokenTest;
 import io.qameta.allure.spock2.samples.DataDrivenTest;
 import io.qameta.allure.spock2.samples.DerivedSpec;
+import io.qameta.allure.spock2.samples.FailedCleanup;
+import io.qameta.allure.spock2.samples.FailedCleanupSpec;
+import io.qameta.allure.spock2.samples.FailedSetup;
+import io.qameta.allure.spock2.samples.FailedSetupSpec;
 import io.qameta.allure.spock2.samples.FailedTest;
 import io.qameta.allure.spock2.samples.FailedTestWithAnnotations;
 import io.qameta.allure.spock2.samples.FixturesTest;
@@ -638,6 +642,210 @@ class AllureSpock2Test {
                                         "cleanup spec [ cleanupSpec step 1, cleanupSpec step 2 ] "
                                 )
                         )
+                );
+    }
+
+    @Test
+    void shouldReportSetupSpecFixtureFailureAndSkippedFeatures() {
+        final AllureResults results = runClasses(FailedSetupSpec.class);
+
+        assertThat(results.getTestResults())
+                .extracting(
+                        TestResult::getName,
+                        TestResult::getStatus,
+                        result -> result.getStatusDetails().getMessage()
+                )
+                .containsExactlyInAnyOrder(
+                        tuple("setup spec", Status.BROKEN, "setup spec: exception"),
+                        tuple(
+                                "regular feature",
+                                Status.SKIPPED,
+                                "Skipped because setup spec failed: setup spec: exception"
+                        ),
+                        tuple(
+                                "data feature",
+                                Status.SKIPPED,
+                                "Skipped because setup spec failed: setup spec: exception"
+                        )
+                );
+
+        final TestResult dataFeature = results.getTestResults().stream()
+                .filter(result -> "data feature".equals(result.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("can't find the data feature"));
+        assertThat(dataFeature.getParameters()).isEmpty();
+
+        final TestResultContainer specContainer = results.getTestResultContainers().stream()
+                .filter(
+                        container -> container.getBefores().stream()
+                                .anyMatch(fixture -> "setup spec".equals(fixture.getName()))
+                )
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("can't find the spec container"));
+
+        assertThat(specContainer.getBefores())
+                .extracting(
+                        FixtureResult::getName,
+                        FixtureResult::getStatus,
+                        fixture -> fixture.getStatusDetails().getMessage(),
+                        this::printSteps
+                )
+                .containsExactly(
+                        tuple(
+                                "setup spec",
+                                Status.BROKEN,
+                                "setup spec: exception",
+                                "setup spec before failure"
+                        )
+                );
+        assertThat(specContainer.getChildren())
+                .containsExactlyInAnyOrderElementsOf(
+                        results.getTestResults().stream()
+                                .map(TestResult::getUuid)
+                                .collect(Collectors.toList())
+                );
+    }
+
+    @Test
+    void shouldReportSetupFixtureFailure() {
+        final AllureResults results = runClasses(FailedSetup.class);
+
+        assertThat(results.getTestResults()).hasSize(1);
+        final TestResult testResult = results.getTestResults().get(0);
+        assertThat(testResult)
+                .extracting(
+                        TestResult::getName,
+                        TestResult::getStatus,
+                        result -> result.getStatusDetails().getMessage()
+                )
+                .containsExactly(
+                        "feature with failed setup",
+                        Status.BROKEN,
+                        "setup: exception"
+                );
+
+        final TestResultContainer fixtureContainer = results.getTestResultContainers().stream()
+                .filter(
+                        container -> container.getBefores().stream()
+                                .anyMatch(fixture -> "setup".equals(fixture.getName()))
+                )
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("can't find the setup fixture container"));
+
+        assertThat(fixtureContainer.getBefores())
+                .extracting(
+                        FixtureResult::getName,
+                        FixtureResult::getStatus,
+                        fixture -> fixture.getStatusDetails().getMessage(),
+                        this::printSteps
+                )
+                .containsExactly(
+                        tuple(
+                                "setup",
+                                Status.BROKEN,
+                                "setup: exception",
+                                "setup before failure"
+                        )
+                );
+        assertThat(fixtureContainer.getChildren()).containsExactly(testResult.getUuid());
+    }
+
+    @Test
+    void shouldReportCleanupFixtureFailure() {
+        final AllureResults results = runClasses(FailedCleanup.class);
+
+        assertThat(results.getTestResults()).hasSize(1);
+        final TestResult testResult = results.getTestResults().get(0);
+        assertThat(testResult)
+                .extracting(
+                        TestResult::getName,
+                        TestResult::getStatus,
+                        result -> result.getStatusDetails().getMessage()
+                )
+                .containsExactly(
+                        "feature with failed cleanup",
+                        Status.BROKEN,
+                        "cleanup: exception"
+                );
+
+        final TestResultContainer fixtureContainer = results.getTestResultContainers().stream()
+                .filter(
+                        container -> container.getAfters().stream()
+                                .anyMatch(fixture -> "cleanup".equals(fixture.getName()))
+                )
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("can't find the cleanup fixture container"));
+
+        assertThat(fixtureContainer.getAfters())
+                .extracting(
+                        FixtureResult::getName,
+                        FixtureResult::getStatus,
+                        fixture -> fixture.getStatusDetails().getMessage(),
+                        this::printSteps
+                )
+                .containsExactly(
+                        tuple(
+                                "cleanup",
+                                Status.BROKEN,
+                                "cleanup: exception",
+                                "cleanup before failure"
+                        )
+                );
+        assertThat(fixtureContainer.getChildren()).containsExactly(testResult.getUuid());
+    }
+
+    @Test
+    void shouldReportCleanupSpecFixtureFailure() {
+        final AllureResults results = runClasses(FailedCleanupSpec.class);
+
+        assertThat(results.getTestResults()).hasSize(1);
+        final TestResult testResult = results.getTestResults().get(0);
+        assertThat(testResult)
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(
+                        "feature with failed cleanup spec",
+                        Status.PASSED
+                );
+
+        final TestResultContainer fixtureContainer = results.getTestResultContainers().stream()
+                .filter(
+                        container -> container.getAfters().stream()
+                                .anyMatch(fixture -> "cleanup spec".equals(fixture.getName()))
+                )
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("can't find the cleanup spec fixture container"));
+
+        assertThat(fixtureContainer.getAfters())
+                .extracting(
+                        FixtureResult::getName,
+                        FixtureResult::getStatus,
+                        fixture -> fixture.getStatusDetails().getMessage(),
+                        this::printSteps
+                )
+                .containsExactly(
+                        tuple(
+                                "cleanup spec",
+                                Status.BROKEN,
+                                "cleanup spec: exception",
+                                "cleanup spec before failure"
+                        )
+                );
+        assertThat(fixtureContainer.getChildren()).containsExactly(testResult.getUuid());
+    }
+
+    @Test
+    void shouldReportOnlySelectedFeaturesWhenSetupSpecFails() {
+        final TestPlanV1_0 plan = new TestPlanV1_0().setTests(
+                Collections.singletonList(new TestPlanV1_0.TestCase().setId("1"))
+        );
+
+        final AllureResults results = runClasses(plan, FailedSetupSpec.class);
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactlyInAnyOrder(
+                        tuple("setup spec", Status.BROKEN),
+                        tuple("regular feature", Status.SKIPPED)
                 );
     }
 

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedCleanup.groovy
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedCleanup.groovy
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.spock2.samples
+
+import spock.lang.Specification
+
+import static io.qameta.allure.Allure.step
+
+class FailedCleanup extends Specification {
+
+    def cleanup() {
+        step "cleanup before failure"
+        throw new RuntimeException("cleanup: exception")
+    }
+
+    def "feature with failed cleanup"() {
+        when:
+        step "feature body"
+
+        then:
+        true
+    }
+}

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedCleanupSpec.groovy
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedCleanupSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.spock2.samples
+
+import spock.lang.Specification
+
+import static io.qameta.allure.Allure.step
+
+class FailedCleanupSpec extends Specification {
+
+    def cleanupSpec() {
+        step "cleanup spec before failure"
+        throw new RuntimeException("cleanup spec: exception")
+    }
+
+    def "feature with failed cleanup spec"() {
+        when:
+        step "feature body"
+
+        then:
+        true
+    }
+}

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedSetup.groovy
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedSetup.groovy
@@ -1,0 +1,36 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.spock2.samples
+
+import spock.lang.Specification
+
+import static io.qameta.allure.Allure.step
+
+class FailedSetup extends Specification {
+
+    def setup() {
+        step "setup before failure"
+        throw new RuntimeException("setup: exception")
+    }
+
+    def "feature with failed setup"() {
+        when:
+        step "feature body"
+
+        then:
+        true
+    }
+}

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedSetupSpec.groovy
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedSetupSpec.groovy
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.spock2.samples
+
+import io.qameta.allure.AllureId
+import spock.lang.Specification
+
+import static io.qameta.allure.Allure.step
+
+class FailedSetupSpec extends Specification {
+
+    def setupSpec() {
+        step "setup spec before failure"
+        throw new RuntimeException("setup spec: exception")
+    }
+
+    @AllureId("1")
+    def "regular feature"() {
+        expect:
+        true
+    }
+
+    @AllureId("2")
+    def "data feature"() {
+        expect:
+        value > 0
+
+        where:
+        value << [1, 2]
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

When a Spock `setupSpec()` fixture fails, Allure now records the failure as a broken configuration and reports every affected feature as skipped instead of leaving the report empty. The skipped results retain the failure reason and remain linked to the specification.

Data-driven features are represented once when their iterations cannot be created, while Allure test plan filtering ensures excluded or unselected features are not reported.

fixes #1151

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java