### PR TITLE
fix(playwright): use vnd.allure.playwright-trace content type for trace attachments (fixes #1381)

### DIFF
--- a/allure-model/src/main/java/io/qameta/allure/model/AttachmentType.java
+++ b/allure-model/src/main/java/io/qameta/allure/model/AttachmentType.java
@@ -55,6 +55,11 @@ public final class AttachmentType {
      */
     public static final AttachmentType OCTET_STREAM = new AttachmentType("application/octet-stream", "");
 
+    /**
+     * Predefined attachment type for Playwright trace archives.
+     */
+    public static final AttachmentType PLAYWRIGHT_TRACE = new AttachmentType("application/vnd.allure.playwright-trace", ZIP.getExtension());
+
     private final String mediaType;
     private final String extension;
 

--- a/allure-playwright/src/main/java/io/qameta/allure/playwright/AllurePlaywright.java
+++ b/allure-playwright/src/main/java/io/qameta/allure/playwright/AllurePlaywright.java
@@ -205,7 +205,7 @@ public final class AllurePlaywright {
      * @param traceZip the path to the trace zip file.
      */
     public static void attachTrace(final String name, final Path traceZip) {
-        attachPath(defaultName(name, TRACE), AttachmentType.ZIP, traceZip);
+        attachPath(defaultName(name, TRACE), AttachmentType.PLAYWRIGHT_TRACE, traceZip);
     }
 
     /**

--- a/allure-playwright/src/test/java/io/qameta/allure/playwright/AllurePlaywrightTest.java
+++ b/allure-playwright/src/test/java/io/qameta/allure/playwright/AllurePlaywrightTest.java
@@ -28,6 +28,7 @@ import io.qameta.allure.Description;
 import io.qameta.allure.Param;
 import io.qameta.allure.Step;
 import io.qameta.allure.model.Attachment;
+import io.qameta.allure.model.AttachmentType;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.model.StepResult;
@@ -361,6 +362,9 @@ class AllurePlaywrightTest {
 
         assertThat(results.getAttachments())
                 .hasSize(1);
+        assertThat(attachments(results))
+                .extracting(Attachment::getType)
+                .containsExactly(AttachmentType.PLAYWRIGHT_TRACE.getMediaType());
         assertAttachmentStartsWith(results, ZIP_HEADER);
     }
 
@@ -385,6 +389,9 @@ class AllurePlaywrightTest {
 
         assertThat(results.getAttachments())
                 .hasSize(1);
+        assertThat(attachments(results))
+                .extracting(Attachment::getType)
+                .containsExactly(AttachmentType.PLAYWRIGHT_TRACE.getMediaType());
         assertAttachmentStartsWith(results, ZIP_HEADER);
     }
 
@@ -408,6 +415,9 @@ class AllurePlaywrightTest {
 
         assertThat(results.getAttachments())
                 .hasSize(1);
+        assertThat(attachments(results))
+                .extracting(Attachment::getType)
+                .containsExactly(AttachmentType.PLAYWRIGHT_TRACE.getMediaType());
         assertAttachmentStartsWith(results, ZIP_HEADER);
     }
 


### PR DESCRIPTION
### Context

Fixes #1381

## Problem

`AllurePlaywright.attachTrace()` attached Playwright trace archives using the generic `application/zip` content type, so the Allure report rendered them as a plain zip download instead of using the built-in embedded trace viewer.

## Fix

Added a shared `AttachmentType.PLAYWRIGHT_TRACE` constant (`application/vnd.allure.playwright-trace`, already registered in `WellKnownFileExtensionsUtils` mapped to the `.zip` extension) alongside the other predefined types (`PNG`, `ZIP`, `WEBM`, ...), and switched `attachTrace()` to use it. The `.zip` file extension behavior is unchanged.

## Testing

Extended the three existing trace-attachment tests to assert the attachment's `type` is `AttachmentType.PLAYWRIGHT_TRACE.getMediaType()`, in addition to the existing zip-payload checks.

#### Checklist

- [x] Sign Allure CLA
- [x] Provide unit tests