### PR TITLE
Fix package hierarchy for JUnit 4 and Spock 2 results

### DIFF
--- a/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
+++ b/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
@@ -300,7 +300,7 @@ public class AllureJunit4 extends RunListener {
         testResult.getLabels().addAll(getProvidedLabels());
         testResult.getLabels().addAll(
                 Arrays.asList(
-                        createPackageLabel(getPackage(description.getTestClass())),
+                        createPackageLabel(className),
                         createTestClassLabel(className),
                         createHostLabel(),
                         createThreadLabel(),

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
@@ -64,6 +64,7 @@ import static io.qameta.allure.junit4.samples.TaggedTests.METHOD_TAG1;
 import static io.qameta.allure.junit4.samples.TaggedTests.METHOD_TAG2;
 import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
 import static io.qameta.allure.util.ResultsUtils.HOST_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.PACKAGE_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.SEVERITY_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.THREAD_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.md5;
@@ -107,6 +108,19 @@ class AllureJunit4Test {
                         "io", "qameta", "allure", "junit4", "samples",
                         "Should be overwritten by method annotation"
                 );
+    }
+
+    @Test
+    @AllureFeatures.Trees
+    void shouldUseQualifiedClassNameForPackageLabel() {
+        final AllureResults results = runClasses(OneTest.class);
+
+        assertThat(results.getTestResults())
+                .hasSize(1)
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(Label::getName, PACKAGE_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly(OneTest.class.getName());
     }
 
     @Test
@@ -480,6 +494,11 @@ class AllureJunit4Test {
                 .containsExactly(
                         tuple("SampleTestInDefaultPackage.testMethod", Status.PASSED)
                 );
+        assertThat(testResults)
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(Label::getName, PACKAGE_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly(testInDefaultPackage.getName());
     }
 
     @Test

--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -235,7 +235,7 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
 
         final List<Label> labels = new ArrayList<>(
                 Arrays.asList(
-                        createPackageLabel(packageName),
+                        createPackageLabel(testClassName),
                         createTestClassLabel(testClassName),
                         createTestMethodLabel(testMethodName),
                         createHostLabel(),

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
@@ -86,6 +86,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
+import static io.qameta.allure.util.ResultsUtils.PACKAGE_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.SEVERITY_LABEL_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -280,6 +281,19 @@ class AllureSpock2Test {
         assertThat(results.getTestResults())
                 .extracting(TestResult::getFullName)
                 .containsExactly("io.qameta.allure.spock2.samples.OneTest.Simple Test");
+    }
+
+    @Test
+    @AllureFeatures.Trees
+    void shouldUseQualifiedClassNameForPackageLabel() {
+        final AllureResults results = runClasses(OneTest.class);
+
+        assertThat(results.getTestResults())
+                .hasSize(1)
+                .flatExtracting(TestResult::getLabels)
+                .filteredOn(Label::getName, PACKAGE_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly(OneTest.class.getName());
     }
 
     @Test


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

JUnit 4 and Spock 2 test results now use the fully qualified test class name for the `package` label. This restores the class level in Allure’s Packages tree instead of grouping tests only by their Java package.

JUnit 4 tests in the default package now use their class name instead of an empty package label, making package hierarchy behavior consistent across the supported adapters.

fixes #850

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java