### PR TITLE
Fix Awaitility step hierarchy with reusable executor threads

### DIFF
--- a/allure-awaitility/src/main/java/io/qameta/allure/awaitility/AllureAwaitilityListener.java
+++ b/allure-awaitility/src/main/java/io/qameta/allure/awaitility/AllureAwaitilityListener.java
@@ -35,6 +35,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -60,6 +62,12 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * </code>
  * </pre>
  * </p>
+ * <p>
+ * A listener instance tracks a single condition at a time, so prefer one instance per condition when tests run in
+ * parallel. Awaitility fires no callback when a non-ignored exception escapes a condition; such an aborted wait
+ * stays the reporting parent until the same listener starts its next condition, which finalizes the aborted one,
+ * or until the test ends.
+ * </p>
  *
  * @see org.awaitility.core.ConditionEvaluationListener
  * @see Awaitility#setDefaultConditionEvaluationListener(ConditionEvaluationListener)
@@ -69,17 +77,15 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 @SuppressWarnings("unused")
 public class AllureAwaitilityListener implements ConditionEvaluationListener<Object> {
 
-    private TimeUnit unit;
-    private boolean logIgnoredExceptions;
+    private final AtomicReference<TimeUnit> unit = new AtomicReference<>(MILLISECONDS);
+    private final AtomicBoolean logIgnoredExceptions = new AtomicBoolean(true);
     private final String onStartStepTextPattern;
     private final String onSatisfiedStepTextPattern;
     private final String onAwaitStepTextPattern;
     private final String onTimeoutStepTextPattern;
     private final String onExceptionStepTextPattern;
 
-    private AllureExternalKey currentConditionStepKey;
-
-    private AllureThreadBinding currentConditionBinding;
+    private final AtomicReference<ConditionState> currentCondition = new AtomicReference<>();
 
     /**
      * Returns the lifecycle.
@@ -94,8 +100,6 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
      * Default all args constructor with default params.
      */
     public AllureAwaitilityListener() {
-        this.unit = MILLISECONDS;
-        this.logIgnoredExceptions = true;
         this.onStartStepTextPattern = "Awaitility: %s";
         this.onSatisfiedStepTextPattern = "%s after %d %s (remaining time %d %s, last poll interval was %s)";
         this.onAwaitStepTextPattern = "%s (elapsed time %d %s, remaining time %d %s (last poll interval was %s))";
@@ -110,7 +114,7 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
      * @return this factory
      */
     public AllureAwaitilityListener setUnit(final TimeUnit unit) {
-        this.unit = unit;
+        this.unit.set(unit);
         return this;
     }
 
@@ -121,7 +125,7 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
      * @return this factory
      */
     public AllureAwaitilityListener setLogIgnoredExceptions(final boolean logging) {
-        this.logIgnoredExceptions = logging;
+        this.logIgnoredExceptions.set(logging);
         return this;
     }
 
@@ -132,14 +136,14 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
      */
     @Override
     public void beforeEvaluation(final StartEvaluationEvent<Object> startEvaluationEvent) {
-        currentConditionStepKey = null;
-        getLifecycle().getCurrentExecutableKey().ifPresent(parent -> {
+        finishCurrentCondition();
+        final AllureLifecycle lifecycle = getLifecycle();
+        lifecycle.getCurrentExecutableKey().ifPresent(parent -> {
             final String nameWoAlias = String.format(onStartStepTextPattern, startEvaluationEvent.getDescription());
             final String nameWithAlias = String.format(onStartStepTextPattern, startEvaluationEvent.getAlias());
             final String stepName = startEvaluationEvent.getAlias() != null ? nameWithAlias : nameWoAlias;
             final AllureExternalKey conditionStepKey = AllureExternalKey.random(AllureAwaitilityListener.class);
-            currentConditionStepKey = conditionStepKey;
-            getLifecycle().startStep(
+            lifecycle.startStep(
                     parent,
                     conditionStepKey,
                     new StepResult()
@@ -147,9 +151,11 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
                             .setDescription("Awaitility condition started")
                             .setStatus(Status.FAILED)
             );
-            // bind the polling thread to the condition step, so steps produced while evaluating the
-            // condition — for example assertion steps from untilAsserted polls — nest under it
-            currentConditionBinding = getLifecycle().bindDetached(conditionStepKey);
+            final ConditionState condition = new ConditionState(lifecycle, conditionStepKey);
+            currentCondition.set(condition);
+            // Keep condition-body steps under the wait. The binding remembers the caller thread's stack, so
+            // Awaitility may close it from a polling callback without mutating a reused worker's unrelated context.
+            condition.setBinding(lifecycle.bindDetached(conditionStepKey));
         });
     }
 
@@ -160,18 +166,18 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
      */
     @Override
     public void onTimeout(final TimeoutEvent timeoutEvent) {
-        if (currentConditionStepKey == null) {
+        final ConditionState condition = currentCondition.get();
+        if (condition == null) {
             return;
         }
-        closeConditionBinding();
-        getLifecycle().logStep(
-                currentConditionStepKey,
+        condition.getLifecycle().logStep(
+                condition.getStepKey(),
                 new StepResult()
                         .setName(String.format(onTimeoutStepTextPattern, timeoutEvent.getDescription()))
                         .setDescription("Awaitility condition timeout")
                         .setStatus(Status.BROKEN)
         );
-        getLifecycle().stopStep(currentConditionStepKey);
+        finishCondition(condition);
     }
 
     /**
@@ -181,10 +187,11 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
      */
     @Override
     public void conditionEvaluated(final EvaluatedCondition<Object> condition) {
+        final TimeUnit currentUnit = unit.get();
         final String description = condition.getDescription();
-        final long elapsedTime = unit.convert(condition.getElapsedTimeInMS(), MILLISECONDS);
-        final long remainingTime = unit.convert(condition.getRemainingTimeInMS(), MILLISECONDS);
-        final String unitAsString = unit.toString().toLowerCase();
+        final long elapsedTime = currentUnit.convert(condition.getElapsedTimeInMS(), MILLISECONDS);
+        final long remainingTime = currentUnit.convert(condition.getRemainingTimeInMS(), MILLISECONDS);
+        final String unitAsString = currentUnit.toString().toLowerCase();
 
         final String message = String.format(
                 condition.isSatisfied() ? onSatisfiedStepTextPattern : onAwaitStepTextPattern,
@@ -196,29 +203,79 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
                 new TemporalDuration(condition.getPollInterval())
         );
 
-        if (currentConditionStepKey == null) {
+        final ConditionState current = currentCondition.get();
+        if (current == null) {
             return;
         }
-        getLifecycle().logStep(
-                currentConditionStepKey,
+        current.getLifecycle().logStep(
+                current.getStepKey(),
                 new StepResult()
                         .setName(message)
                         .setDescription("Awaitility condition satisfied or not, but awaiting still in progress")
                         .setStatus(Status.PASSED)
         );
         if (condition.isSatisfied()) {
-            closeConditionBinding();
-            getLifecycle().updateStep(
-                    currentConditionStepKey, awaitilityCondition -> awaitilityCondition.setStatus(Status.PASSED)
+            current.getLifecycle().updateStep(
+                    current.getStepKey(), awaitilityCondition -> awaitilityCondition.setStatus(Status.PASSED)
             );
-            getLifecycle().stopStep(currentConditionStepKey);
+            finishCondition(current);
         }
     }
 
-    private void closeConditionBinding() {
-        if (currentConditionBinding != null) {
-            currentConditionBinding.close();
-            currentConditionBinding = null;
+    private void finishCurrentCondition() {
+        final ConditionState condition = currentCondition.getAndSet(null);
+        if (condition != null) {
+            condition.finish();
+        }
+    }
+
+    private void finishCondition(final ConditionState condition) {
+        currentCondition.compareAndSet(condition, null);
+        condition.finish();
+    }
+
+    private static final class ConditionState {
+
+        private final AllureLifecycle lifecycle;
+        private final AllureExternalKey stepKey;
+        private final AtomicReference<AllureThreadBinding> binding = new AtomicReference<>();
+        private final AtomicBoolean finished = new AtomicBoolean();
+
+        private ConditionState(final AllureLifecycle lifecycle, final AllureExternalKey stepKey) {
+            this.lifecycle = lifecycle;
+            this.stepKey = stepKey;
+        }
+
+        private AllureLifecycle getLifecycle() {
+            return lifecycle;
+        }
+
+        private AllureExternalKey getStepKey() {
+            return stepKey;
+        }
+
+        private void setBinding(final AllureThreadBinding value) {
+            binding.set(value);
+            if (finished.get()) {
+                closeBinding();
+            }
+        }
+
+        private void finish() {
+            if (finished.compareAndSet(false, true)) {
+                try {
+                    closeBinding();
+                } finally {
+                    lifecycle.stopStep(stepKey);
+                }
+            }
+        }
+
+        private void closeBinding() {
+            final AllureThreadBinding current = binding.getAndSet(null);
+            if (current != null) {
+                current.close();
+            }
         }
     }
 
@@ -237,7 +294,8 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
      */
     @Override
     public void exceptionIgnored(final IgnoredException ignoredException) {
-        if (logIgnoredExceptions && currentConditionStepKey != null) {
+        final ConditionState condition = currentCondition.get();
+        if (logIgnoredExceptions.get() && condition != null) {
             final AllureExternalKey exceptionIgnoredStepKey = AllureExternalKey.random(AllureAwaitilityListener.class);
             final String message = String.format(
                     onExceptionStepTextPattern, ignoredException.getThrowable().getMessage()
@@ -245,22 +303,22 @@ public class AllureAwaitilityListener implements ConditionEvaluationListener<Obj
             final StringWriter stringWriter = new StringWriter();
             ignoredException.getThrowable().printStackTrace(new PrintWriter(stringWriter));
             final String stackTrace = stringWriter.toString();
-            getLifecycle().startStep(
-                    currentConditionStepKey,
+            condition.getLifecycle().startStep(
+                    condition.getStepKey(),
                     exceptionIgnoredStepKey,
                     new StepResult()
                             .setName(message)
                             .setDescription("Exception occurred and ignored, but awaiting still in progress")
                             .setStatus(Status.SKIPPED)
             );
-            getLifecycle().addAttachment(
+            condition.getLifecycle().addAttachment(
                     exceptionIgnoredStepKey,
                     ignoredException.getThrowable().getMessage(),
                     "text/plain",
                     new ByteArrayInputStream(stackTrace.getBytes(StandardCharsets.UTF_8)),
                     AttachmentOptions.empty()
             );
-            getLifecycle().stopStep(exceptionIgnoredStepKey);
+            condition.getLifecycle().stopStep(exceptionIgnoredStepKey);
         }
     }
 

--- a/allure-awaitility/src/test/java/io/qameta/allure/awaitility/ConditionListenersPositiveTest.java
+++ b/allure-awaitility/src/test/java/io/qameta/allure/awaitility/ConditionListenersPositiveTest.java
@@ -195,6 +195,71 @@ class ConditionListenersPositiveTest {
                 .contains("last poll interval was");
     }
 
+    /**
+     * Verifies that Awaitility 4.3's supplier-and-consumer {@code untilAsserted} overload reports every supplied value
+     * under one successful Awaitility step.
+     */
+    @Description
+    @Test
+    void supplierConsumerUntilAssertedShouldReportPollsUnderSingleAwaitilityStep() {
+        final List<TestResult> testResults = runWithinTestContext(() -> {
+            final AtomicInteger counter = new AtomicInteger();
+            await("supplied counter reaches 2").with()
+                    .conditionEvaluationListener(new AllureAwaitilityListener())
+                    .atMost(Duration.of(1000, ChronoUnit.MILLIS))
+                    .pollInterval(Duration.of(10, ChronoUnit.MILLIS))
+                    .untilAsserted(counter::getAndIncrement, value -> assertThat(value).isEqualTo(2));
+        }).getTestResults();
+
+        final TestResult testResult = testResults.get(0);
+        assertThat(testResult.getSteps())
+                .singleElement()
+                .satisfies(step -> {
+                    assertThat(step.getName()).isEqualTo("Awaitility: supplied counter reaches 2");
+                    assertThat(step.getStatus()).isEqualTo(Status.PASSED);
+                    final List<StepResult> evaluationSteps = step.getSteps().stream()
+                            .filter(ConditionListenersPositiveTest::isAwaitilityEvaluationStep)
+                            .toList();
+                    assertThat(evaluationSteps)
+                            .hasSize(3);
+                });
+    }
+
+    /**
+     * Verifies that a nested wait with its own listener keeps the outer condition active and reports the inner
+     * condition beneath it.
+     */
+    @Description
+    @Test
+    void nestedAwaitShouldKeepOuterConditionScope() {
+        final List<TestResult> testResults = runWithinTestContext(
+                () -> await("outer condition").with()
+                        .pollInSameThread()
+                        .conditionEvaluationListener(new AllureAwaitilityListener())
+                        .atMost(Duration.ofSeconds(1))
+                        .until(() -> {
+                            await("inner condition").with()
+                                    .pollInSameThread()
+                                    .conditionEvaluationListener(new AllureAwaitilityListener())
+                                    .atMost(Duration.ofSeconds(1))
+                                    .until(() -> true);
+                            return true;
+                        })
+        ).getTestResults();
+
+        final List<StepResult> topLevelSteps = testResults.get(0).getSteps();
+        assertThat(topLevelSteps)
+                .extracting(StepResult::getName)
+                .containsExactly("Awaitility: outer condition");
+
+        final List<String> nestedStepNames = topLevelSteps.get(0).getSteps().stream()
+                .map(StepResult::getName)
+                .toList();
+        assertThat(nestedStepNames)
+                .as("nested condition step names")
+                .contains("Awaitility: inner condition");
+    }
+
     private List<StepResult> runAwaitWithoutAliasTopLevelSteps() {
         final List<TestResult> testResult = runWithinTestContext(() -> {
             final AtomicInteger atomicInteger = new AtomicInteger(0);

--- a/allure-awaitility/src/test/java/io/qameta/allure/awaitility/ExceptionReportingTest.java
+++ b/allure-awaitility/src/test/java/io/qameta/allure/awaitility/ExceptionReportingTest.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.awaitility;
+
+import io.qameta.allure.Allure;
+import io.qameta.allure.Description;
+import io.qameta.allure.model.Stage;
+import io.qameta.allure.model.StepResult;
+import io.qameta.allure.model.TestResult;
+import io.qameta.allure.test.IsolatedLifecycle;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.qameta.allure.test.RunUtils.runWithinTestContext;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@IsolatedLifecycle
+class ExceptionReportingTest {
+
+    /**
+     * Verifies that reusing a listener after a propagated condition exception cannot retain the failed wait as the
+     * parent of the next condition or later test steps, and that the aborted wait's step is finalized when the next
+     * condition starts. Awaitility fires no callback for a propagated exception, so a wait aborted this way is
+     * cleaned up when the same listener starts its next condition.
+     */
+    @Description
+    @Test
+    void shouldDiscardAbortedConditionBindingBeforeListenerReuse() {
+        final IllegalStateException failure = new IllegalStateException("first condition aborted");
+        final AtomicReference<IllegalStateException> caught = new AtomicReference<>();
+        final AllureAwaitilityListener listener = new AllureAwaitilityListener();
+
+        final List<TestResult> testResults = runWithinTestContext(() -> {
+            try {
+                await("aborting condition").with()
+                        .pollInSameThread()
+                        .conditionEvaluationListener(listener)
+                        .atMost(Duration.ofSeconds(1))
+                        .until(() -> {
+                            throw failure;
+                        });
+            } catch (IllegalStateException exception) {
+                caught.set(exception);
+            }
+
+            await("following condition").with()
+                    .pollInSameThread()
+                    .conditionEvaluationListener(listener)
+                    .atMost(Duration.ofSeconds(1))
+                    .until(() -> true);
+            Allure.step("step after following condition");
+        }).getTestResults();
+
+        assertThat(caught.get())
+                .isSameAs(failure);
+
+        final List<StepResult> topLevelSteps = testResults.get(0).getSteps();
+        assertThat(topLevelSteps)
+                .extracting(StepResult::getName)
+                .containsExactly(
+                        "Awaitility: aborting condition",
+                        "Awaitility: following condition",
+                        "step after following condition"
+                );
+
+        final StepResult abortedCondition = topLevelSteps.get(0);
+        assertThat(abortedCondition.getStage())
+                .as("aborted condition stage")
+                .isEqualTo(Stage.FINISHED);
+        assertThat(abortedCondition.getStop())
+                .as("aborted condition stop time")
+                .isGreaterThanOrEqualTo(abortedCondition.getStart());
+    }
+
+}

--- a/allure-awaitility/src/test/java/io/qameta/allure/awaitility/ExecutorServiceReportingTest.java
+++ b/allure-awaitility/src/test/java/io/qameta/allure/awaitility/ExecutorServiceReportingTest.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.awaitility;
+
+import io.qameta.allure.Allure;
+import io.qameta.allure.Description;
+import io.qameta.allure.Issue;
+import io.qameta.allure.model.StepResult;
+import io.qameta.allure.model.TestResult;
+import io.qameta.allure.test.IsolatedLifecycle;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static io.qameta.allure.test.RunUtils.runWithinTestContext;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@IsolatedLifecycle
+class ExecutorServiceReportingTest {
+
+    /**
+     * Verifies that reusing an Awaitility polling thread cannot retain a finished wait as the parent of steps produced
+     * later by the test, protecting the report hierarchy regression described in issue 891.
+     */
+    @Description
+    @Issue("891")
+    @Test
+    void shouldKeepFollowingStepsAtTestLevelWhenExecutorIsReused() throws Exception {
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            executor.submit(() -> {
+                // Start the reusable worker before an Allure test context exists.
+            }).get(5, SECONDS);
+
+            final AllureAwaitilityListener listener = new AllureAwaitilityListener();
+            final List<TestResult> testResults = runWithinTestContext(() -> {
+                await("first condition").with()
+                        .pollExecutorService(executor)
+                        .conditionEvaluationListener(listener)
+                        .atMost(Duration.ofSeconds(1))
+                        .until(() -> true);
+                Allure.step("step after first condition");
+
+                await("second condition").with()
+                        .pollExecutorService(executor)
+                        .conditionEvaluationListener(listener)
+                        .atMost(Duration.ofSeconds(1))
+                        .until(() -> true);
+                Allure.step("step after second condition");
+            }).getTestResults();
+
+            final TestResult testResult = testResults.get(0);
+            final List<StepResult> topLevelSteps = testResult.getSteps();
+
+            assertThat(topLevelSteps)
+                    .extracting(StepResult::getName)
+                    .containsExactly(
+                            "Awaitility: first condition",
+                            "step after first condition",
+                            "Awaitility: second condition",
+                            "step after second condition"
+                    );
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+}

--- a/allure-awaitility/src/test/resources/allure.properties
+++ b/allure-awaitility/src/test/resources/allure.properties
@@ -1,3 +1,4 @@
 allure.results.directory=build/allure-results
+allure.link.issue.pattern=https://github.com/allure-framework/allure-java/issues/{}
 allure.label.epic=#project.description#
 allure.label.module=allure-awaitility

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
@@ -61,7 +61,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -1187,11 +1186,9 @@ public class AllureLifecycle {
         final AllureExecutionContext snapshot = snapshotOf(key, items.get(key));
         if (Objects.isNull(snapshot)) {
             LOGGER.warn(KEY_NOT_FOUND, "bind", key);
-            threadContext.push(new AllureExecutionContext());
-        } else {
-            threadContext.push(snapshot.copy());
+            return threadContext.pushBinding(new AllureExecutionContext());
         }
-        return new ThreadBinding(threadContext);
+        return threadContext.pushBinding(snapshot.copy());
     }
 
     /**
@@ -1206,11 +1203,9 @@ public class AllureLifecycle {
         final AllureExecutionContext snapshot = snapshotOf(key, items.get(key));
         if (Objects.isNull(snapshot)) {
             LOGGER.warn(KEY_NOT_FOUND, "bind detached", key);
-            threadContext.push(new AllureExecutionContext());
-        } else {
-            threadContext.push(snapshot.copy().child());
+            return threadContext.pushBinding(new AllureExecutionContext());
         }
-        return new ThreadBinding(threadContext);
+        return threadContext.pushBinding(snapshot.copy().child());
     }
 
     // ── Internals ────────────────────────────────────────────────────────────────────────────
@@ -1452,26 +1447,6 @@ public class AllureLifecycle {
 
         private ScopeItem(final ScopeResult result) {
             this(result, ConcurrentHashMap.newKeySet());
-        }
-    }
-
-    /**
-     * Thread binding returned by {@code bind}/{@code bindDetached}: restores the previous context once, on the
-     * first close.
-     */
-    private record ThreadBinding(AllureThreadContext threadContext, AtomicBoolean closed)
-            implements
-                AllureThreadBinding {
-
-        private ThreadBinding(final AllureThreadContext threadContext) {
-            this(threadContext, new AtomicBoolean());
-        }
-
-        @Override
-        public void close() {
-            if (closed.compareAndSet(false, true)) {
-                threadContext.pop();
-            }
         }
     }
 

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureThreadBinding.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureThreadBinding.java
@@ -18,6 +18,7 @@ package io.qameta.allure;
 /**
  * Thread binding returned by {@link AllureLifecycle#bind(AllureExternalKey)} and
  * {@link AllureLifecycle#bindDetached(AllureExternalKey)} that restores the previous thread context when closed.
+ * A binding may be closed from another thread; it always restores the context stack on the thread that created it.
  */
 public interface AllureThreadBinding extends AutoCloseable {
 

--- a/allure-java-commons/src/main/java/io/qameta/allure/internal/AllureThreadContext.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/internal/AllureThreadContext.java
@@ -16,17 +16,22 @@
 package io.qameta.allure.internal;
 
 import io.qameta.allure.AllureExternalKey;
+import io.qameta.allure.AllureThreadBinding;
 
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Thread-local binding for the current Allure execution context.
  */
 public class AllureThreadContext {
+
+    private static final String EXECUTION_CONTEXT = "execution context";
 
     private final Context context = new Context();
 
@@ -109,7 +114,20 @@ public class AllureThreadContext {
      * @param executionContext the context to bind
      */
     public void push(final AllureExecutionContext executionContext) {
-        context.get().push(Objects.requireNonNull(executionContext, "execution context"));
+        context.get().push(Objects.requireNonNull(executionContext, EXECUTION_CONTEXT));
+    }
+
+    /**
+     * Adds execution context binding to the current thread and returns a handle for removing that exact binding.
+     *
+     * @param executionContext the context to bind
+     * @return a binding that removes this exact context when closed, including when another thread closes it
+     */
+    public AllureThreadBinding pushBinding(final AllureExecutionContext executionContext) {
+        final AllureExecutionContext binding = Objects.requireNonNull(executionContext, EXECUTION_CONTEXT);
+        final ContextStack stack = context.get();
+        stack.push(binding);
+        return new ThreadBinding(stack, binding);
     }
 
     /**
@@ -118,11 +136,7 @@ public class AllureThreadContext {
      * @return removed execution context.
      */
     public Optional<AllureExecutionContext> pop() {
-        final Deque<AllureExecutionContext> stack = context.get();
-        if (stack.size() <= 1) {
-            return Optional.empty();
-        }
-        return Optional.of(stack.pop());
+        return context.get().pop();
     }
 
     /**
@@ -144,23 +158,96 @@ public class AllureThreadContext {
     /**
      * Thread local binding for the current execution context.
      */
-    private static final class Context extends InheritableThreadLocal<Deque<AllureExecutionContext>> {
+    private static final class Context extends InheritableThreadLocal<ContextStack> {
 
         @Override
-        public Deque<AllureExecutionContext> initialValue() {
+        public ContextStack initialValue() {
             return singletonStack(new AllureExecutionContext());
         }
 
         @Override
-        protected Deque<AllureExecutionContext> childValue(final Deque<AllureExecutionContext> parentStack) {
+        protected ContextStack childValue(final ContextStack parentStack) {
             return singletonStack(parentStack.getFirst().child());
         }
 
     }
 
-    private static Deque<AllureExecutionContext> singletonStack(final AllureExecutionContext executionContext) {
-        final Deque<AllureExecutionContext> stack = new LinkedList<>();
-        stack.push(executionContext);
-        return stack;
+    /**
+     * Removes the exact pushed context from its origin thread's stack once.
+     */
+    private static final class ThreadBinding implements AllureThreadBinding {
+
+        private final ContextStack stack;
+        private final AllureExecutionContext binding;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private ThreadBinding(final ContextStack stack, final AllureExecutionContext binding) {
+            this.stack = stack;
+            this.binding = binding;
+        }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                stack.remove(binding);
+            }
+        }
+
+    }
+
+    /**
+     * A lock-protected context stack that can be restored by a worker while its owner thread is waiting.
+     */
+    private static final class ContextStack {
+
+        private final Deque<AllureExecutionContext> stack = new LinkedList<>();
+        private final ReentrantLock lock = new ReentrantLock();
+
+        private ContextStack(final AllureExecutionContext executionContext) {
+            stack.push(executionContext);
+        }
+
+        private AllureExecutionContext getFirst() {
+            lock.lock();
+            try {
+                return stack.getFirst();
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private void push(final AllureExecutionContext executionContext) {
+            lock.lock();
+            try {
+                stack.push(executionContext);
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private Optional<AllureExecutionContext> pop() {
+            lock.lock();
+            try {
+                return stack.size() <= 1
+                        ? Optional.empty()
+                        : Optional.of(stack.pop());
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private void remove(final AllureExecutionContext executionContext) {
+            lock.lock();
+            try {
+                stack.removeFirstOccurrence(executionContext);
+            } finally {
+                lock.unlock();
+            }
+        }
+
+    }
+
+    private static ContextStack singletonStack(final AllureExecutionContext executionContext) {
+        return new ContextStack(executionContext);
     }
 }

--- a/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
@@ -908,6 +908,35 @@ class AllureLifecycleTest {
     }
 
     @Test
+    void shouldRestoreDetachedBindingOnOriginThreadWhenClosedFromWorker() throws Exception {
+        final AllureExternalKey testKey = AllureExternalKey.random(AllureLifecycleTest.class);
+        lifecycle.scheduleTest(testKey, new TestResult().setName(randomName()));
+        lifecycle.startTest(testKey);
+
+        final AllureExternalKey conditionStepKey = AllureExternalKey.random(AllureLifecycleTest.class);
+        lifecycle.startStep(testKey, conditionStepKey, new StepResult().setName(randomName()));
+        final AllureThreadBinding binding = lifecycle.bindDetached(conditionStepKey);
+
+        assertThat(lifecycle.getCurrentExecutableKey())
+                .hasValue(conditionStepKey);
+
+        final ExecutorService worker = Executors.newSingleThreadExecutor();
+        try {
+            worker.submit(binding::close).get(1, TimeUnit.SECONDS);
+        } finally {
+            worker.shutdownNow();
+        }
+
+        assertThat(lifecycle.getCurrentExecutableKey())
+                .as("closing a binding from a worker restores the thread that created it")
+                .hasValue(testKey);
+
+        lifecycle.stopStep(conditionStepKey);
+        lifecycle.stopTest(testKey);
+        lifecycle.writeTest(testKey);
+    }
+
+    @Test
     void shouldNotDisturbThreadContextWhenManualStepRunsOnWorker() throws Exception {
         final AllureExternalKey testKey = AllureExternalKey.random(AllureLifecycleTest.class);
         lifecycle.scheduleTest(testKey, new TestResult().setName(randomName()));


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Keeps Allure report steps correctly scoped when Awaitility evaluates conditions on reusable executor threads. Steps recorded after `await()` now remain at the expected test level instead of becoming nested under a completed Awaitility condition or disappearing, resolving #891.

The integration also preserves nested await reporting, supports Awaitility 4.3’s supplier-consumer `untilAsserted` workflow, and cleans up an aborted condition before the same listener starts another wait. This works with the Awaitility version supplied by the user’s project and introduces no AspectJ runtime requirement.

fixes #891

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java