### PR TITLE
Respect TestNG XML parameter overrides in reported results

### DIFF
--- a/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
+++ b/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
@@ -989,7 +989,7 @@ public class AllureTestNg
                                           final ITestNGMethod method,
                                           final Object... parameters) {
         final Map<String, Parameter> result = new HashMap<>();
-        context.getCurrentXmlTest().getAllParameters()
+        method.findMethodParameters(context.getCurrentXmlTest())
                 .forEach((name, value) -> result.put(name, createParameter(name, value)));
         final Object instance = method.getInstance();
         if (nonNull(instance)) {

--- a/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
@@ -1769,6 +1769,28 @@ public class AllureTestNgTest {
 
     @SuppressWarnings("unchecked")
     @AllureFeatures.Parameters
+    @Issue("1359")
+    @Test
+    public void shouldRespectClassAndMethodXmlParameterOverrides() {
+        final AllureResults results = runTestNgSuites("suites/gh-1359.xml");
+
+        final TestResult classOverride = findTestResultByName(results, "classOverride");
+        assertThat(classOverride.getParameters())
+                .extracting(Parameter::getName, Parameter::getValue)
+                .containsExactly(
+                        tuple("scope", "class")
+                );
+
+        final TestResult methodOverride = findTestResultByName(results, "methodOverride");
+        assertThat(methodOverride.getParameters())
+                .extracting(Parameter::getName, Parameter::getValue)
+                .containsExactly(
+                        tuple("scope", "method")
+                );
+    }
+
+    @SuppressWarnings("unchecked")
+    @AllureFeatures.Parameters
     @Issue("141")
     @Test
     public void shouldSupportFactoryOnConstructor() {
@@ -1919,6 +1941,7 @@ public class AllureTestNgTest {
         final ITestNGMethod method = mock(ITestNGMethod.class);
         when(method.getInstance()).thenReturn(null);
         when(method.getConstructorOrMethod()).thenReturn(new ConstructorOrMethod(source));
+        when(method.findMethodParameters(xmlTest)).thenReturn(xmlTest.getAllParameters());
 
         final AllureTestNg adapter = new AllureTestNg(
                 new AllureLifecycle(new AllureResultsWriterStub()),

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/XmlParameterOverridesTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/XmlParameterOverridesTest.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import org.testng.annotations.Test;
+
+public class XmlParameterOverridesTest {
+
+    @Test
+    public void classOverride() {
+    }
+
+    @Test
+    public void methodOverride() {
+    }
+}

--- a/allure-testng/src/test/resources/suites/gh-1359.xml
+++ b/allure-testng/src/test/resources/suites/gh-1359.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="XML parameter overrides">
+    <parameter name="scope" value="suite"/>
+    <test name="XML parameter overrides">
+        <parameter name="scope" value="test"/>
+        <classes>
+            <class name="io.qameta.allure.testng.samples.XmlParameterOverridesTest">
+                <parameter name="scope" value="class"/>
+                <methods>
+                    <include name="classOverride"/>
+                    <include name="methodOverride">
+                        <parameter name="scope" value="method"/>
+                    </include>
+                </methods>
+            </class>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure TestNG now reports XML parameters using the same suite → test → class → method precedence as TestNG itself. Class-level and method-level overrides are preserved even when a test method does not inject the parameter directly, so reports reflect the configuration the test actually ran with.

For example, a class that overrides `headless` from `true` at the `<test>` level to `false` now appears as `headless: false` in Allure Report and Allure TestOps.

fixes #1359

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java