### PR TITLE
Capture gRPC metadata by default with configurable redaction

### DIFF
--- a/allure-grpc/README.md
+++ b/allure-grpc/README.md
@@ -8,7 +8,7 @@ Use this module when your tests call gRPC services and you want method calls, me
 
 - Allure Java 3.x requires Java 17 or newer.
 - This module targets gRPC Java.
-- The current build validates against gRPC Java 1.81.0 and Protobuf Java 4.35.0.
+- The current build validates against gRPC Java 1.83.1 and Protobuf Java 4.35.1.
 
 ## Installation
 
@@ -42,19 +42,38 @@ ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", 8080)
         .build();
 ```
 
-For advanced capture policy, use the constructor that accepts an HTTP exchange builder customizer:
+Request and response metadata are captured by default. Cookie metadata is represented as structured HTTP exchange
+cookies, so header and cookie redaction can be configured through the HTTP exchange capture policy.
+
+Use the builder to add application-specific header and cookie redaction:
 
 ```java
-ClientInterceptor allure = new AllureGrpc(
-        Allure.getLifecycle(),
-        true,
-        true,
-        exchange -> exchange.redactHeader("authorization")
-);
+ClientInterceptor allure = AllureGrpc.builder()
+        .redactHeader("x-api-key")
+        .redactCookie("session")
+        .build();
+```
+
+Metadata capture can be disabled independently for either direction:
+
+```java
+ClientInterceptor allure = AllureGrpc.builder()
+        .captureRequestMetadata(false)
+        .captureResponseMetadata(false)
+        .build();
+```
+
+For other HTTP exchange capture options, configure the underlying exchange builder:
+
+```java
+ClientInterceptor allure = AllureGrpc.builder()
+        .configureExchange(exchange -> exchange.setMaxBodySize(256_000))
+        .build();
 ```
 
 ## Report Output
 
 - gRPC method calls as Allure steps.
 - Request and response messages, metadata, status, and timing.
+- Repeated metadata values in their original order; binary metadata values are Base64-encoded.
 - Stream metadata for unary and streaming calls where available.

--- a/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
+++ b/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
@@ -18,10 +18,12 @@ package io.qameta.allure.grpc;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.MessageOrBuilder;
 import com.google.protobuf.util.JsonFormat;
+import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
+import io.grpc.ClientStreamTracer;
 import io.grpc.ForwardingClientCall;
 import io.grpc.ForwardingClientCallListener;
 import io.grpc.Metadata;
@@ -32,6 +34,7 @@ import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.AttachmentOptions;
 import io.qameta.allure.http.HttpExchange;
 import io.qameta.allure.http.HttpExchangeBody;
+import io.qameta.allure.http.HttpExchangeCookie;
 import io.qameta.allure.http.HttpExchangeNameValue;
 import io.qameta.allure.http.HttpExchangeRequest;
 import io.qameta.allure.http.HttpExchangeResponse;
@@ -45,12 +48,12 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 /**
@@ -64,7 +67,8 @@ import java.util.function.Consumer;
             "checkstyle:ClassFanOutComplexity",
             "checkstyle:AnonInnerLength",
             "checkstyle:JavaNCSS",
-            "PMD.GodClass"
+            "PMD.GodClass",
+            "PMD.TooManyMethods"
     }
 )
 public class AllureGrpc implements ClientInterceptor {
@@ -76,6 +80,11 @@ public class AllureGrpc implements ClientInterceptor {
     private static final String GRPC_STATUS = "grpc-status";
     private static final String GRPC_MESSAGE = "grpc-message";
     private static final String CONTENT_TYPE_HEADER = "content-type";
+    private static final String COOKIE_HEADER = "cookie";
+    private static final String SET_COOKIE_HEADER = "set-cookie";
+    private static final String TE_HEADER = "te";
+    private static final String AUTHORITY_HEADER = ":authority";
+    private static final String COOKIE_SEPARATOR = ";";
     private static final String HTTP_METHOD = "POST";
     private static final String HTTP_VERSION = "HTTP/2";
     private static final String PATH_SEPARATOR = "/";
@@ -84,14 +93,24 @@ public class AllureGrpc implements ClientInterceptor {
 
     private final AllureLifecycle lifecycle;
     private final boolean markStepFailedOnNonZeroCode;
-    private final boolean interceptResponseMetadata;
+    private final boolean captureRequestMetadata;
+    private final boolean captureResponseMetadata;
     private final Consumer<HttpExchange.Builder> exchangeCustomizer;
 
     /**
-     * Creates an Allure grpc with default configuration.
+     * Creates an Allure gRPC interceptor that captures request and response metadata.
      */
     public AllureGrpc() {
-        this(Allure.getLifecycle(), true, false);
+        this(builder());
+    }
+
+    /**
+     * Creates an Allure gRPC builder.
+     *
+     * @return a builder configured to capture request and response metadata
+     */
+    public static Builder builder() {
+        return new Builder();
     }
 
     /**
@@ -99,13 +118,13 @@ public class AllureGrpc implements ClientInterceptor {
      *
      * @param lifecycle the Allure lifecycle to use
      * @param markStepFailedOnNonZeroCode the mark step failed on non zero code
-     * @param interceptResponseMetadata the intercept response metadata
+     * @param interceptResponseMetadata whether to capture response metadata; request metadata is captured
      */
     public AllureGrpc(
                       final AllureLifecycle lifecycle,
                       final boolean markStepFailedOnNonZeroCode,
                       final boolean interceptResponseMetadata) {
-        this(lifecycle, markStepFailedOnNonZeroCode, interceptResponseMetadata, builder -> {
+        this(lifecycle, markStepFailedOnNonZeroCode, true, interceptResponseMetadata, builder -> {
         });
     }
 
@@ -114,7 +133,7 @@ public class AllureGrpc implements ClientInterceptor {
      *
      * @param lifecycle the Allure lifecycle to use
      * @param markStepFailedOnNonZeroCode the mark step failed on non zero code
-     * @param interceptResponseMetadata the intercept response metadata
+     * @param interceptResponseMetadata whether to capture response metadata; request metadata is captured
      * @param exchangeCustomizer the HTTP exchange builder customizer
      */
     public AllureGrpc(
@@ -122,9 +141,29 @@ public class AllureGrpc implements ClientInterceptor {
                       final boolean markStepFailedOnNonZeroCode,
                       final boolean interceptResponseMetadata,
                       final Consumer<HttpExchange.Builder> exchangeCustomizer) {
+        this(lifecycle, markStepFailedOnNonZeroCode, true, interceptResponseMetadata, exchangeCustomizer);
+    }
+
+    private AllureGrpc(final Builder builder) {
+        this(
+                builder.lifecycle,
+                builder.markStepFailedOnNonZeroCode,
+                builder.captureRequestMetadata,
+                builder.captureResponseMetadata,
+                builder.exchangeCustomizer
+        );
+    }
+
+    private AllureGrpc(
+                       final AllureLifecycle lifecycle,
+                       final boolean markStepFailedOnNonZeroCode,
+                       final boolean captureRequestMetadata,
+                       final boolean captureResponseMetadata,
+                       final Consumer<HttpExchange.Builder> exchangeCustomizer) {
         this.lifecycle = lifecycle;
         this.markStepFailedOnNonZeroCode = markStepFailedOnNonZeroCode;
-        this.interceptResponseMetadata = interceptResponseMetadata;
+        this.captureRequestMetadata = captureRequestMetadata;
+        this.captureResponseMetadata = captureResponseMetadata;
         this.exchangeCustomizer = exchangeCustomizer == null ? builder -> {
         } : exchangeCustomizer;
     }
@@ -148,8 +187,8 @@ public class AllureGrpc implements ClientInterceptor {
         final long start = System.currentTimeMillis();
         final List<String> clientMessages = new ArrayList<>();
         final List<String> serverMessages = new ArrayList<>();
-        final Map<String, String> initialHeaders = new LinkedHashMap<>();
-        final Map<String, String> trailers = new LinkedHashMap<>();
+        final List<HttpExchangeNameValue> initialHeaders = new ArrayList<>();
+        final List<HttpExchangeNameValue> trailers = new ArrayList<>();
         final String authority = channel.authority();
 
         final String stepName = buildStepName(channel, methodDescriptor);
@@ -162,11 +201,16 @@ public class AllureGrpc implements ClientInterceptor {
                 serverMessages, initialHeaders, trailers, authority, start
         );
 
+        final CallOptions effectiveCallOptions = captureRequestMetadata
+                ? callOptions.withStreamTracerFactory(requestMetadataTracer(stepContext))
+                : callOptions;
+
         return new ForwardingClientCall.SimpleForwardingClientCall<T, R>(
-                channel.newCall(methodDescriptor, callOptions)
+                channel.newCall(methodDescriptor, effectiveCallOptions)
         ) {
             @Override
             public void start(final Listener<R> responseListener, final Metadata requestHeaders) {
+                handleRequestHeaders(requestHeaders, stepContext);
                 final Listener<R> forwardingListener = new ForwardingClientCallListener<R>() {
                     @Override
                     protected Listener<R> delegate() {
@@ -207,8 +251,8 @@ public class AllureGrpc implements ClientInterceptor {
                              final Metadata responseTrailers,
                              final StepContext<?, ?> stepContext) {
         try {
-            if (interceptResponseMetadata && responseTrailers != null) {
-                copyAsciiResponseMetadata(responseTrailers, stepContext.getTrailers());
+            if (captureResponseMetadata && responseTrailers != null) {
+                stepContext.getTrailers().addAll(copyMetadata(responseTrailers));
             }
             attachExchange(stepContext, status);
             stepContext.getLifecycle().updateStep(
@@ -226,13 +270,45 @@ public class AllureGrpc implements ClientInterceptor {
         }
     }
 
-    private void handleHeaders(final Metadata headers, final Map<String, String> destination) {
+    private ClientStreamTracer.Factory requestMetadataTracer(final StepContext<?, ?> stepContext) {
+        return new ClientStreamTracer.Factory() {
+            @Override
+            public ClientStreamTracer newClientStreamTracer(
+                                                            final ClientStreamTracer.StreamInfo info,
+                                                            final Metadata headers) {
+                handleRequestHeaders(headers, stepContext);
+                return new ClientStreamTracer() {
+                    @Override
+                    public void streamCreated(final Attributes transportAttrs, final Metadata streamHeaders) {
+                        handleRequestHeaders(streamHeaders, stepContext);
+                    }
+
+                    @Override
+                    public void streamClosed(final io.grpc.Status status) {
+                        handleRequestHeaders(headers, stepContext);
+                    }
+                };
+            }
+        };
+    }
+
+    private void handleRequestHeaders(final Metadata headers, final StepContext<?, ?> stepContext) {
         try {
-            if (interceptResponseMetadata && headers != null) {
-                copyAsciiResponseMetadata(headers, destination);
+            if (captureRequestMetadata && headers != null) {
+                stepContext.setRequestHeaders(copyMetadata(headers));
             }
         } catch (Throwable throwable) {
-            LOGGER.warn("Failed to capture response headers", throwable);
+            LOGGER.warn("Failed to capture request metadata", throwable);
+        }
+    }
+
+    private void handleHeaders(final Metadata headers, final List<HttpExchangeNameValue> destination) {
+        try {
+            if (captureResponseMetadata && headers != null) {
+                destination.addAll(copyMetadata(headers));
+            }
+        } catch (Throwable throwable) {
+            LOGGER.warn("Failed to capture response metadata", throwable);
         }
     }
 
@@ -260,6 +336,7 @@ public class AllureGrpc implements ClientInterceptor {
         final HttpExchangeRequest request = buildRequest(
                 stepContext.getMethodDescriptor(),
                 stepContext.getClientMessages(),
+                stepContext.getRequestHeaders(),
                 stepContext.getAuthority()
         );
         final HttpExchangeResponse response = buildResponse(
@@ -286,16 +363,25 @@ public class AllureGrpc implements ClientInterceptor {
     private HttpExchangeRequest buildRequest(
                                              final MethodDescriptor<?, ?> methodDescriptor,
                                              final List<String> clientMessages,
+                                             final List<HttpExchangeNameValue> requestHeaders,
                                              final String authority) {
         final HttpExchangeRequest.Builder builder = HttpExchangeRequest.builder(
                 HTTP_METHOD,
                 PATH_SEPARATOR + methodDescriptor.getFullMethodName()
         )
-                .setHttpVersion(HTTP_VERSION)
-                .addHeader(CONTENT_TYPE_HEADER, GRPC_CONTENT_TYPE)
-                .addHeader("te", "trailers");
-        if (authority != null) {
-            builder.addHeader(":authority", authority);
+                .setHttpVersion(HTTP_VERSION);
+        if (!containsName(requestHeaders, CONTENT_TYPE_HEADER)) {
+            builder.addHeader(CONTENT_TYPE_HEADER, GRPC_CONTENT_TYPE);
+        }
+        if (!containsName(requestHeaders, TE_HEADER)) {
+            builder.addHeader(TE_HEADER, "trailers");
+        }
+        if (authority != null && !containsName(requestHeaders, AUTHORITY_HEADER)) {
+            builder.addHeader(AUTHORITY_HEADER, authority);
+        }
+        if (captureRequestMetadata) {
+            builder.addHeaders(withoutName(requestHeaders, COOKIE_HEADER));
+            builder.addCookies(extractRequestCookies(requestHeaders));
         }
         return builder
                 .setBody(toHttpBody(clientMessages, isRequestStreaming(methodDescriptor.getType())))
@@ -306,27 +392,29 @@ public class AllureGrpc implements ClientInterceptor {
                                                final MethodDescriptor<?, ?> methodDescriptor,
                                                final List<String> serverMessages,
                                                final io.grpc.Status status,
-                                               final Map<String, String> initialHeaders,
-                                               final Map<String, String> trailers) {
-        final Map<String, String> responseHeaders = new LinkedHashMap<>();
-        responseHeaders.put(CONTENT_TYPE_HEADER, GRPC_CONTENT_TYPE);
-        if (interceptResponseMetadata) {
-            responseHeaders.putAll(initialHeaders);
-        }
-
-        final Map<String, String> responseTrailers = new LinkedHashMap<>();
-        if (interceptResponseMetadata) {
-            responseTrailers.putAll(trailers);
-        }
-        responseTrailers.putIfAbsent(GRPC_STATUS, String.valueOf(status.getCode().value()));
-        responseTrailers.putIfAbsent(GRPC_MESSAGE, status.getDescription() == null ? "" : status.getDescription());
-
+                                               final List<HttpExchangeNameValue> initialHeaders,
+                                               final List<HttpExchangeNameValue> trailers) {
         final HttpExchangeResponse.Builder builder = HttpExchangeResponse.builder()
                 .setStatus(200)
                 .setHttpVersion(HTTP_VERSION)
-                .addHeaders(toNameValues(responseHeaders))
                 .setBody(toHttpBody(serverMessages, isResponseStreaming(methodDescriptor.getType())));
-        responseTrailers.forEach(builder::addTrailer);
+        if (!containsName(initialHeaders, CONTENT_TYPE_HEADER)) {
+            builder.addHeader(CONTENT_TYPE_HEADER, GRPC_CONTENT_TYPE);
+        }
+        if (captureResponseMetadata) {
+            final List<HttpExchangeCookie> cookies = new ArrayList<>(extractResponseCookies(initialHeaders));
+            cookies.addAll(extractResponseCookies(trailers));
+            builder.addCookies(cookies);
+            builder.addHeaders(withoutName(initialHeaders, SET_COOKIE_HEADER));
+            withoutName(trailers, SET_COOKIE_HEADER)
+                    .forEach(trailer -> builder.addTrailer(trailer.name(), trailer.value()));
+        }
+        if (!containsName(trailers, GRPC_STATUS)) {
+            builder.addTrailer(GRPC_STATUS, String.valueOf(status.getCode().value()));
+        }
+        if (!containsName(trailers, GRPC_MESSAGE)) {
+            builder.addTrailer(GRPC_MESSAGE, status.getDescription() == null ? "" : status.getDescription());
+        }
         return builder.build();
     }
 
@@ -409,12 +497,6 @@ public class AllureGrpc implements ClientInterceptor {
         );
     }
 
-    private static List<HttpExchangeNameValue> toNameValues(final Map<String, String> values) {
-        return values.entrySet().stream()
-                .map(entry -> new HttpExchangeNameValue(entry.getKey(), entry.getValue()))
-                .toList();
-    }
-
     private static boolean isRequestStreaming(final MethodDescriptor.MethodType methodType) {
         return methodType == MethodDescriptor.MethodType.CLIENT_STREAMING
                 || methodType == MethodDescriptor.MethodType.BIDI_STREAMING;
@@ -425,21 +507,253 @@ public class AllureGrpc implements ClientInterceptor {
                 || methodType == MethodDescriptor.MethodType.BIDI_STREAMING;
     }
 
-    private static void copyAsciiResponseMetadata(
-                                                  final Metadata source,
-                                                  final Map<String, String> target) {
+    private static List<HttpExchangeNameValue> copyMetadata(final Metadata source) {
+        final List<HttpExchangeNameValue> result = new ArrayList<>();
         for (String key : source.keys()) {
             if (key == null) {
                 continue;
             }
             if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
+                copyBinaryMetadataValues(source, key, result);
+            } else {
+                copyAsciiMetadataValues(source, key, result);
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static void copyAsciiMetadataValues(
+                                                final Metadata source,
+                                                final String key,
+                                                final List<HttpExchangeNameValue> destination) {
+        try {
+            final Metadata.Key<String> metadataKey = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+            final Iterable<String> values = source.getAll(metadataKey);
+            if (values != null) {
+                values.forEach(value -> destination.add(new HttpExchangeNameValue(key, value)));
+            }
+        } catch (Throwable throwable) {
+            LOGGER.warn("Failed to capture ASCII gRPC metadata entry {}", key, throwable);
+        }
+    }
+
+    private static void copyBinaryMetadataValues(
+                                                 final Metadata source,
+                                                 final String key,
+                                                 final List<HttpExchangeNameValue> destination) {
+        try {
+            final Metadata.Key<byte[]> metadataKey = Metadata.Key.of(key, Metadata.BINARY_BYTE_MARSHALLER);
+            final Iterable<byte[]> values = source.getAll(metadataKey);
+            if (values != null) {
+                values.forEach(
+                        value -> destination.add(
+                                new HttpExchangeNameValue(key, Base64.getEncoder().encodeToString(value))
+                        )
+                );
+            }
+        } catch (Throwable throwable) {
+            LOGGER.warn("Failed to capture binary gRPC metadata entry {}", key, throwable);
+        }
+    }
+
+    private static boolean containsName(final List<HttpExchangeNameValue> values, final String name) {
+        return values.stream().anyMatch(value -> name.equalsIgnoreCase(value.name()));
+    }
+
+    private static List<HttpExchangeNameValue> withoutName(
+                                                           final List<HttpExchangeNameValue> metadata,
+                                                           final String name) {
+        return metadata.stream()
+                .filter(value -> !name.equalsIgnoreCase(value.name()))
+                .toList();
+    }
+
+    private static List<HttpExchangeCookie> extractRequestCookies(final List<HttpExchangeNameValue> metadata) {
+        final List<HttpExchangeCookie> result = new ArrayList<>();
+        for (HttpExchangeNameValue header : metadata) {
+            if (!COOKIE_HEADER.equalsIgnoreCase(header.name())) {
                 continue;
             }
-            final Metadata.Key<String> keyAscii = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
-            final String value = source.get(keyAscii);
-            if (value != null) {
-                target.put(key, value);
+            for (String value : header.value().split(COOKIE_SEPARATOR, -1)) {
+                parseCookiePair(value)
+                        .map(AllureGrpc::toCookie)
+                        .ifPresent(result::add);
             }
+        }
+        return List.copyOf(result);
+    }
+
+    private static List<HttpExchangeCookie> extractResponseCookies(final List<HttpExchangeNameValue> metadata) {
+        final List<HttpExchangeCookie> result = new ArrayList<>();
+        for (HttpExchangeNameValue header : metadata) {
+            if (SET_COOKIE_HEADER.equalsIgnoreCase(header.name())) {
+                parseResponseCookie(header.value()).ifPresent(result::add);
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private static Optional<HttpExchangeNameValue> parseCookiePair(final String value) {
+        final int separator = value.indexOf('=');
+        if (separator <= 0) {
+            return Optional.empty();
+        }
+        final String name = value.substring(0, separator).trim();
+        if (name.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new HttpExchangeNameValue(name, value.substring(separator + 1).trim()));
+    }
+
+    private static HttpExchangeCookie toCookie(final HttpExchangeNameValue value) {
+        return new HttpExchangeCookie(value.name(), value.value());
+    }
+
+    private static Optional<HttpExchangeCookie> parseResponseCookie(final String value) {
+        final String[] parts = value.split(COOKIE_SEPARATOR, -1);
+        final Optional<HttpExchangeNameValue> cookie = parseCookiePair(parts[0]);
+        if (cookie.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String path = null;
+        String domain = null;
+        String expires = null;
+        Boolean httpOnly = null;
+        Boolean secure = null;
+        String sameSite = null;
+        for (int index = 1; index < parts.length; index++) {
+            final String attribute = parts[index].trim();
+            final int separator = attribute.indexOf('=');
+            final String name = (separator < 0 ? attribute : attribute.substring(0, separator))
+                    .trim()
+                    .toLowerCase(Locale.ROOT);
+            final String attributeValue = separator < 0 ? null : attribute.substring(separator + 1).trim();
+            switch (name) {
+                case "path" -> path = attributeValue;
+                case "domain" -> domain = attributeValue;
+                case "expires" -> expires = attributeValue;
+                case "httponly" -> httpOnly = true;
+                case "secure" -> secure = true;
+                case "samesite" -> sameSite = attributeValue;
+                default -> {
+                    // The HTTP exchange cookie schema does not model this Set-Cookie attribute.
+                }
+            }
+        }
+
+        return Optional.of(
+                new HttpExchangeCookie(
+                        cookie.get().name(),
+                        cookie.get().value(),
+                        path,
+                        domain,
+                        expires,
+                        httpOnly,
+                        secure,
+                        sameSite
+                )
+        );
+    }
+
+    /**
+     * Builder for {@link AllureGrpc} capture configuration.
+     */
+    public static final class Builder {
+        private AllureLifecycle lifecycle = Allure.getLifecycle();
+        private boolean markStepFailedOnNonZeroCode = true;
+        private boolean captureRequestMetadata = true;
+        private boolean captureResponseMetadata = true;
+        private Consumer<HttpExchange.Builder> exchangeCustomizer = exchange -> {
+        };
+
+        private Builder() {
+        }
+
+        /**
+         * Sets the Allure lifecycle used to report calls.
+         *
+         * @param lifecycle the lifecycle to use
+         * @return this builder
+         */
+        public Builder lifecycle(final AllureLifecycle lifecycle) {
+            this.lifecycle = Objects.requireNonNull(lifecycle, "lifecycle must not be null");
+            return this;
+        }
+
+        /**
+         * Configures whether a non-zero gRPC status fails the reported step.
+         *
+         * @param enabled whether a non-zero status fails the step
+         * @return this builder
+         */
+        public Builder markStepFailedOnNonZeroCode(final boolean enabled) {
+            this.markStepFailedOnNonZeroCode = enabled;
+            return this;
+        }
+
+        /**
+         * Configures request metadata capture.
+         *
+         * @param enabled whether to capture request metadata
+         * @return this builder
+         */
+        public Builder captureRequestMetadata(final boolean enabled) {
+            this.captureRequestMetadata = enabled;
+            return this;
+        }
+
+        /**
+         * Configures response header and trailer capture.
+         *
+         * @param enabled whether to capture response metadata
+         * @return this builder
+         */
+        public Builder captureResponseMetadata(final boolean enabled) {
+            this.captureResponseMetadata = enabled;
+            return this;
+        }
+
+        /**
+         * Adds a case-insensitive metadata name to the redaction policy.
+         *
+         * @param name the metadata name to redact
+         * @return this builder
+         */
+        public Builder redactHeader(final String name) {
+            return configureExchange(exchange -> exchange.redactHeader(name));
+        }
+
+        /**
+         * Adds a case-insensitive cookie name to the redaction policy.
+         *
+         * @param name the cookie name to redact
+         * @return this builder
+         */
+        public Builder redactCookie(final String name) {
+            return configureExchange(exchange -> exchange.redactCookie(name));
+        }
+
+        /**
+         * Adds an HTTP exchange capture customizer.
+         *
+         * @param customizer the customizer to apply when an exchange is built
+         * @return this builder
+         */
+        public Builder configureExchange(final Consumer<HttpExchange.Builder> customizer) {
+            exchangeCustomizer = exchangeCustomizer.andThen(
+                    Objects.requireNonNull(customizer, "customizer must not be null")
+            );
+            return this;
+        }
+
+        /**
+         * Builds the configured interceptor.
+         *
+         * @return the configured interceptor
+         */
+        public AllureGrpc build() {
+            return new AllureGrpc(this);
         }
     }
 
@@ -453,8 +767,9 @@ public class AllureGrpc implements ClientInterceptor {
         private final AllureLifecycle lifecycle;
         private final List<String> clientMessages;
         private final List<String> serverMessages;
-        private final Map<String, String> initialHeaders;
-        private final Map<String, String> trailers;
+        private final AtomicReference<List<HttpExchangeNameValue>> requestHeaders = new AtomicReference<>(List.of());
+        private final List<HttpExchangeNameValue> initialHeaders;
+        private final List<HttpExchangeNameValue> trailers;
         private final String authority;
         private final long start;
 
@@ -464,8 +779,8 @@ public class AllureGrpc implements ClientInterceptor {
                     final AllureLifecycle lifecycle,
                     final List<String> clientMessages,
                     final List<String> serverMessages,
-                    final Map<String, String> initialHeaders,
-                    final Map<String, String> trailers,
+                    final List<HttpExchangeNameValue> initialHeaders,
+                    final List<HttpExchangeNameValue> trailers,
                     final String authority,
                     final long start) {
             this.stepKey = stepKey;
@@ -499,11 +814,19 @@ public class AllureGrpc implements ClientInterceptor {
             return serverMessages;
         }
 
-        Map<String, String> getInitialHeaders() {
+        List<HttpExchangeNameValue> getRequestHeaders() {
+            return requestHeaders.get();
+        }
+
+        void setRequestHeaders(final List<HttpExchangeNameValue> requestHeaders) {
+            this.requestHeaders.set(requestHeaders);
+        }
+
+        List<HttpExchangeNameValue> getInitialHeaders() {
             return initialHeaders;
         }
 
-        Map<String, String> getTrailers() {
+        List<HttpExchangeNameValue> getTrailers() {
             return trailers;
         }
 

--- a/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
+++ b/allure-grpc/src/main/java/io/qameta/allure/grpc/AllureGrpc.java
@@ -34,7 +34,6 @@ import io.qameta.allure.AllureLifecycle;
 import io.qameta.allure.AttachmentOptions;
 import io.qameta.allure.http.HttpExchange;
 import io.qameta.allure.http.HttpExchangeBody;
-import io.qameta.allure.http.HttpExchangeCookie;
 import io.qameta.allure.http.HttpExchangeNameValue;
 import io.qameta.allure.http.HttpExchangeRequest;
 import io.qameta.allure.http.HttpExchangeResponse;
@@ -80,11 +79,8 @@ public class AllureGrpc implements ClientInterceptor {
     private static final String GRPC_STATUS = "grpc-status";
     private static final String GRPC_MESSAGE = "grpc-message";
     private static final String CONTENT_TYPE_HEADER = "content-type";
-    private static final String COOKIE_HEADER = "cookie";
-    private static final String SET_COOKIE_HEADER = "set-cookie";
     private static final String TE_HEADER = "te";
     private static final String AUTHORITY_HEADER = ":authority";
-    private static final String COOKIE_SEPARATOR = ";";
     private static final String HTTP_METHOD = "POST";
     private static final String HTTP_VERSION = "HTTP/2";
     private static final String PATH_SEPARATOR = "/";
@@ -380,8 +376,7 @@ public class AllureGrpc implements ClientInterceptor {
             builder.addHeader(AUTHORITY_HEADER, authority);
         }
         if (captureRequestMetadata) {
-            builder.addHeaders(withoutName(requestHeaders, COOKIE_HEADER));
-            builder.addCookies(extractRequestCookies(requestHeaders));
+            builder.addHeaders(requestHeaders);
         }
         return builder
                 .setBody(toHttpBody(clientMessages, isRequestStreaming(methodDescriptor.getType())))
@@ -402,12 +397,8 @@ public class AllureGrpc implements ClientInterceptor {
             builder.addHeader(CONTENT_TYPE_HEADER, GRPC_CONTENT_TYPE);
         }
         if (captureResponseMetadata) {
-            final List<HttpExchangeCookie> cookies = new ArrayList<>(extractResponseCookies(initialHeaders));
-            cookies.addAll(extractResponseCookies(trailers));
-            builder.addCookies(cookies);
-            builder.addHeaders(withoutName(initialHeaders, SET_COOKIE_HEADER));
-            withoutName(trailers, SET_COOKIE_HEADER)
-                    .forEach(trailer -> builder.addTrailer(trailer.name(), trailer.value()));
+            builder.addHeaders(initialHeaders);
+            trailers.forEach(trailer -> builder.addTrailer(trailer.name(), trailer.value()));
         }
         if (!containsName(trailers, GRPC_STATUS)) {
             builder.addTrailer(GRPC_STATUS, String.valueOf(status.getCode().value()));
@@ -558,102 +549,6 @@ public class AllureGrpc implements ClientInterceptor {
 
     private static boolean containsName(final List<HttpExchangeNameValue> values, final String name) {
         return values.stream().anyMatch(value -> name.equalsIgnoreCase(value.name()));
-    }
-
-    private static List<HttpExchangeNameValue> withoutName(
-                                                           final List<HttpExchangeNameValue> metadata,
-                                                           final String name) {
-        return metadata.stream()
-                .filter(value -> !name.equalsIgnoreCase(value.name()))
-                .toList();
-    }
-
-    private static List<HttpExchangeCookie> extractRequestCookies(final List<HttpExchangeNameValue> metadata) {
-        final List<HttpExchangeCookie> result = new ArrayList<>();
-        for (HttpExchangeNameValue header : metadata) {
-            if (!COOKIE_HEADER.equalsIgnoreCase(header.name())) {
-                continue;
-            }
-            for (String value : header.value().split(COOKIE_SEPARATOR, -1)) {
-                parseCookiePair(value)
-                        .map(AllureGrpc::toCookie)
-                        .ifPresent(result::add);
-            }
-        }
-        return List.copyOf(result);
-    }
-
-    private static List<HttpExchangeCookie> extractResponseCookies(final List<HttpExchangeNameValue> metadata) {
-        final List<HttpExchangeCookie> result = new ArrayList<>();
-        for (HttpExchangeNameValue header : metadata) {
-            if (SET_COOKIE_HEADER.equalsIgnoreCase(header.name())) {
-                parseResponseCookie(header.value()).ifPresent(result::add);
-            }
-        }
-        return List.copyOf(result);
-    }
-
-    private static Optional<HttpExchangeNameValue> parseCookiePair(final String value) {
-        final int separator = value.indexOf('=');
-        if (separator <= 0) {
-            return Optional.empty();
-        }
-        final String name = value.substring(0, separator).trim();
-        if (name.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(new HttpExchangeNameValue(name, value.substring(separator + 1).trim()));
-    }
-
-    private static HttpExchangeCookie toCookie(final HttpExchangeNameValue value) {
-        return new HttpExchangeCookie(value.name(), value.value());
-    }
-
-    private static Optional<HttpExchangeCookie> parseResponseCookie(final String value) {
-        final String[] parts = value.split(COOKIE_SEPARATOR, -1);
-        final Optional<HttpExchangeNameValue> cookie = parseCookiePair(parts[0]);
-        if (cookie.isEmpty()) {
-            return Optional.empty();
-        }
-
-        String path = null;
-        String domain = null;
-        String expires = null;
-        Boolean httpOnly = null;
-        Boolean secure = null;
-        String sameSite = null;
-        for (int index = 1; index < parts.length; index++) {
-            final String attribute = parts[index].trim();
-            final int separator = attribute.indexOf('=');
-            final String name = (separator < 0 ? attribute : attribute.substring(0, separator))
-                    .trim()
-                    .toLowerCase(Locale.ROOT);
-            final String attributeValue = separator < 0 ? null : attribute.substring(separator + 1).trim();
-            switch (name) {
-                case "path" -> path = attributeValue;
-                case "domain" -> domain = attributeValue;
-                case "expires" -> expires = attributeValue;
-                case "httponly" -> httpOnly = true;
-                case "secure" -> secure = true;
-                case "samesite" -> sameSite = attributeValue;
-                default -> {
-                    // The HTTP exchange cookie schema does not model this Set-Cookie attribute.
-                }
-            }
-        }
-
-        return Optional.of(
-                new HttpExchangeCookie(
-                        cookie.get().name(),
-                        cookie.get().value(),
-                        path,
-                        domain,
-                        expires,
-                        httpOnly,
-                        secure,
-                        sameSite
-                )
-        );
     }
 
     /**

--- a/allure-grpc/src/test/java/io/qameta/allure/grpc/AllureGrpcTest.java
+++ b/allure-grpc/src/test/java/io/qameta/allure/grpc/AllureGrpcTest.java
@@ -17,8 +17,19 @@ package io.qameta.allure.grpc;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.grpc.CallCredentials;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientStreamTracer;
+import io.grpc.ForwardingServerCall;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
@@ -33,15 +44,18 @@ import org.grpcmock.junit5.GrpcMockExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import static io.qameta.allure.test.RunUtils.runWithinTestContext;
 import static java.util.Arrays.asList;
@@ -52,13 +66,27 @@ import static org.grpcmock.GrpcMock.clientStreamingMethod;
 import static org.grpcmock.GrpcMock.serverStreamingMethod;
 import static org.grpcmock.GrpcMock.unaryMethod;
 
-@ExtendWith(GrpcMockExtension.class)
 @IsolatedLifecycle
 class AllureGrpcTest {
 
     private static final String RESPONSE_MESSAGE = "Hello world!";
     private static final String GRPC_EXCHANGE = "gRPC exchange";
+    private static final String REDACTED_VALUE = "__ALLURE_REDACTED__";
+    private static final Metadata.Key<String> REQUEST_ID = asciiKey("x-request-id");
+    private static final Metadata.Key<String> REPEATED_REQUEST = asciiKey("x-request-repeated");
+    private static final Metadata.Key<byte[]> BINARY_REQUEST = binaryKey("x-request-bin");
+    private static final Metadata.Key<String> AUTHORIZATION = asciiKey("authorization");
+    private static final Metadata.Key<String> API_KEY = asciiKey("x-api-key");
+    private static final Metadata.Key<String> COOKIE = asciiKey("cookie");
+    private static final Metadata.Key<String> RESPONSE_HEADER = asciiKey("x-response-repeated");
+    private static final Metadata.Key<String> RESPONSE_TRAILER = asciiKey("x-response-trailer");
+    private static final Metadata.Key<String> SET_COOKIE = asciiKey("set-cookie");
     private static final ObjectMapper JSON = new ObjectMapper();
+
+    @RegisterExtension
+    static final GrpcMockExtension GRPC_MOCK = GrpcMockExtension.builder()
+            .withInterceptor(new ResponseMetadataInterceptor())
+            .build();
 
     private ManagedChannel managedChannel;
 
@@ -320,6 +348,145 @@ class AllureGrpcTest {
         assertThat(exchange.at("/request/body/contentType").asText()).isEqualTo("application/grpc+json");
     }
 
+    /**
+     * Request metadata added by call credentials and response metadata are captured by default, including repeated
+     * and binary values.
+     */
+    @Test
+    void metadataIsCapturedByDefaultAfterCredentialsAreApplied() throws Exception {
+        Metadata credentialMetadata = new Metadata();
+        credentialMetadata.put(REQUEST_ID, "request-42");
+        credentialMetadata.put(REPEATED_REQUEST, "first");
+        credentialMetadata.put(REPEATED_REQUEST, "second");
+        credentialMetadata.put(BINARY_REQUEST, "binary-value".getBytes(StandardCharsets.UTF_8));
+        credentialMetadata.put(AUTHORIZATION, "Bearer secret");
+        credentialMetadata.put(COOKIE, "session=request-secret; theme=dark");
+
+        AllureResults allureResults = executeUnaryWithConfiguration(
+                Request.newBuilder().setTopic("metadata-defaults").build(),
+                AllureGrpc::new,
+                callCredentials(credentialMetadata)
+        );
+
+        JsonNode exchange = readGrpcExchangeAttachment(allureResults);
+
+        assertThat(findValuesByName(exchange.at("/request/headers"), REQUEST_ID.name()))
+                .containsExactly("request-42");
+        assertThat(findValuesByName(exchange.at("/request/headers"), REPEATED_REQUEST.name()))
+                .containsExactly("first", "second");
+        assertThat(findValuesByName(exchange.at("/request/headers"), BINARY_REQUEST.name()))
+                .containsExactly("YmluYXJ5LXZhbHVl");
+        assertThat(findValuesByName(exchange.at("/request/headers"), AUTHORIZATION.name()))
+                .containsExactly(REDACTED_VALUE);
+        assertThat(findValuesByName(exchange.at("/request/headers"), COOKIE.name())).isEmpty();
+        assertThat(findValueByName(exchange.at("/request/cookies"), "session"))
+                .contains("request-secret");
+        assertThat(findValueByName(exchange.at("/request/cookies"), "theme"))
+                .contains("dark");
+        assertThat(findValuesByName(exchange.at("/response/headers"), RESPONSE_HEADER.name()))
+                .containsExactly("first", "second");
+        assertThat(findValuesByName(exchange.at("/response/headers"), SET_COOKIE.name())).isEmpty();
+        assertThat(findValueByName(exchange.at("/response/cookies"), "session"))
+                .contains("response-secret");
+        assertThat(findValueByName(exchange.at("/response/cookies"), "theme"))
+                .contains("light");
+        assertThat(findValuesByName(exchange.at("/response/trailers"), RESPONSE_TRAILER.name()))
+                .containsExactly("trailer-value");
+
+        JsonNode responseSession = findByName(exchange.at("/response/cookies"), "session").orElseThrow();
+        assertThat(responseSession.path("path").asText()).isEqualTo("/");
+        assertThat(responseSession.path("domain").asText()).isEqualTo("example.test");
+        assertThat(responseSession.path("expires").asText()).isEqualTo("Wed, 21 Oct 2015 07:28:00 GMT");
+        assertThat(responseSession.path("httpOnly").asBoolean()).isTrue();
+        assertThat(responseSession.path("secure").asBoolean()).isTrue();
+        assertThat(responseSession.path("sameSite").asText()).isEqualTo("Lax");
+    }
+
+    /**
+     * Metadata applied after tracer creation is refreshed when a transport-level failing stream closes without ever
+     * invoking {@link ClientStreamTracer#streamCreated(io.grpc.Attributes, Metadata)}.
+     */
+    @Test
+    void finalRequestMetadataIsCapturedWhenTransportStreamCreationFails() throws Exception {
+        AllureResults allureResults = Allure.step(
+                "Execute a gRPC request whose transport stream cannot be created",
+                () -> runWithinTestContext(() -> {
+                    ClientCall<Request, Response> call = new AllureGrpc().interceptCall(
+                            TestServiceGrpc.getCalculateMethod(),
+                            CallOptions.DEFAULT,
+                            failingTransportChannel()
+                    );
+                    call.start(new ClientCall.Listener<>() {
+                    }, new Metadata());
+                })
+        );
+
+        JsonNode exchange = readGrpcExchangeAttachment(allureResults);
+
+        assertThat(findValuesByName(exchange.at("/request/headers"), REQUEST_ID.name()))
+                .containsExactly("failed-request-42");
+    }
+
+    /**
+     * Callers can turn request and response metadata capture off independently of message and status capture.
+     */
+    @Test
+    void metadataCaptureCanBeDisabled() throws Exception {
+        Metadata credentialMetadata = new Metadata();
+        credentialMetadata.put(REQUEST_ID, "request-42");
+
+        AllureResults allureResults = executeUnaryWithConfiguration(
+                Request.newBuilder().setTopic("metadata-disabled").build(),
+                () -> AllureGrpc.builder()
+                        .captureRequestMetadata(false)
+                        .captureResponseMetadata(false)
+                        .build(),
+                callCredentials(credentialMetadata)
+        );
+
+        JsonNode exchange = readGrpcExchangeAttachment(allureResults);
+
+        assertThat(findValuesByName(exchange.at("/request/headers"), REQUEST_ID.name())).isEmpty();
+        assertThat(findValuesByName(exchange.at("/response/headers"), RESPONSE_HEADER.name())).isEmpty();
+        assertThat(findValuesByName(exchange.at("/response/trailers"), RESPONSE_TRAILER.name())).isEmpty();
+        assertThat(findValueByName(exchange.at("/response/trailers"), "grpc-status")).contains("0");
+    }
+
+    /**
+     * Header and structured-cookie redaction configured on the gRPC builder is applied by the HTTP exchange builder.
+     */
+    @Test
+    void configuredHeadersAndCookiesAreRedacted() throws Exception {
+        Metadata credentialMetadata = new Metadata();
+        credentialMetadata.put(API_KEY, "api-secret");
+        credentialMetadata.put(COOKIE, "theme=dark; session=request-secret");
+
+        AllureResults allureResults = executeUnaryWithConfiguration(
+                Request.newBuilder().setTopic("metadata-redaction").build(),
+                () -> AllureGrpc.builder()
+                        .configureExchange(HttpExchange.Builder::clearRedactedHeaders)
+                        .redactHeader(API_KEY.name())
+                        .redactCookie("session")
+                        .build(),
+                callCredentials(credentialMetadata)
+        );
+
+        JsonNode exchange = readGrpcExchangeAttachment(allureResults);
+
+        assertThat(findValuesByName(exchange.at("/request/headers"), API_KEY.name()))
+                .containsExactly(REDACTED_VALUE);
+        assertThat(findValuesByName(exchange.at("/request/headers"), COOKIE.name())).isEmpty();
+        assertThat(findValueByName(exchange.at("/request/cookies"), "session"))
+                .contains(REDACTED_VALUE);
+        assertThat(findValueByName(exchange.at("/request/cookies"), "theme"))
+                .contains("dark");
+        assertThat(findValuesByName(exchange.at("/response/headers"), SET_COOKIE.name())).isEmpty();
+        assertThat(findValueByName(exchange.at("/response/cookies"), "session"))
+                .contains(REDACTED_VALUE);
+        assertThat(findValueByName(exchange.at("/response/cookies"), "theme"))
+                .contains("light");
+    }
+
     @Test
     void unaryResponseBodyIsCapturedAsJsonObject() throws Exception {
         GrpcMock.stubFor(
@@ -417,12 +584,114 @@ class AllureGrpcTest {
     }
 
     private static Optional<String> findValueByName(final JsonNode values, final String name) {
+        return findByName(values, name).map(value -> value.path("value").asText());
+    }
+
+    private static Optional<JsonNode> findByName(final JsonNode values, final String name) {
         for (JsonNode value : values) {
             if (name.equals(value.path("name").asText())) {
-                return Optional.of(value.path("value").asText());
+                return Optional.of(value);
             }
         }
         return Optional.empty();
+    }
+
+    private static List<String> findValuesByName(final JsonNode values, final String name) {
+        List<String> result = new ArrayList<>();
+        for (JsonNode value : values) {
+            if (name.equals(value.path("name").asText())) {
+                result.add(value.path("value").asText());
+            }
+        }
+        return result;
+    }
+
+    private static Metadata.Key<String> asciiKey(final String name) {
+        return Metadata.Key.of(name, Metadata.ASCII_STRING_MARSHALLER);
+    }
+
+    private static Metadata.Key<byte[]> binaryKey(final String name) {
+        return Metadata.Key.of(name, Metadata.BINARY_BYTE_MARSHALLER);
+    }
+
+    private static CallCredentials callCredentials(final Metadata source) {
+        return new CallCredentials() {
+            @Override
+            public void applyRequestMetadata(
+                                             final RequestInfo requestInfo,
+                                             final Executor appExecutor,
+                                             final MetadataApplier applier) {
+                appExecutor.execute(() -> {
+                    Metadata metadata = new Metadata();
+                    metadata.merge(source);
+                    applier.apply(metadata);
+                });
+            }
+        };
+    }
+
+    private static Channel failingTransportChannel() {
+        return new Channel() {
+            @Override
+            public String authority() {
+                return "unavailable.example";
+            }
+
+            @Override
+            public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
+                                                                 final MethodDescriptor<ReqT, RespT> methodDescriptor,
+                                                                 final CallOptions callOptions) {
+                return new ClientCall<>() {
+                    @Override
+                    public void start(final Listener<RespT> responseListener, final Metadata headers) {
+                        final List<ClientStreamTracer.Factory> factories = callOptions.getStreamTracerFactories();
+                        final ClientStreamTracer.Factory factory = factories.get(factories.size() - 1);
+                        final ClientStreamTracer tracer = factory.newClientStreamTracer(
+                                ClientStreamTracer.StreamInfo.newBuilder()
+                                        .setCallOptions(callOptions)
+                                        .build(),
+                                headers
+                        );
+
+                        headers.put(REQUEST_ID, "failed-request-42");
+                        tracer.streamClosed(Status.UNAVAILABLE);
+                        responseListener.onClose(Status.UNAVAILABLE, new Metadata());
+                    }
+
+                    @Override
+                    public void request(final int numMessages) {
+                    }
+
+                    @Override
+                    public void cancel(final String message, final Throwable cause) {
+                    }
+
+                    @Override
+                    public void halfClose() {
+                    }
+
+                    @Override
+                    public void sendMessage(final ReqT message) {
+                    }
+                };
+            }
+        };
+    }
+
+    private AllureResults executeUnaryWithConfiguration(
+                                                        final Request request,
+                                                        final Supplier<AllureGrpc> interceptor,
+                                                        final CallCredentials credentials) {
+        return Allure.step(
+                "Execute configured unary gRPC request and collect Allure results",
+                () -> runWithinTestContext(() -> {
+                    TestServiceGrpc.TestServiceBlockingStub stub = TestServiceGrpc.newBlockingStub(managedChannel)
+                            .withInterceptors(interceptor.get())
+                            .withCallCredentials(credentials);
+                    Response response = stub.calculate(request);
+                    assertThat(response.getMessage()).isEqualTo(RESPONSE_MESSAGE);
+                })
+        );
     }
 
     protected final AllureResults executeUnary(Request request) {
@@ -473,6 +742,37 @@ class AllureGrpcTest {
                                 })
                 )
         );
+    }
+
+    private static final class ResponseMetadataInterceptor implements ServerInterceptor {
+
+        @Override
+        public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                                                                     final ServerCall<ReqT, RespT> call,
+                                                                     final Metadata headers,
+                                                                     final ServerCallHandler<ReqT, RespT> next) {
+            final ServerCall<ReqT, RespT> forwardingCall = new ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {
+                @Override
+                public void sendHeaders(final Metadata responseHeaders) {
+                    responseHeaders.put(RESPONSE_HEADER, "first");
+                    responseHeaders.put(RESPONSE_HEADER, "second");
+                    responseHeaders.put(
+                            SET_COOKIE,
+                            "session=response-secret; Path=/; Domain=example.test; "
+                                    + "Expires=Wed, 21 Oct 2015 07:28:00 GMT; HttpOnly; Secure; SameSite=Lax"
+                    );
+                    responseHeaders.put(SET_COOKIE, "theme=light; Path=/");
+                    super.sendHeaders(responseHeaders);
+                }
+
+                @Override
+                public void close(final Status status, final Metadata trailers) {
+                    trailers.put(RESPONSE_TRAILER, "trailer-value");
+                    super.close(status, trailers);
+                }
+            };
+            return next.startCall(forwardingCall, headers);
+        }
     }
 
 }

--- a/allure-java-commons/src/main/java/io/qameta/allure/http/HttpExchangeCookieParser.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/http/HttpExchangeCookieParser.java
@@ -1,0 +1,197 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.http;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+final class HttpExchangeCookieParser {
+
+    private static final String COOKIE_HEADER = "cookie";
+    private static final String SET_COOKIE_HEADER = "set-cookie";
+    private static final String COOKIE_SEPARATOR = ";";
+    private static final String TOKEN_SEPARATORS = "()<>@,;:\\\"/[]?={}";
+
+    private HttpExchangeCookieParser() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    static boolean isCookieHeader(final String name) {
+        return COOKIE_HEADER.equalsIgnoreCase(name);
+    }
+
+    static boolean isSetCookieHeader(final String name) {
+        return SET_COOKIE_HEADER.equalsIgnoreCase(name);
+    }
+
+    static Optional<List<HttpExchangeCookie>> parseCookieHeader(final String value) {
+        final List<HttpExchangeCookie> result = new ArrayList<>();
+        for (String part : value.split(COOKIE_SEPARATOR, -1)) {
+            final Optional<HttpExchangeCookie> cookie = parseCookiePair(part);
+            if (cookie.isEmpty()) {
+                return Optional.empty();
+            }
+            result.add(cookie.orElseThrow());
+        }
+        return result.isEmpty() ? Optional.empty() : Optional.of(List.copyOf(result));
+    }
+
+    static Optional<HttpExchangeCookie> parseSetCookieHeader(final String value) {
+        final String[] parts = value.split(COOKIE_SEPARATOR, -1);
+        final Optional<HttpExchangeCookie> cookie = parseCookiePair(parts[0]);
+        if (cookie.isEmpty()) {
+            return Optional.empty();
+        }
+
+        final CookieAttributes attributes = new CookieAttributes();
+        for (int index = 1; index < parts.length; index++) {
+            if (!attributes.add(parts[index])) {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.of(attributes.toCookie(cookie.orElseThrow()));
+    }
+
+    private static Optional<HttpExchangeCookie> parseCookiePair(final String value) {
+        final int separator = value.indexOf('=');
+        if (separator <= 0) {
+            return Optional.empty();
+        }
+        final String name = value.substring(0, separator).trim();
+        final String cookieValue = value.substring(separator + 1).trim();
+        if (!isToken(name) || !isCookieValue(cookieValue)) {
+            return Optional.empty();
+        }
+        return Optional.of(new HttpExchangeCookie(name, cookieValue));
+    }
+
+    private static boolean isToken(final String value) {
+        if (value.isEmpty()) {
+            return false;
+        }
+        for (int index = 0; index < value.length(); index++) {
+            final char character = value.charAt(index);
+            if (character <= ' ' || character >= '\u007f' || TOKEN_SEPARATORS.indexOf(character) >= 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isCookieValue(final String value) {
+        final boolean quoted = value.length() >= 2 && value.charAt(0) == '"'
+                && value.charAt(value.length() - 1) == '"';
+        final int start = quoted ? 1 : 0;
+        final int end = quoted ? value.length() - 1 : value.length();
+        for (int index = start; index < end; index++) {
+            if (!isCookieOctet(value.charAt(index))) {
+                return false;
+            }
+        }
+        return quoted || value.indexOf('"') < 0;
+    }
+
+    private static boolean isCookieOctet(final char character) {
+        return character == '!'
+                || character >= '#' && character <= '+'
+                || character >= '-' && character <= ':'
+                || character >= '<' && character <= '['
+                || character >= ']' && character <= '~';
+    }
+
+    private static final class CookieAttributes {
+        private final Set<String> seen = new HashSet<>();
+        private String path;
+        private String domain;
+        private String expires;
+        private Boolean httpOnly;
+        private Boolean secure;
+        private String sameSite;
+
+        boolean add(final String rawAttribute) {
+            final String attribute = rawAttribute.trim();
+            final int separator = attribute.indexOf('=');
+            final String name = (separator < 0 ? attribute : attribute.substring(0, separator)).trim();
+            if (!isToken(name)) {
+                return false;
+            }
+
+            final String normalizedName = name.toLowerCase(Locale.ROOT);
+            if (!seen.add(normalizedName)) {
+                return false;
+            }
+
+            final String value = separator < 0 ? null : attribute.substring(separator + 1).trim();
+            return switch (normalizedName) {
+                case "path" -> setPath(value);
+                case "domain" -> setDomain(value);
+                case "expires" -> setExpires(value);
+                case "httponly" -> setHttpOnly(value);
+                case "secure" -> setSecure(value);
+                case "samesite" -> setSameSite(value);
+                default -> false;
+            };
+        }
+
+        HttpExchangeCookie toCookie(final HttpExchangeCookie cookie) {
+            return new HttpExchangeCookie(
+                    cookie.name(),
+                    cookie.value(),
+                    path,
+                    domain,
+                    expires,
+                    httpOnly,
+                    secure,
+                    sameSite
+            );
+        }
+
+        private boolean setPath(final String value) {
+            path = value;
+            return value != null;
+        }
+
+        private boolean setDomain(final String value) {
+            domain = value;
+            return value != null;
+        }
+
+        private boolean setExpires(final String value) {
+            expires = value;
+            return value != null;
+        }
+
+        private boolean setHttpOnly(final String value) {
+            httpOnly = value == null ? true : null;
+            return value == null;
+        }
+
+        private boolean setSecure(final String value) {
+            secure = value == null ? true : null;
+            return value == null;
+        }
+
+        private boolean setSameSite(final String value) {
+            sameSite = value;
+            return value != null;
+        }
+    }
+}

--- a/allure-java-commons/src/main/java/io/qameta/allure/http/HttpExchangeRequest.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/http/HttpExchangeRequest.java
@@ -18,6 +18,7 @@ package io.qameta.allure.http;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * HTTP request captured in an exchange attachment.
@@ -76,13 +77,34 @@ public record HttpExchangeRequest(String method, String url, String httpVersion,
             return this;
         }
 
+        /**
+         * Adds a request header, converting a valid Cookie header to structured cookies.
+         *
+         * @param name the header name
+         * @param value the header value
+         * @return this builder
+         */
         public Builder addHeader(final String name, final String value) {
-            headers.add(new HttpExchangeNameValue(name, value));
+            final HttpExchangeNameValue header = new HttpExchangeNameValue(name, value);
+            if (HttpExchangeCookieParser.isCookieHeader(name)) {
+                final Optional<List<HttpExchangeCookie>> parsed = HttpExchangeCookieParser.parseCookieHeader(value);
+                if (parsed.isPresent()) {
+                    cookies.addAll(parsed.orElseThrow());
+                    return this;
+                }
+            }
+            headers.add(header);
             return this;
         }
 
+        /**
+         * Adds request headers, converting every valid Cookie header to structured cookies.
+         *
+         * @param headers the headers to add
+         * @return this builder
+         */
         public Builder addHeaders(final List<HttpExchangeNameValue> headers) {
-            this.headers.addAll(headers);
+            headers.forEach(header -> addHeader(header.name(), header.value()));
             return this;
         }
 

--- a/allure-java-commons/src/main/java/io/qameta/allure/http/HttpExchangeResponse.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/http/HttpExchangeResponse.java
@@ -17,6 +17,7 @@ package io.qameta.allure.http;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * HTTP response captured in an exchange attachment.
@@ -78,13 +79,26 @@ public record HttpExchangeResponse(Integer status, String statusText, String htt
             return this;
         }
 
+        /**
+         * Adds a response header, converting a valid Set-Cookie header to a structured cookie.
+         *
+         * @param name the header name
+         * @param value the header value
+         * @return this builder
+         */
         public Builder addHeader(final String name, final String value) {
-            headers.add(new HttpExchangeNameValue(name, value));
+            addHeaderOrCookie(headers, name, value);
             return this;
         }
 
+        /**
+         * Adds response headers, converting every valid Set-Cookie header to a structured cookie.
+         *
+         * @param headers the headers to add
+         * @return this builder
+         */
         public Builder addHeaders(final List<HttpExchangeNameValue> headers) {
-            this.headers.addAll(headers);
+            headers.forEach(header -> addHeader(header.name(), header.value()));
             return this;
         }
 
@@ -103,8 +117,15 @@ public record HttpExchangeResponse(Integer status, String statusText, String htt
             return this;
         }
 
+        /**
+         * Adds a response trailer, converting a valid Set-Cookie field to a structured cookie.
+         *
+         * @param name the trailer name
+         * @param value the trailer value
+         * @return this builder
+         */
         public Builder addTrailer(final String name, final String value) {
-            trailers.add(new HttpExchangeNameValue(name, value));
+            addHeaderOrCookie(trailers, name, value);
             return this;
         }
 
@@ -122,6 +143,21 @@ public record HttpExchangeResponse(Integer status, String statusText, String htt
 
         private static <T> List<T> nullIfEmpty(final List<T> values) {
             return values.isEmpty() ? null : values;
+        }
+
+        private void addHeaderOrCookie(
+                                       final List<HttpExchangeNameValue> destination,
+                                       final String name,
+                                       final String value) {
+            final HttpExchangeNameValue header = new HttpExchangeNameValue(name, value);
+            if (HttpExchangeCookieParser.isSetCookieHeader(name)) {
+                final Optional<HttpExchangeCookie> parsed = HttpExchangeCookieParser.parseSetCookieHeader(value);
+                if (parsed.isPresent()) {
+                    cookies.add(parsed.orElseThrow());
+                    return;
+                }
+            }
+            destination.add(header);
         }
     }
 }

--- a/allure-java-commons/src/main/java/io/qameta/allure/http/HttpExchangeResponse.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/http/HttpExchangeResponse.java
@@ -93,6 +93,11 @@ public record HttpExchangeResponse(Integer status, String statusText, String htt
             return this;
         }
 
+        public Builder addCookies(final List<HttpExchangeCookie> cookies) {
+            this.cookies.addAll(cookies);
+            return this;
+        }
+
         public Builder setBody(final HttpExchangeBody body) {
             this.body = body;
             return this;

--- a/allure-java-commons/src/test/java/io/qameta/allure/http/HttpExchangeCookieBuilderTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/http/HttpExchangeCookieBuilderTest.java
@@ -1,0 +1,140 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.http;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static io.qameta.allure.Allure.step;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+class HttpExchangeCookieBuilderTest {
+
+    @Test
+    void requestBuilderConvertsCookieHeadersToStructuredCookies() {
+        final HttpExchangeRequest request = step(
+                "Build a request from individual and bulk headers",
+                () -> HttpExchangeRequest.builder("GET", "https://example.test")
+                        .addHeader("Cookie", "session=abc=123; theme=dark")
+                        .addHeaders(
+                                List.of(
+                                        new HttpExchangeNameValue("X-Trace", "trace-1"),
+                                        new HttpExchangeNameValue("cOoKiE", "locale=en-GB")
+                                )
+                        )
+                        .build()
+        );
+
+        step("Verify Cookie headers are represented once as structured cookies", () -> {
+            assertThat(request.headers())
+                    .extracting(HttpExchangeNameValue::name, HttpExchangeNameValue::value)
+                    .containsExactly(tuple("X-Trace", "trace-1"));
+            assertThat(request.cookies())
+                    .extracting(HttpExchangeCookie::name, HttpExchangeCookie::value)
+                    .containsExactly(
+                            tuple("session", "abc=123"),
+                            tuple("theme", "dark"),
+                            tuple("locale", "en-GB")
+                    );
+        });
+    }
+
+    @Test
+    void responseBuilderConvertsSetCookieHeadersAndTrailersToStructuredCookies() {
+        final HttpExchangeResponse response = step(
+                "Build a response from headers and trailers",
+                () -> HttpExchangeResponse.builder()
+                        .addHeader(
+                                "SET-COOKIE",
+                                "session=response-secret; Path=/; Domain=example.test; "
+                                        + "Expires=Wed, 21 Oct 2015 07:28:00 GMT; HttpOnly; Secure; SameSite=Lax"
+                        )
+                        .addHeaders(
+                                List.of(
+                                        new HttpExchangeNameValue("X-Trace", "trace-1"),
+                                        new HttpExchangeNameValue("set-cookie", "theme=light")
+                                )
+                        )
+                        .addTrailer("Set-Cookie", "trailer=value")
+                        .build()
+        );
+
+        step("Verify Set-Cookie fields preserve supported attributes without raw duplicates", () -> {
+            assertThat(response.headers())
+                    .extracting(HttpExchangeNameValue::name, HttpExchangeNameValue::value)
+                    .containsExactly(tuple("X-Trace", "trace-1"));
+            assertThat(response.trailers()).isNull();
+            assertThat(response.cookies())
+                    .extracting(
+                            HttpExchangeCookie::name,
+                            HttpExchangeCookie::value,
+                            HttpExchangeCookie::path,
+                            HttpExchangeCookie::domain,
+                            HttpExchangeCookie::expires,
+                            HttpExchangeCookie::httpOnly,
+                            HttpExchangeCookie::secure,
+                            HttpExchangeCookie::sameSite
+                    )
+                    .containsExactly(
+                            tuple(
+                                    "session",
+                                    "response-secret",
+                                    "/",
+                                    "example.test",
+                                    "Wed, 21 Oct 2015 07:28:00 GMT",
+                                    true,
+                                    true,
+                                    "Lax"
+                            ),
+                            tuple("theme", "light", null, null, null, null, null, null),
+                            tuple("trailer", "value", null, null, null, null, null, null)
+                    );
+        });
+    }
+
+    @Test
+    void buildersKeepRawCookieHeadersWhenConversionWouldLoseInformation() {
+        final HttpExchangeRequest request = step(
+                "Build a request with a malformed Cookie header",
+                () -> HttpExchangeRequest.builder("GET", "https://example.test")
+                        .addHeader("Cookie", "session=value; malformed")
+                        .build()
+        );
+        final HttpExchangeResponse response = step(
+                "Build a response with unsupported and malformed Set-Cookie fields",
+                () -> HttpExchangeResponse.builder()
+                        .addHeader("Set-Cookie", "session=value; Max-Age=60")
+                        .addTrailer("Set-Cookie", "malformed")
+                        .build()
+        );
+
+        step("Verify the original fields remain available for lossless capture", () -> {
+            assertThat(request.cookies()).isNull();
+            assertThat(request.headers())
+                    .extracting(HttpExchangeNameValue::name, HttpExchangeNameValue::value)
+                    .containsExactly(tuple("Cookie", "session=value; malformed"));
+            assertThat(response.cookies()).isNull();
+            assertThat(response.headers())
+                    .extracting(HttpExchangeNameValue::name, HttpExchangeNameValue::value)
+                    .containsExactly(tuple("Set-Cookie", "session=value; Max-Age=60"));
+            assertThat(response.trailers())
+                    .extracting(HttpExchangeNameValue::name, HttpExchangeNameValue::value)
+                    .containsExactly(tuple("Set-Cookie", "malformed"));
+        });
+    }
+}

--- a/allure-java-commons/src/test/java/io/qameta/allure/http/HttpExchangeProcessorTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/http/HttpExchangeProcessorTest.java
@@ -67,8 +67,7 @@ class HttpExchangeProcessorTest {
                                 "POST", "https://example.test/api", request -> request
                                         .addHeader("Authorization", "Bearer token")
                                         .addHeader("Accept", "application/json")
-                                        .addCookie("SESSION", "cookie-secret")
-                                        .addCookie("theme", "dark")
+                                        .addHeader("Cookie", "SESSION=cookie-secret; theme=dark")
                                         .addQuery("token", "query-secret")
                                         .addQuery("page", "1")
                                         .setBody(body)

--- a/allure-rest-assured/src/test/java/io/qameta/allure/restassured/AllureRestAssuredTest.java
+++ b/allure-rest-assured/src/test/java/io/qameta/allure/restassured/AllureRestAssuredTest.java
@@ -355,7 +355,10 @@ class AllureRestAssuredTest {
                 "Verify REST Assured exchange uses shared redaction and truncation", () -> assertThat(
                         results.getAttachmentContentAsString(httpExchangeAttachment(results))
                 )
-                        .contains("\"name\":\"sid\",\"value\":\"" + HttpExchange.REDACTED_VALUE + "\"")
+                        .containsOnlyOnce(
+                                "\"name\":\"sid\",\"value\":\"" + HttpExchange.REDACTED_VALUE + "\""
+                        )
+                        .doesNotContain("\"name\":\"Cookie\"")
                         .contains("\"name\":\"token\",\"value\":\"" + HttpExchange.REDACTED_VALUE + "\"")
                         .contains("\"name\":\"secret\",\"value\":\"" + HttpExchange.REDACTED_VALUE + "\"")
                         .contains("\"value\":\"resp\"")

--- a/allure-servlet-api/src/main/java/io/qameta/allure/servletapi/HttpServletAttachmentBuilder.java
+++ b/allure-servlet-api/src/main/java/io/qameta/allure/servletapi/HttpServletAttachmentBuilder.java
@@ -21,13 +21,11 @@ import io.qameta.allure.http.HttpExchangeResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 
 /**
@@ -58,12 +56,6 @@ public final class HttpServletAttachmentBuilder {
                     final String value = request.getHeader(name);
                     requestBuilder.addHeader(name, value);
                 });
-
-        final Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            Arrays.stream(cookies)
-                    .forEach(cookie -> requestBuilder.addCookie(cookie.getName(), cookie.getValue()));
-        }
         requestBuilder.setBody(HttpExchangeBody.utf8(getBody(request)));
         return requestBuilder.build();
     }

--- a/allure-servlet-api/src/test/java/io/qameta/allure/servletapi/HttpServletAttachmentBuilderTest.java
+++ b/allure-servlet-api/src/test/java/io/qameta/allure/servletapi/HttpServletAttachmentBuilderTest.java
@@ -20,7 +20,6 @@ import io.qameta.allure.http.HttpExchangeRequest;
 import io.qameta.allure.http.HttpExchangeResponse;
 import org.junit.jupiter.api.Test;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -41,10 +40,10 @@ class HttpServletAttachmentBuilderTest {
         final HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getMethod()).thenReturn("POST");
         when(request.getRequestURI()).thenReturn("/orders");
-        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of("X-Trace", "Accept")));
+        when(request.getHeaderNames()).thenReturn(Collections.enumeration(List.of("X-Trace", "Cookie", "Accept")));
         when(request.getHeader("X-Trace")).thenReturn("trace-1");
+        when(request.getHeader("Cookie")).thenReturn("session=abc123");
         when(request.getHeader("Accept")).thenReturn("application/json");
-        when(request.getCookies()).thenReturn(new Cookie[]{new Cookie("session", "abc123")});
         when(request.getReader()).thenReturn(new BufferedReader(new StringReader("{\"ok\":true}")));
 
         final HttpExchangeRequest attachment = Allure.step(
@@ -67,12 +66,11 @@ class HttpServletAttachmentBuilderTest {
     }
 
     @Test
-    void shouldHandleRequestsWithoutCookies() throws Exception {
+    void shouldHandleRequestsWithoutCookieHeaders() throws Exception {
         final HttpServletRequest request = mock(HttpServletRequest.class);
         when(request.getMethod()).thenReturn("GET");
         when(request.getRequestURI()).thenReturn("/orders");
         when(request.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
-        when(request.getCookies()).thenReturn(null);
         when(request.getReader()).thenReturn(new BufferedReader(new StringReader("")));
 
         final HttpExchangeRequest attachment = Allure.step(


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->
Capture request metadata, response headers, and trailers in gRPC HTTP exchange attachments by default, including repeated values, Base64-encoded binary metadata, and metadata added by call credentials. Request and response metadata capture can be disabled independently when needed.

Cookie metadata is represented as structured cookies, preserving supported response attributes and allowing sensitive values to be handled consistently through `redactHeader`, `redactCookie`, and existing HTTP exchange capture settings. Raw cookie headers are omitted to avoid duplicating sensitive data.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java