### PR TITLE
Prevent reports from reading partially written Allure attachments

### DIFF
--- a/allure-java-commons/src/main/java/io/qameta/allure/FileSystemResultsWriter.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/FileSystemResultsWriter.java
@@ -29,6 +29,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -120,11 +122,23 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
                 consumer.accept(channel);
                 channel.force(true);
             }
-            Files.move(tempFile, file, StandardCopyOption.REPLACE_EXISTING);
+            try {
+                Files.move(
+                        tempFile,
+                        file,
+                        StandardCopyOption.REPLACE_EXISTING,
+                        StandardCopyOption.ATOMIC_MOVE
+                );
+            } catch (AtomicMoveNotSupportedException
+                    | FileAlreadyExistsException
+                    | UnsupportedOperationException ignored) {
+                Files.move(tempFile, file, StandardCopyOption.REPLACE_EXISTING);
+            }
             tempFile = null;
         } catch (IOException e) {
-            deleteIfExists(tempFile);
             throw new AllureResultsWriteException(getErrorMessage(entityName), e);
+        } finally {
+            deleteIfExists(tempFile);
         }
     }
 

--- a/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
@@ -20,13 +20,21 @@ import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.CopyOption;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -38,6 +46,12 @@ import static io.qameta.allure.FileSystemResultsWriter.generateTestResultName;
 import static io.qameta.allure.test.ThreadLocalEnhancedRandom.current;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 
 public class FileSystemResultsWriterTest {
 
@@ -125,6 +139,169 @@ public class FileSystemResultsWriterTest {
                 .isEqualTo(content);
     }
 
+    /**
+     * Verifies that a supported atomic move publishes an attachment without using the fallback.
+     *
+     * @param folder the temporary results directory
+     */
+    @Test
+    void shouldPublishAttachmentAtomicallyWhenSupported(@TempDir final Path folder) throws IOException {
+        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
+        final String source = "source-attachment.txt";
+        final String content = "attachment body";
+        final Path attachmentFile = folder.resolve(source);
+
+        try (MockedStatic<Files> files = mockStatic(Files.class, CALLS_REAL_METHODS)) {
+            Allure.step(
+                    "Write attachment using an atomic move",
+                    () -> writer.write(source, new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)))
+            );
+
+            Allure.step("Verify the atomic move was used without the fallback", () -> {
+                files.verify(
+                        () -> Files.move(
+                                any(Path.class),
+                                eq(attachmentFile),
+                                aryEq(
+                                        new CopyOption[]{
+                                                StandardCopyOption.REPLACE_EXISTING,
+                                                StandardCopyOption.ATOMIC_MOVE
+                                        }
+                                )
+                        )
+                );
+                files.verify(
+                        () -> Files.move(
+                                any(Path.class),
+                                eq(attachmentFile),
+                                aryEq(new CopyOption[]{StandardCopyOption.REPLACE_EXISTING})
+                        ),
+                        never()
+                );
+            });
+        }
+
+        assertThat(Files.readString(attachmentFile))
+                .isEqualTo(content);
+        assertThat(listFiles(folder))
+                .containsExactly(attachmentFile);
+    }
+
+    /**
+     * Verifies that an atomic-move failure still replaces an attachment with a complete file using a regular move.
+     *
+     * @param failureName the atomic-move failure scenario
+     * @param failure the atomic-move failure
+     * @param folder the temporary results directory
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("atomicMoveFallbackFailures")
+    void shouldReplaceAttachmentUsingFallbackWhenAtomicMoveFails(
+                                                                 final String failureName,
+                                                                 final Exception failure,
+                                                                 @TempDir final Path folder)
+            throws IOException {
+        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
+        final String source = "source-attachment.txt";
+        final String content = "attachment body";
+        final Path attachmentFile = folder.resolve(source);
+        Files.writeString(attachmentFile, "previous attachment body");
+
+        try (MockedStatic<Files> files = mockStatic(Files.class, CALLS_REAL_METHODS)) {
+            files.when(
+                    () -> Files.move(
+                            any(Path.class),
+                            eq(attachmentFile),
+                            aryEq(
+                                    new CopyOption[]{
+                                            StandardCopyOption.REPLACE_EXISTING,
+                                            StandardCopyOption.ATOMIC_MOVE
+                                    }
+                            )
+                    )
+            )
+                    .thenThrow(failure);
+
+            Allure.step(
+                    "Write attachment after the atomic move fails",
+                    () -> writer.write(source, new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)))
+            );
+
+            Allure.step("Verify the atomic move was attempted before the fallback", () -> {
+                files.verify(
+                        () -> Files.move(
+                                any(Path.class),
+                                eq(attachmentFile),
+                                aryEq(
+                                        new CopyOption[]{
+                                                StandardCopyOption.REPLACE_EXISTING,
+                                                StandardCopyOption.ATOMIC_MOVE
+                                        }
+                                )
+                        )
+                );
+                files.verify(
+                        () -> Files.move(
+                                any(Path.class),
+                                eq(attachmentFile),
+                                aryEq(new CopyOption[]{StandardCopyOption.REPLACE_EXISTING})
+                        )
+                );
+            });
+        }
+
+        assertThat(Files.readString(attachmentFile))
+                .isEqualTo(content);
+        assertThat(listFiles(folder))
+                .containsExactly(attachmentFile);
+    }
+
+    @Test
+    void shouldDeleteTemporaryFileWhenFallbackMoveFailsUnchecked(@TempDir final Path folder) throws IOException {
+        FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
+        final String source = "source-attachment.txt";
+        final String content = "attachment body";
+        final Path attachmentFile = folder.resolve(source);
+
+        try (MockedStatic<Files> files = mockStatic(Files.class, CALLS_REAL_METHODS)) {
+            files.when(
+                    () -> Files.move(
+                            any(Path.class),
+                            eq(attachmentFile),
+                            aryEq(
+                                    new CopyOption[]{
+                                            StandardCopyOption.REPLACE_EXISTING,
+                                            StandardCopyOption.ATOMIC_MOVE
+                                    }
+                            )
+                    )
+            )
+                    .thenThrow(new UnsupportedOperationException("Atomic move is not supported"));
+            files.when(
+                    () -> Files.move(
+                            any(Path.class),
+                            eq(attachmentFile),
+                            aryEq(new CopyOption[]{StandardCopyOption.REPLACE_EXISTING})
+                    )
+            )
+                    .thenThrow(new IllegalStateException("Fallback move failed"));
+
+            assertThatThrownBy(
+                    () -> writer.write(
+                            source,
+                            new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))
+                    )
+            )
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessage("Fallback move failed");
+        }
+
+        assertThat(attachmentFile)
+                .doesNotExist();
+        assertThat(listFiles(folder))
+                .isEmpty();
+    }
+
     @Test
     void shouldNotCreateFinalAttachmentFileWhenStreamFails(@TempDir final Path folder) throws IOException {
         FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
@@ -167,6 +344,23 @@ public class FileSystemResultsWriterTest {
         try (Stream<Path> files = Files.list(folder)) {
             return files.collect(Collectors.toList());
         }
+    }
+
+    private static Stream<Arguments> atomicMoveFallbackFailures() {
+        return Stream.of(
+                Arguments.of(
+                        "Atomic move is not supported",
+                        new AtomicMoveNotSupportedException("source", "target", "Not supported")
+                ),
+                Arguments.of(
+                        "Atomic move option is not supported",
+                        new UnsupportedOperationException("Atomic move is not supported")
+                ),
+                Arguments.of(
+                        "Atomic move cannot replace an existing target",
+                        new FileAlreadyExistsException("target")
+                )
+        );
     }
 
     private static final class FailingInputStream extends InputStream {


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure results and attachments are now published with an atomic move after writing completes, preventing report generation and TestOps from picking up incomplete files on supported filesystems. This is especially important for large artifacts such as test-session video recordings, which could otherwise appear corrupted when a report starts immediately after the tests finish.

Filesystems that do not support atomic moves retain the existing replace behavior instead of losing the completed file. Failed publications also clean up their temporary files.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java