### PR TITLE
Add run-level globals and global error reporting

### DIFF
--- a/allure-java-commons-test/src/main/java/io/qameta/allure/test/AllureResults.java
+++ b/allure-java-commons-test/src/main/java/io/qameta/allure/test/AllureResults.java
@@ -17,6 +17,7 @@ package io.qameta.allure.test;
 
 import io.qameta.allure.model.Attachment;
 import io.qameta.allure.model.ExecutableItem;
+import io.qameta.allure.model.Globals;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
 
@@ -50,6 +51,15 @@ public interface AllureResults {
      * @return the test containers
      */
     List<TestResultContainer> getTestResultContainers();
+
+    /**
+     * Returns the global artifacts.
+     *
+     * @return the global artifacts
+     */
+    default List<Globals> getGlobals() {
+        return List.of();
+    }
 
     /**
      * Returns the attachments.

--- a/allure-java-commons-test/src/main/java/io/qameta/allure/test/AllureResultsWriterStub.java
+++ b/allure-java-commons-test/src/main/java/io/qameta/allure/test/AllureResultsWriterStub.java
@@ -16,6 +16,7 @@
 package io.qameta.allure.test;
 
 import io.qameta.allure.AllureResultsWriter;
+import io.qameta.allure.model.Globals;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
 import org.apache.commons.io.IOUtils;
@@ -37,6 +38,7 @@ public class AllureResultsWriterStub implements AllureResultsWriter, AllureResul
 
     private final List<TestResult> testResults = new CopyOnWriteArrayList<>();
     private final List<TestResultContainer> testContainers = new CopyOnWriteArrayList<>();
+    private final List<Globals> globals = new CopyOnWriteArrayList<>();
     private final Map<String, byte[]> attachments = new ConcurrentHashMap<>();
 
     /**
@@ -53,6 +55,14 @@ public class AllureResultsWriterStub implements AllureResultsWriter, AllureResul
     @Override
     public void write(final TestResultContainer testResultContainer) {
         testContainers.add(testResultContainer);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void write(final Globals value) {
+        globals.add(value);
     }
 
     /**
@@ -82,6 +92,14 @@ public class AllureResultsWriterStub implements AllureResultsWriter, AllureResul
     @Override
     public List<TestResultContainer> getTestResultContainers() {
         return testContainers;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Globals> getGlobals() {
+        return globals;
     }
 
     /**

--- a/allure-java-commons-test/src/main/java/io/qameta/allure/test/AllureTestCommonsUtils.java
+++ b/allure-java-commons-test/src/main/java/io/qameta/allure/test/AllureTestCommonsUtils.java
@@ -36,6 +36,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT;
@@ -93,6 +94,18 @@ public final class AllureTestCommonsUtils {
                         container.getUuid() + AllureConstants.TEST_RESULT_CONTAINER_FILE_SUFFIX,
                         JSON_TYPE,
                         WRITER.writeValueAsString(container)
+                );
+            } catch (JsonProcessingException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+
+        allureResults.getGlobals().forEach(globals -> {
+            try {
+                Allure.attachment(
+                        UUID.randomUUID() + AllureConstants.GLOBALS_FILE_SUFFIX,
+                        JSON_TYPE,
+                        WRITER.writeValueAsString(globals)
                 );
             } catch (JsonProcessingException e) {
                 throw new UncheckedIOException(e);

--- a/allure-java-commons-test/src/test/java/io/qameta/allure/test/AllureResultsWriterStubTest.java
+++ b/allure-java-commons-test/src/test/java/io/qameta/allure/test/AllureResultsWriterStubTest.java
@@ -17,6 +17,8 @@ package io.qameta.allure.test;
 
 import io.qameta.allure.Allure;
 import io.qameta.allure.model.Attachment;
+import io.qameta.allure.model.GlobalError;
+import io.qameta.allure.model.Globals;
 import io.qameta.allure.model.StepResult;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
@@ -25,13 +27,14 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AllureResultsWriterStubTest {
 
     @Test
-    void shouldStoreResultsContainersAndAttachments() {
+    void shouldStoreResultsContainersGlobalsAndAttachments() {
         final AllureResultsWriterStub writer = new AllureResultsWriterStub();
         final TestResult testResult = new TestResult()
                 .setUuid("test-uuid")
@@ -39,10 +42,13 @@ class AllureResultsWriterStubTest {
         final TestResultContainer container = new TestResultContainer()
                 .setUuid("container-uuid")
                 .setChildren(List.of("test-uuid"));
+        final Globals globals = new Globals()
+                .setErrors(List.of(new GlobalError().setMessage("global error").setTimestamp(123L)));
 
-        Allure.step("Store a test result, its container, and an attachment", () -> {
+        Allure.step("Store a test result, its container, globals, and an attachment", () -> {
             writer.write(testResult);
             writer.write(container);
+            writer.write(globals);
             writer.write("payload.txt", new ByteArrayInputStream("payload".getBytes(StandardCharsets.UTF_8)));
         });
 
@@ -51,9 +57,42 @@ class AllureResultsWriterStubTest {
                     .isSameAs(testResult);
             assertThat(writer.getTestResultContainersForTestResult(testResult))
                     .containsExactly(container);
+            assertThat(writer.getGlobals())
+                    .containsExactly(
+                            new Globals()
+                                    .setErrors(
+                                            List.of(
+                                                    new GlobalError()
+                                                            .setMessage("global error")
+                                                            .setTimestamp(123L)
+                                            )
+                                    )
+                    );
             assertThat(writer.getAttachments().get("payload.txt"))
                     .isEqualTo("payload".getBytes(StandardCharsets.UTF_8));
         });
+    }
+
+    @Test
+    void shouldDefaultGlobalsToEmptyForLegacyResultsImplementations() {
+        final AllureResults legacyResults = new AllureResults() {
+            @Override
+            public List<TestResult> getTestResults() {
+                return List.of();
+            }
+
+            @Override
+            public List<TestResultContainer> getTestResultContainers() {
+                return List.of();
+            }
+
+            @Override
+            public Map<String, byte[]> getAttachments() {
+                return Map.of();
+            }
+        };
+
+        assertThat(legacyResults.getGlobals()).isEmpty();
     }
 
     @Test

--- a/allure-java-commons-test/src/test/java/io/qameta/allure/test/RunUtilsTest.java
+++ b/allure-java-commons-test/src/test/java/io/qameta/allure/test/RunUtilsTest.java
@@ -16,11 +16,15 @@
 package io.qameta.allure.test;
 
 import io.qameta.allure.Allure;
+import io.qameta.allure.AllureConstants;
+import io.qameta.allure.model.Attachment;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.TestResult;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,18 +54,30 @@ class RunUtilsTest {
     void shouldAttachNestedRunArtifactsToOuterLifecycle() {
         final AllureResults results = Allure
                 .step("Execute a nested synthetic run and capture its emitted attachments", () -> RunUtils.runWithinTestContext(() -> RunUtils.runWithinTestContext(() -> {
+                    Allure.globalError(new IllegalStateException("nested global error"));
                 })
                 )
                 );
 
         Allure.attachment("nested-attachment-keys", String.join("\n", results.getAttachments().keySet()));
         Allure.step("Verify the outer lifecycle receives serialized artifacts from the nested run", () -> {
+            final List<String> attachmentContents = results.getAttachments().values().stream()
+                    .map(bytes -> new String(bytes, StandardCharsets.UTF_8))
+                    .collect(Collectors.toList());
             assertThat(results.getAttachments())
                     .isNotEmpty();
-            assertThat(results.getAttachments().values())
-                    .anySatisfy(
-                            bytes -> assertThat(new String(bytes, StandardCharsets.UTF_8))
-                                    .contains("\"uuid\"")
+            assertThat(results.getAttachmentsRecursively())
+                    .extracting(Attachment::getName)
+                    .anyMatch(
+                            name -> name != null
+                                    && name.endsWith(AllureConstants.GLOBALS_FILE_SUFFIX)
+                    );
+            assertThat(attachmentContents)
+                    .anyMatch(content -> content.contains("\"uuid\""));
+            assertThat(attachmentContents)
+                    .anyMatch(
+                            content -> content.contains("\"errors\"")
+                                    && content.contains("nested global error")
                     );
         });
     }

--- a/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/Allure.java
@@ -17,10 +17,13 @@ package io.qameta.allure;
 
 import io.qameta.allure.http.HttpExchange;
 import io.qameta.allure.http.HttpExchangeSerializer;
+import io.qameta.allure.model.GlobalError;
+import io.qameta.allure.model.Globals;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Status;
+import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.model.StepResult;
 import io.qameta.allure.util.ExceptionUtils;
 
@@ -407,6 +410,48 @@ public final class Allure {
      */
     public static void descriptionHtml(final String descriptionHtml) {
         getLifecycle().updateTestMetadata(metadata -> metadata.setDescriptionHtml(descriptionHtml));
+    }
+
+    /**
+     * Adds an error from the given throwable that belongs to the test run rather than to a test or fixture.
+     * The error is passed synchronously to the configured results writer before this method returns.
+     * Writers that support globals store it in a new globals artifact.
+     *
+     * @param throwable the error to add
+     */
+    public static void globalError(final Throwable throwable) {
+        Objects.requireNonNull(throwable, "throwable");
+        final StatusDetails statusDetails = getStatusDetails(throwable).orElseThrow();
+        globalError(statusDetails);
+    }
+
+    /**
+     * Adds an error with the given status details that belongs to the test run rather than to a test or fixture.
+     * The error is passed synchronously to the configured results writer before this method returns.
+     * Writers that support globals store it in a new globals artifact.
+     * The status detail fields are copied without normalization, and the timestamp is assigned when this method
+     * is called.
+     *
+     * @param statusDetails the error details to add
+     */
+    public static void globalError(final StatusDetails statusDetails) {
+        Objects.requireNonNull(statusDetails, "statusDetails");
+        final GlobalError globalError = toGlobalError(statusDetails)
+                .setTimestamp(System.currentTimeMillis());
+        final Globals globals = new Globals();
+        globals.getErrors().add(globalError);
+        getLifecycle().writeGlobals(globals);
+    }
+
+    private static GlobalError toGlobalError(final StatusDetails statusDetails) {
+        return new GlobalError()
+                .setKnown(statusDetails.isKnown())
+                .setMuted(statusDetails.isMuted())
+                .setFlaky(statusDetails.isFlaky())
+                .setMessage(statusDetails.getMessage())
+                .setTrace(statusDetails.getTrace())
+                .setActual(statusDetails.getActual())
+                .setExpected(statusDetails.getExpected());
     }
 
     /**

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureConstants.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureConstants.java
@@ -44,6 +44,16 @@ public final class AllureConstants {
     public static final String TEST_RESULT_CONTAINER_FILE_GLOB = "*-container.json";
 
     /**
+     * File suffix used for global artifacts.
+     */
+    public static final String GLOBALS_FILE_SUFFIX = "-globals.json";
+
+    /**
+     * Glob pattern used to find global artifacts.
+     */
+    public static final String GLOBALS_FILE_GLOB = "*-globals.json";
+
+    /**
      * File suffix used for attachment artifacts.
      */
     public static final String ATTACHMENT_FILE_SUFFIX = "-attachment";

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
@@ -24,6 +24,7 @@ import io.qameta.allure.listener.StepLifecycleListener;
 import io.qameta.allure.listener.TestLifecycleListener;
 import io.qameta.allure.model.Attachment;
 import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.Globals;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.ScopeFixtureResult;
@@ -153,6 +154,17 @@ public class AllureLifecycle {
         this.notifier = lifecycleNotifier;
         this.writer = writer;
         this.threadContext = new AllureThreadContext();
+    }
+
+    // ── Globals ──────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Writes test-run-level attachments and errors immediately.
+     *
+     * @param globals the global attachments and errors
+     */
+    public void writeGlobals(final Globals globals) {
+        writer.write(Objects.requireNonNull(globals, "globals"));
     }
 
     // ── Scopes ───────────────────────────────────────────────────────────────────────────────

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureResultsWriter.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureResultsWriter.java
@@ -15,6 +15,7 @@
  */
 package io.qameta.allure;
 
+import io.qameta.allure.model.Globals;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
 
@@ -42,6 +43,21 @@ public interface AllureResultsWriter {
      * during operation.
      */
     void write(TestResultContainer testResultContainer);
+
+    /**
+     * Writes Allure globals bean.
+     *
+     * <p>The default implementation preserves compatibility with custom writers
+     * that predate global artifacts. Such writers do not persist globals until
+     * they override this method.</p>
+     *
+     * @param globals the given bean to write.
+     * @throws AllureResultsWriteException if an overriding implementation fails
+     * during operation.
+     */
+    default void write(final Globals globals) {
+        // Compatibility no-op for custom writers that predate global artifacts.
+    }
 
     /**
      * Writes given attachment. Will close the given stream.

--- a/allure-java-commons/src/main/java/io/qameta/allure/FileSystemResultsWriter.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/FileSystemResultsWriter.java
@@ -17,6 +17,7 @@ package io.qameta.allure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.qameta.allure.internal.Allure2ModelJackson;
+import io.qameta.allure.model.Globals;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
 import org.slf4j.Logger;
@@ -50,6 +51,8 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
     private static final String TEST_RESULT_ENTITY_NAME = "test result";
 
     private static final String TEST_RESULT_CONTAINER_ENTITY_NAME = "test result container";
+
+    private static final String GLOBALS_ENTITY_NAME = "globals";
 
     private static final String ATTACHMENT_ENTITY_NAME = "attachment";
 
@@ -94,6 +97,19 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
         write(file, TEST_RESULT_CONTAINER_ENTITY_NAME, channel -> {
             final DataOutput output = new DataOutputStream(Channels.newOutputStream(channel));
             mapper.writeValue(output, testResultContainer);
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void write(final Globals globals) {
+        Objects.requireNonNull(globals, GLOBALS_ENTITY_NAME);
+        final Path file = outputDirectory.resolve(generateGlobalsName());
+        write(file, GLOBALS_ENTITY_NAME, channel -> {
+            final DataOutput output = new DataOutputStream(Channels.newOutputStream(channel));
+            mapper.writeValue(output, globals);
         });
     }
 
@@ -213,5 +229,24 @@ public class FileSystemResultsWriter implements AllureResultsWriter {
      */
     protected static String generateTestResultContainerName(final String uuid) {
         return uuid + AllureConstants.TEST_RESULT_CONTAINER_FILE_SUFFIX;
+    }
+
+    /**
+     * Generates and returns the globals name.
+     *
+     * @return the generated globals name
+     */
+    protected static String generateGlobalsName() {
+        return generateGlobalsName(UUID.randomUUID().toString());
+    }
+
+    /**
+     * Generates and returns the globals name.
+     *
+     * @param uuid the Allure UUID of the globals artifact
+     * @return the generated globals name
+     */
+    protected static String generateGlobalsName(final String uuid) {
+        return uuid + AllureConstants.GLOBALS_FILE_SUFFIX;
     }
 }

--- a/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
@@ -19,10 +19,13 @@ import io.qameta.allure.listener.LifecycleNotifier;
 import io.qameta.allure.listener.TestLifecycleListener;
 import io.qameta.allure.model.Attachment;
 import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.GlobalError;
+import io.qameta.allure.model.Globals;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Stage;
+import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.model.StepResult;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
@@ -61,10 +64,13 @@ import static io.qameta.allure.test.TestData.randomId;
 import static io.qameta.allure.test.TestData.randomName;
 import static io.qameta.allure.test.TestData.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 @SuppressWarnings({"deprecation", "removal"})
 @IsolatedLifecycle
 class AllureLifecycleTest {
@@ -102,6 +108,163 @@ class AllureLifecycleTest {
                 .isNotNull()
                 .hasFieldOrPropertyWithValue("uuid", uuid)
                 .hasFieldOrPropertyWithValue("name", name);
+    }
+
+    @Test
+    void shouldWriteGlobalErrorImmediatelyFromThrowable() {
+        final IllegalStateException throwable = new IllegalStateException("global setup failed");
+        final long before = System.currentTimeMillis();
+
+        final AllureResults results = RunUtils.runTests(ignored -> Allure.globalError(throwable));
+        final long after = System.currentTimeMillis();
+
+        assertThat(results.getGlobals()).hasSize(1);
+        final Globals globals = results.getGlobals().get(0);
+        assertThat(globals.getAttachments()).isEmpty();
+        assertThat(globals.getErrors()).hasSize(1);
+        final GlobalError error = globals.getErrors().get(0);
+        assertThat(error.getMessage()).isEqualTo("global setup failed");
+        assertThat(error.getTrace()).startsWith("java.lang.IllegalStateException: global setup failed");
+        assertThat(error.getTimestamp()).isBetween(before, after);
+    }
+
+    @Test
+    void shouldNormalizeMissingThrowableMessageForGlobalError() {
+        final AllureResults results = RunUtils.runTests(ignored -> Allure.globalError(new IllegalStateException()));
+
+        assertThat(results.getGlobals()).hasSize(1);
+        assertThat(results.getGlobals().get(0).getErrors()).hasSize(1);
+        final GlobalError error = results.getGlobals().get(0).getErrors().get(0);
+        assertThat(error.getMessage()).isEqualTo(IllegalStateException.class.getName());
+    }
+
+    @Test
+    void shouldWriteGlobalErrorImmediatelyFromStatusDetails() {
+        final StatusDetails statusDetails = new StatusDetails()
+                .setKnown(true)
+                .setMuted(false)
+                .setFlaky(true)
+                .setMessage("configured global error")
+                .setTrace("configured trace")
+                .setActual("actual value")
+                .setExpected("expected value");
+        final long before = System.currentTimeMillis();
+
+        final AllureResults results = RunUtils.runTests(ignored -> Allure.globalError(statusDetails));
+        final long after = System.currentTimeMillis();
+
+        assertThat(results.getGlobals()).hasSize(1);
+        final Globals globals = results.getGlobals().get(0);
+        assertThat(globals.getAttachments()).isEmpty();
+        assertThat(globals.getErrors()).hasSize(1);
+        final GlobalError error = globals.getErrors().get(0);
+        assertThat(error.isKnown()).isTrue();
+        assertThat(error.isMuted()).isFalse();
+        assertThat(error.isFlaky()).isTrue();
+        assertThat(error.getMessage()).isEqualTo("configured global error");
+        assertThat(error.getTrace()).isEqualTo("configured trace");
+        assertThat(error.getActual()).isEqualTo("actual value");
+        assertThat(error.getExpected()).isEqualTo("expected value");
+        assertThat(error.getTimestamp()).isBetween(before, after);
+    }
+
+    @Test
+    void shouldReplacePresetGlobalErrorTimestampWithoutMutatingInput() {
+        final GlobalError input = new GlobalError()
+                .setMessage("preset global error")
+                .setTimestamp(1L);
+        final long before = System.currentTimeMillis();
+
+        final AllureResults results = RunUtils.runTests(ignored -> Allure.globalError(input));
+        final long after = System.currentTimeMillis();
+
+        assertThat(results.getGlobals()).hasSize(1);
+        assertThat(results.getGlobals().get(0).getErrors()).hasSize(1);
+        final GlobalError error = results.getGlobals().get(0).getErrors().get(0);
+        assertThat(error).isNotSameAs(input);
+        assertThat(error.getMessage()).isEqualTo("preset global error");
+        assertThat(error.getTimestamp()).isBetween(before, after);
+        assertThat(input.getTimestamp()).isEqualTo(1L);
+    }
+
+    @Test
+    void shouldPreserveEmptyStatusDetailsForGlobalError() {
+        final long before = System.currentTimeMillis();
+
+        final AllureResults results = RunUtils.runTests(ignored -> Allure.globalError(new StatusDetails()));
+        final long after = System.currentTimeMillis();
+
+        assertThat(results.getGlobals()).hasSize(1);
+        assertThat(results.getGlobals().get(0).getErrors()).hasSize(1);
+        final GlobalError error = results.getGlobals().get(0).getErrors().get(0);
+        assertThat(error.isKnown()).isFalse();
+        assertThat(error.isMuted()).isFalse();
+        assertThat(error.isFlaky()).isFalse();
+        assertThat(error.getMessage()).isNull();
+        assertThat(error.getTrace()).isNull();
+        assertThat(error.getActual()).isNull();
+        assertThat(error.getExpected()).isNull();
+        assertThat(error.getTimestamp()).isBetween(before, after);
+    }
+
+    @Test
+    void shouldWriteEveryGlobalErrorAsSeparateGlobalsArtifact() {
+        final AllureResults results = RunUtils.runTests(ignored -> {
+            Allure.globalError(new IllegalStateException("first global error"));
+            Allure.globalError(new IllegalArgumentException("second global error"));
+        });
+
+        assertThat(results.getGlobals()).hasSize(2);
+        assertThat(results.getGlobals())
+                .flatExtracting(Globals::getErrors)
+                .extracting(GlobalError::getMessage)
+                .containsExactly("first global error", "second global error");
+    }
+
+    @Test
+    void shouldKeepGlobalsCompatibleWithLegacyResultsWriter() {
+        final AllureResultsWriter legacyWriter = new AllureResultsWriter() {
+            @Override
+            public void write(final TestResult testResult) {
+                throw new AssertionError("unexpected test result");
+            }
+
+            @Override
+            public void write(final TestResultContainer testResultContainer) {
+                throw new AssertionError("unexpected test result container");
+            }
+
+            @Override
+            public void write(final String source, final InputStream attachment) {
+                throw new AssertionError("unexpected attachment");
+            }
+        };
+
+        assertThatCode(() -> new AllureLifecycle(legacyWriter).writeGlobals(new Globals()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldRejectNullGlobals() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> lifecycle.writeGlobals(null))
+                .withMessage("globals");
+
+        verifyNoInteractions(writer);
+    }
+
+    @Test
+    void shouldRejectNullThrowableGlobalError() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> Allure.globalError((Throwable) null))
+                .withMessage("throwable");
+    }
+
+    @Test
+    void shouldRejectNullStatusDetailsGlobalError() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> Allure.globalError((StatusDetails) null))
+                .withMessage("statusDetails");
     }
 
     @Test

--- a/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/FileSystemResultsWriterTest.java
@@ -15,6 +15,11 @@
  */
 package io.qameta.allure;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import io.qameta.allure.internal.Allure2ModelJackson;
+import io.qameta.allure.model.GlobalAttachment;
+import io.qameta.allure.model.GlobalError;
+import io.qameta.allure.model.Globals;
 import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
@@ -36,6 +41,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -89,6 +95,108 @@ public class FileSystemResultsWriterTest {
         final String fileName = generateTestResultContainerName(uuid);
         assertThat(folder.resolve(fileName))
                 .isRegularFile();
+    }
+
+    @Test
+    void shouldWriteGlobals(@TempDir final Path folder) throws IOException {
+        final FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
+        final GlobalAttachment attachment = new GlobalAttachment()
+                .setName("setup log")
+                .setSource("setup-attachment.txt")
+                .setType("text/plain")
+                .setSize(12L)
+                .setTimestamp(123L);
+        final GlobalError error = new GlobalError()
+                .setKnown(true)
+                .setMuted(false)
+                .setFlaky(true)
+                .setMessage("setup failed")
+                .setTrace("stack trace")
+                .setActual("actual value")
+                .setExpected("expected value")
+                .setTimestamp(456L);
+        final Globals globals = new Globals()
+                .setAttachments(Collections.singletonList(attachment))
+                .setErrors(Collections.singletonList(error));
+
+        writer.write(globals);
+
+        final List<Path> files = listFiles(folder);
+        assertThat(files).hasSize(1);
+        final Path globalsFile = files.get(0);
+        assertThat(globalsFile.getFileName().toString())
+                .matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-globals\\.json");
+
+        final JsonNode payload = Allure2ModelJackson.createMapper().readTree(globalsFile.toFile());
+        assertThat(payload.size()).isEqualTo(2);
+        assertThat(payload.path("attachments").size()).isEqualTo(1);
+        final JsonNode attachmentPayload = payload.path("attachments").path(0);
+        assertThat(attachmentPayload.size()).isEqualTo(5);
+        assertThat(attachmentPayload.path("name").textValue()).isEqualTo("setup log");
+        assertThat(attachmentPayload.path("source").textValue()).isEqualTo("setup-attachment.txt");
+        assertThat(attachmentPayload.path("type").textValue()).isEqualTo("text/plain");
+        assertThat(attachmentPayload.path("size").longValue()).isEqualTo(12L);
+        assertThat(attachmentPayload.path("timestamp").longValue()).isEqualTo(123L);
+
+        assertThat(payload.path("errors").size()).isEqualTo(1);
+        final JsonNode errorPayload = payload.path("errors").path(0);
+        assertThat(errorPayload.size()).isEqualTo(8);
+        assertThat(errorPayload.path("known").booleanValue()).isTrue();
+        assertThat(errorPayload.path("muted").booleanValue()).isFalse();
+        assertThat(errorPayload.path("flaky").booleanValue()).isTrue();
+        assertThat(errorPayload.path("message").textValue()).isEqualTo("setup failed");
+        assertThat(errorPayload.path("trace").textValue()).isEqualTo("stack trace");
+        assertThat(errorPayload.path("actual").textValue()).isEqualTo("actual value");
+        assertThat(errorPayload.path("expected").textValue()).isEqualTo("expected value");
+        assertThat(errorPayload.path("timestamp").longValue()).isEqualTo(456L);
+
+        final Globals written = Allure2ModelJackson.createMapper().readValue(globalsFile.toFile(), Globals.class);
+        assertThat(written.getAttachments()).hasSize(1);
+        final GlobalAttachment writtenAttachment = written.getAttachments().get(0);
+        assertThat(writtenAttachment.getName()).isEqualTo("setup log");
+        assertThat(writtenAttachment.getSource()).isEqualTo("setup-attachment.txt");
+        assertThat(writtenAttachment.getType()).isEqualTo("text/plain");
+        assertThat(writtenAttachment.getSize()).isEqualTo(12L);
+        assertThat(writtenAttachment.getTimestamp()).isEqualTo(123L);
+
+        assertThat(written.getErrors()).hasSize(1);
+        final GlobalError writtenError = written.getErrors().get(0);
+        assertThat(writtenError.isKnown()).isTrue();
+        assertThat(writtenError.isMuted()).isFalse();
+        assertThat(writtenError.isFlaky()).isTrue();
+        assertThat(writtenError.getMessage()).isEqualTo("setup failed");
+        assertThat(writtenError.getTrace()).isEqualTo("stack trace");
+        assertThat(writtenError.getActual()).isEqualTo("actual value");
+        assertThat(writtenError.getExpected()).isEqualTo("expected value");
+        assertThat(writtenError.getTimestamp()).isEqualTo(456L);
+    }
+
+    @Test
+    void shouldWriteEachGlobalsArtifactToDistinctFile(@TempDir final Path folder) throws IOException {
+        final FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
+
+        writer.write(new Globals());
+        writer.write(new Globals());
+
+        assertThat(listFiles(folder))
+                .hasSize(2)
+                .extracting(path -> path.getFileName().toString())
+                .doesNotHaveDuplicates()
+                .allMatch(
+                        fileName -> fileName
+                                .matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-globals\\.json")
+                );
+    }
+
+    @Test
+    void shouldRejectNullGlobalsWithoutCreatingArtifact(@TempDir final Path folder) throws IOException {
+        final FileSystemResultsWriter writer = new FileSystemResultsWriter(folder);
+
+        assertThatThrownBy(() -> writer.write((Globals) null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("globals");
+
+        assertThat(listFiles(folder)).isEmpty();
     }
 
     @Test

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/AllureJupiterTest.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/AllureJupiterTest.java
@@ -19,10 +19,12 @@ import io.qameta.allure.Step;
 import io.qameta.allure.junitplatform.AllureJunitPlatform;
 import io.qameta.allure.jupiter.features.BrokenBeforeEachTests;
 import io.qameta.allure.jupiter.features.FixtureTests;
+import io.qameta.allure.jupiter.features.GlobalErrorTests;
 import io.qameta.allure.jupiter.features.NestedTemplatesTests;
 import io.qameta.allure.jupiter.features.ParamAnnotationTests;
 import io.qameta.allure.jupiter.features.ParameterizedClassTests;
 import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.GlobalError;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.TestResult;
@@ -131,6 +133,20 @@ class AllureJupiterTest {
                 .orElseThrow(() -> new AssertionError("no scope with the broken fixture"));
         assertThat(methodScope.getChildren())
                 .containsExactly(testResult.getUuid());
+    }
+
+    @Test
+    void shouldReportGlobalErrorFromJupiterTest() {
+        final AllureResults results = runClasses(GlobalErrorTests.class);
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getStatus)
+                .containsExactly(Status.PASSED);
+        assertThat(results.getGlobals()).hasSize(1);
+        assertThat(results.getGlobals().get(0).getErrors()).hasSize(1);
+        final GlobalError globalError = results.getGlobals().get(0).getErrors().get(0);
+        assertThat(globalError.getMessage()).isEqualTo("jupiter global error");
+        assertThat(globalError.getTimestamp()).isPositive();
     }
 
     @Test

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/GlobalErrorTests.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/GlobalErrorTests.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jupiter.features;
+
+import io.qameta.allure.Allure;
+import io.qameta.allure.jupiter.AllureJupiter;
+import io.qameta.allure.model.StatusDetails;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(AllureJupiter.class)
+public class GlobalErrorTests {
+
+    @Test
+    void reportsGlobalError() {
+        Allure.globalError(new StatusDetails().setMessage("jupiter global error"));
+    }
+}

--- a/allure-model/README.md
+++ b/allure-model/README.md
@@ -31,13 +31,14 @@ Maven, with `allure-bom` imported in dependency management:
 
 ## Use
 
-Use this module when you need Java objects for Allure result JSON, containers, fixtures, steps, attachments, labels, links, parameters, statuses, and stages.
+Use this module when you need Java objects for Allure result JSON, containers, globals, fixtures, steps, attachments, labels, links, parameters, statuses, and stages.
 
 Normal test projects should prefer a framework adapter and `allure-java-commons` runtime APIs rather than constructing model objects directly.
 
 ## Provides
 
 - `TestResult`, `StepResult`, `FixtureResult`, and `ScopeResult`.
+- `Globals`, `GlobalAttachment`, and `GlobalError` for run-level `{uuid}-globals.json` artifacts.
 - Attachments, labels, links, parameters, statuses, stages, and status details.
 - Common model interfaces for attachments, steps, parameters, links, and statuses.
 

--- a/allure-model/src/main/java/io/qameta/allure/model/GlobalAttachment.java
+++ b/allure-model/src/main/java/io/qameta/allure/model/GlobalAttachment.java
@@ -1,0 +1,113 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.model;
+
+import java.util.Objects;
+
+/**
+ * An attachment that belongs to the test run rather than to a test or fixture.
+ *
+ * @since 3.0
+ */
+public class GlobalAttachment extends Attachment {
+
+    private static final long serialVersionUID = 1L;
+
+    private long timestamp;
+
+    /**
+     * Gets the time when the attachment was added.
+     *
+     * @return the timestamp in milliseconds since the epoch
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Sets the time when the attachment was added.
+     *
+     * @param value the timestamp in milliseconds since the epoch
+     * @return self for method chaining
+     */
+    public GlobalAttachment setTimestamp(final long value) {
+        this.timestamp = value;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalAttachment setName(final String value) {
+        super.setName(value);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalAttachment setSource(final String value) {
+        super.setSource(value);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalAttachment setType(final String value) {
+        super.setType(value);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalAttachment setSize(final Long value) {
+        super.setSize(value);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final GlobalAttachment that = (GlobalAttachment) o;
+        return timestamp == that.timestamp
+                && Objects.equals(getName(), that.getName())
+                && Objects.equals(getSource(), that.getSource())
+                && Objects.equals(getType(), that.getType())
+                && Objects.equals(getSize(), that.getSize());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(), getSource(), getType(), getSize(), timestamp);
+    }
+}

--- a/allure-model/src/main/java/io/qameta/allure/model/GlobalError.java
+++ b/allure-model/src/main/java/io/qameta/allure/model/GlobalError.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.model;
+
+import java.util.Objects;
+
+/**
+ * Error details that belong to the test run rather than to a test or fixture.
+ *
+ * @since 3.0
+ */
+public class GlobalError extends StatusDetails {
+
+    private static final long serialVersionUID = 1L;
+
+    private long timestamp;
+
+    /**
+     * Gets the time when the error was added.
+     *
+     * @return the timestamp in milliseconds since the epoch
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Sets the time when the error was added.
+     *
+     * @param value the timestamp in milliseconds since the epoch
+     * @return self for method chaining
+     */
+    public GlobalError setTimestamp(final long value) {
+        this.timestamp = value;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalError setKnown(final boolean value) {
+        super.setKnown(value);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalError setMuted(final boolean value) {
+        super.setMuted(value);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalError setFlaky(final boolean value) {
+        super.setFlaky(value);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalError setMessage(final String value) {
+        super.setMessage(value);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalError setTrace(final String value) {
+        super.setTrace(value);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalError setActual(final String value) {
+        super.setActual(value);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GlobalError setExpected(final String value) {
+        super.setExpected(value);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        final GlobalError that = (GlobalError) o;
+        return timestamp == that.timestamp
+                && isKnown() == that.isKnown()
+                && isMuted() == that.isMuted()
+                && isFlaky() == that.isFlaky();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), isKnown(), isMuted(), isFlaky(), timestamp);
+    }
+}

--- a/allure-model/src/main/java/io/qameta/allure/model/Globals.java
+++ b/allure-model/src/main/java/io/qameta/allure/model/Globals.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Test-run-level attachments and errors.
+ *
+ * @since 3.0
+ */
+public class Globals implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<GlobalAttachment> attachments = new ArrayList<>();
+    private List<GlobalError> errors = new ArrayList<>();
+
+    /**
+     * Gets global attachments.
+     *
+     * @return the global attachments
+     */
+    public List<GlobalAttachment> getAttachments() {
+        return attachments;
+    }
+
+    /**
+     * Sets global attachments.
+     *
+     * @param value the global attachments
+     * @return self for method chaining
+     */
+    public Globals setAttachments(final List<GlobalAttachment> value) {
+        this.attachments = value;
+        return this;
+    }
+
+    /**
+     * Gets global errors.
+     *
+     * @return the global errors
+     */
+    public List<GlobalError> getErrors() {
+        return errors;
+    }
+
+    /**
+     * Sets global errors.
+     *
+     * @param value the global errors
+     * @return self for method chaining
+     */
+    public Globals setErrors(final List<GlobalError> value) {
+        this.errors = value;
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final Globals globals = (Globals) o;
+        return Objects.equals(attachments, globals.attachments)
+                && Objects.equals(errors, globals.errors);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(attachments, errors);
+    }
+}

--- a/allure-model/src/test/java/io/qameta/allure/model/GlobalAttachmentTest.java
+++ b/allure-model/src/test/java/io/qameta/allure/model/GlobalAttachmentTest.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalAttachmentTest {
+
+    @Test
+    void shouldSetAndCompareAttachmentDetailsAndTimestamp() {
+        final GlobalAttachment attachment = globalAttachment("setup.log", 123L);
+        final GlobalAttachment equalAttachment = globalAttachment("setup.log", 123L);
+
+        assertThat(attachment.getName()).isEqualTo("setup log");
+        assertThat(attachment.getSource()).isEqualTo("setup.log");
+        assertThat(attachment.getType()).isEqualTo("text/plain");
+        assertThat(attachment.getSize()).isEqualTo(42L);
+        assertThat(attachment.getTimestamp()).isEqualTo(123L);
+        assertThat(attachment)
+                .isEqualTo(attachment)
+                .isEqualTo(equalAttachment)
+                .isNotEqualTo(globalAttachment("different.log", 123L))
+                .isNotEqualTo(globalAttachment("setup.log", 456L))
+                .isNotEqualTo(new Attachment().setSource("setup.log"))
+                .isNotEqualTo(null);
+        assertThat(attachment.hashCode()).isEqualTo(equalAttachment.hashCode());
+    }
+
+    private static GlobalAttachment globalAttachment(final String source, final long timestamp) {
+        return new GlobalAttachment()
+                .setName("setup log")
+                .setSource(source)
+                .setType("text/plain")
+                .setSize(42L)
+                .setTimestamp(timestamp);
+    }
+}

--- a/allure-model/src/test/java/io/qameta/allure/model/GlobalErrorTest.java
+++ b/allure-model/src/test/java/io/qameta/allure/model/GlobalErrorTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalErrorTest {
+
+    @Test
+    void shouldCompareStatusDetailsAndTimestamp() {
+        final GlobalError error = globalError("global setup failed", 123L);
+        final GlobalError equalError = globalError("global setup failed", 123L);
+
+        assertThat(error)
+                .isEqualTo(error)
+                .isEqualTo(equalError)
+                .isNotEqualTo(globalError("different error", 123L))
+                .isNotEqualTo(globalError("global setup failed", 456L))
+                .isNotEqualTo(globalError("global setup failed", 123L).setKnown(false))
+                .isNotEqualTo(globalError("global setup failed", 123L).setMuted(false))
+                .isNotEqualTo(globalError("global setup failed", 123L).setFlaky(false))
+                .isNotEqualTo(new StatusDetails().setMessage("global setup failed"))
+                .isNotEqualTo(null);
+        assertThat(error.hashCode()).isEqualTo(equalError.hashCode());
+    }
+
+    private static GlobalError globalError(final String message, final long timestamp) {
+        return new GlobalError()
+                .setKnown(true)
+                .setMuted(true)
+                .setFlaky(true)
+                .setMessage(message)
+                .setTrace("stack trace")
+                .setActual("actual")
+                .setExpected("expected")
+                .setTimestamp(timestamp);
+    }
+}

--- a/allure-model/src/test/java/io/qameta/allure/model/GlobalsTest.java
+++ b/allure-model/src/test/java/io/qameta/allure/model/GlobalsTest.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalsTest {
+
+    @Test
+    void shouldHaveMutableEmptyCollectionsByDefault() {
+        final Globals globals = new Globals();
+        final GlobalAttachment attachment = new GlobalAttachment();
+        final GlobalError error = new GlobalError();
+
+        assertThat(globals.getAttachments()).isEmpty();
+        assertThat(globals.getErrors()).isEmpty();
+        assertThat(globals.getAttachments().add(attachment)).isTrue();
+        assertThat(globals.getErrors().add(error)).isTrue();
+        assertThat(globals.getAttachments()).containsExactly(attachment);
+        assertThat(globals.getErrors()).containsExactly(error);
+    }
+
+    @Test
+    void shouldSetAndCompareGlobalValues() {
+        final GlobalAttachment attachment = new GlobalAttachment()
+                .setSource("setup.log")
+                .setTimestamp(123L);
+        final GlobalError error = new GlobalError()
+                .setMessage("setup failed")
+                .setTimestamp(456L);
+        final Globals globals = new Globals()
+                .setAttachments(List.of(attachment))
+                .setErrors(List.of(error));
+        final Globals equalGlobals = new Globals()
+                .setAttachments(
+                        List.of(
+                                new GlobalAttachment()
+                                        .setSource("setup.log")
+                                        .setTimestamp(123L)
+                        )
+                )
+                .setErrors(
+                        List.of(
+                                new GlobalError()
+                                        .setMessage("setup failed")
+                                        .setTimestamp(456L)
+                        )
+                );
+
+        assertThat(globals.getAttachments()).containsExactly(attachment);
+        assertThat(globals.getErrors()).containsExactly(error);
+        assertThat(globals)
+                .isEqualTo(globals)
+                .isEqualTo(equalGlobals)
+                .isNotEqualTo(new Globals().setAttachments(List.of(new GlobalAttachment())))
+                .isNotEqualTo(new Globals().setErrors(List.of(new GlobalError())))
+                .isNotEqualTo(null);
+        assertThat(globals.hashCode()).isEqualTo(equalGlobals.hashCode());
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure Java integrations can now report errors that belong to the entire test run instead of assigning them to a test or fixture. `Allure.globalError(...)` accepts either a `Throwable` or `StatusDetails`, timestamps the error, and immediately writes a distinct `{uuid}-globals.json` artifact.

The result model now exposes `Globals`, `GlobalError`, and `GlobalAttachment` for consumers that read or produce run-level artifacts. Result writers retain backward compatibility while gaining globals support, including file-system output and test utility integration.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java