### PR TITLE
Avoid duplicate display names for JUnit Platform test templates

### DIFF
--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
@@ -503,9 +503,10 @@ public class AllureJunitPlatform implements TestExecutionListener {
     private String getName(final TestIdentifier testIdentifier,
                            final boolean testTemplate,
                            final Optional<TestIdentifier> maybeParent) {
-        final String baseName = testTemplate && maybeParent.isPresent()
-                ? maybeParent.get().getDisplayName() + " " + testIdentifier.getDisplayName()
-                : testIdentifier.getDisplayName();
+        final String parentPrefix = testTemplate
+                ? maybeParent.map(TestIdentifier::getDisplayName).orElse("")
+                : "";
+        final String baseName = prependIfMissing(parentPrefix, testIdentifier.getDisplayName());
         // prefix the name with parameterized class invocation display names, so results
         // of the same method from different invocations are distinguishable
         final String prefix = getParents(testIdentifier).stream()
@@ -515,7 +516,13 @@ public class AllureJunitPlatform implements TestExecutionListener {
                 )
                 .map(TestIdentifier::getDisplayName)
                 .collect(Collectors.joining(" "));
-        return prefix.isEmpty() ? baseName : prefix + " " + baseName;
+        return prependIfMissing(prefix, baseName);
+    }
+
+    private static String prependIfMissing(final String prefix, final String name) {
+        return prefix.isEmpty() || name.startsWith(prefix)
+                ? name
+                : prefix + " " + name;
     }
 
     /**

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -43,6 +43,8 @@ import io.qameta.allure.junitplatform.features.ParameterisedTests;
 import io.qameta.allure.junitplatform.features.ParameterisedTestsWithDisplayName;
 import io.qameta.allure.junitplatform.features.PassedTests;
 import io.qameta.allure.junitplatform.features.RepeatedTests;
+import io.qameta.allure.junitplatform.features.RepeatedTestsWithDisplayName;
+import io.qameta.allure.junitplatform.features.RepeatedTestsWithLongDisplayName;
 import io.qameta.allure.junitplatform.features.ReportEntryParameter;
 import io.qameta.allure.junitplatform.features.RuntimeParametersTest;
 import io.qameta.allure.junitplatform.features.RuntimeSuiteLabelTest;
@@ -1038,6 +1040,33 @@ public class AllureJunitPlatformTest {
                 .allMatch(hasStatus(Status.PASSED))
                 .allMatch(hasLabel(OWNER_LABEL_NAME, "me"));
 
+    }
+
+    @Issue("1122")
+    @AllureFeatures.DisplayName
+    @Test
+    void shouldNotDuplicateDisplayNameForRepeatedTests() {
+        final AllureResults results = runClasses(RepeatedTestsWithDisplayName.class);
+        final List<TestResult> testResults = results.getTestResults();
+
+        assertThat(testResults)
+                .extracting(TestResult::getName)
+                .containsExactly("Should work as expected [Attempt 1]");
+    }
+
+    @Issue("831")
+    @AllureFeatures.DisplayName
+    @Test
+    void shouldNotDuplicateLongDisplayNameForRepeatedTests() {
+        final AllureResults results = runClasses(RepeatedTestsWithLongDisplayName.class);
+        final List<TestResult> testResults = results.getTestResults();
+
+        assertThat(testResults)
+                .extracting(TestResult::getName)
+                .containsExactly(
+                        "Long name :: repetition 1 of 2",
+                        "Long name :: repetition 2 of 2"
+                );
     }
 
     @AllureFeatures.MarkerAnnotations

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/RepeatedTestsWithDisplayName.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/RepeatedTestsWithDisplayName.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+
+public class RepeatedTestsWithDisplayName {
+
+    @DisplayName("Should work as expected")
+    @RepeatedTest(
+            value = 1,
+            name = "{displayName} [Attempt {currentRepetition}]"
+    )
+    void shouldWorkAsExpected() {
+    }
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/RepeatedTestsWithLongDisplayName.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/RepeatedTestsWithLongDisplayName.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+
+public class RepeatedTestsWithLongDisplayName {
+
+    @DisplayName("Long name")
+    @RepeatedTest(
+            value = 2,
+            name = RepeatedTest.LONG_DISPLAY_NAME
+    )
+    void repeatLong() {
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure JUnit Platform reports now avoid prepending a parent display name when a test-template invocation already starts with it. For example, `Should work as expected [Attempt 1]` is no longer reported as `Should work as expected Should work as expected [Attempt 1]`.

This also covers JUnit’s `RepeatedTest.LONG_DISPLAY_NAME` pattern while preserving the prefixes needed to distinguish parameterized class invocations.

fixes #1122

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java