### PR TITLE
Report fixture and lifecycle failures without creating phantom tests

### DIFF
--- a/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/AllureCucumber7Jvm.java
+++ b/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/AllureCucumber7Jvm.java
@@ -34,6 +34,8 @@ import io.cucumber.plugin.event.StepArgument;
 import io.cucumber.plugin.event.TestCase;
 import io.cucumber.plugin.event.TestCaseFinished;
 import io.cucumber.plugin.event.TestCaseStarted;
+import io.cucumber.plugin.event.TestRunFinished;
+import io.cucumber.plugin.event.TestRunStarted;
 import io.cucumber.plugin.event.TestSourceRead;
 import io.cucumber.plugin.event.TestStepFinished;
 import io.cucumber.plugin.event.TestStepStarted;
@@ -62,10 +64,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static io.qameta.allure.util.ResultsUtils.createGlobalError;
 import static io.qameta.allure.util.ResultsUtils.createParameter;
 import static io.qameta.allure.util.ResultsUtils.createTitlePath;
 import static io.qameta.allure.util.ResultsUtils.createTitlePathFromSourcePath;
@@ -99,6 +103,9 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
 
     private final TestSourcesModelProxy testSources = new TestSourcesModelProxy();
 
+    private final AtomicBoolean scenarioStarted = new AtomicBoolean();
+
+    private final EventHandler<TestRunStarted> runStartedHandler = event -> scenarioStarted.set(false);
     private final EventHandler<TestSourceRead> featureStartedHandler = this::handleFeatureStartedHandler;
     private final EventHandler<TestCaseStarted> caseStartedHandler = this::handleTestCaseStarted;
     private final EventHandler<TestCaseFinished> caseFinishedHandler = this::handleTestCaseFinished;
@@ -106,6 +113,7 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
     private final EventHandler<TestStepFinished> stepFinishedHandler = this::handleTestStepFinished;
     private final EventHandler<WriteEvent> writeEventHandler = this::handleWriteEvent;
     private final EventHandler<EmbedEvent> embedEventHandler = this::handleEmbedEvent;
+    private final EventHandler<TestRunFinished> runFinishedHandler = this::handleTestRunFinished;
 
     private final Map<UUID, String> hookStepContainerUuid = new ConcurrentHashMap<>();
 
@@ -134,6 +142,7 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
      */
     @Override
     public void setEventPublisher(final EventPublisher publisher) {
+        publisher.registerHandlerFor(TestRunStarted.class, runStartedHandler);
         publisher.registerHandlerFor(TestSourceRead.class, featureStartedHandler);
 
         publisher.registerHandlerFor(TestCaseStarted.class, caseStartedHandler);
@@ -144,6 +153,7 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
 
         publisher.registerHandlerFor(WriteEvent.class, writeEventHandler);
         publisher.registerHandlerFor(EmbedEvent.class, embedEventHandler);
+        publisher.registerHandlerFor(TestRunFinished.class, runFinishedHandler);
     }
 
     private static AllureExternalKey scopeKey(final String uuid) {
@@ -167,6 +177,7 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
     }
 
     private void handleTestCaseStarted(final TestCaseStarted event) {
+        scenarioStarted.set(true);
         final TestCase testCase = event.getTestCase();
         final Feature feature = testSources.getFeature(testCase.getUri());
 
@@ -216,6 +227,25 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
         lifecycle.scheduleTest(testKey, result);
         lifecycle.addDefaultLabels(testKey, labelBuilder.getDefaultLabels());
         lifecycle.startTest(testKey);
+    }
+
+    /**
+     * Reports an error outside an individual scenario as an error of the run.
+     *
+     * <p>A failed scenario also makes the run-finished result unsuccessful, but its error stays on the
+     * {@link TestCaseFinished} event and the run-finished result has no throwable. Only a throwable here represents
+     * a failure such as a run-level hook that has no scenario result of its own.</p>
+     */
+    private void handleTestRunFinished(final TestRunFinished event) {
+        final Result result = event.getResult();
+        if (Objects.isNull(result) || Objects.isNull(result.getError())) {
+            return;
+        }
+
+        final String context = scenarioStarted.get()
+                ? "Cucumber test run failed"
+                : "Cucumber test run failed, scenarios did not run";
+        lifecycle.writeGlobals(createGlobalError(context, result.getError()));
     }
 
     private void handleTestCaseFinished(final TestCaseFinished event) {

--- a/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
+++ b/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
@@ -26,9 +26,11 @@ import io.cucumber.core.runtime.Runtime;
 import io.cucumber.core.runtime.TimeServiceEventBus;
 import io.github.glytching.junit.extension.system.SystemProperty;
 import io.github.glytching.junit.extension.system.SystemPropertyExtension;
+import io.qameta.allure.Description;
 import io.qameta.allure.Step;
 import io.qameta.allure.model.Attachment;
 import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.GlobalError;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Parameter;
@@ -52,7 +54,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static io.qameta.allure.util.ResultsUtils.PACKAGE_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.SUITE_LABEL_NAME;
@@ -60,6 +64,7 @@ import static io.qameta.allure.util.ResultsUtils.TEST_CLASS_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.TEST_METHOD_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.md5;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
 import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
@@ -92,8 +97,12 @@ class AllureCucumber7JvmTest {
                 );
     }
 
+    /**
+     * A failed scenario keeps the failure on its own result and is not duplicated as an error of the test run.
+     */
     @AllureFeatures.FailedTests
     @Test
+    @Description
     void shouldSetFailedStatus() {
         final AllureResults results = runFeature("features/failed.feature");
 
@@ -101,6 +110,9 @@ class AllureCucumber7JvmTest {
         assertThat(testResults)
                 .extracting(TestResult::getStatus)
                 .containsExactlyInAnyOrder(Status.FAILED);
+        assertThat(getGlobalErrors(results))
+                .as("the scenario result already represents this failure")
+                .isEmpty();
     }
 
     @AllureFeatures.FailedTests
@@ -725,6 +737,56 @@ class AllureCucumber7JvmTest {
 
     }
 
+    /**
+     * A failed Cucumber {@code @BeforeAll} hook is an error of the run. No scenario result is invented because the
+     * hook prevents every selected scenario from starting.
+     */
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Test
+    @Description
+    void shouldReportBrokenBeforeAllAsGlobalError() {
+        final AllureResults results = runFeatureExpectingFailure(
+                "features/simple.feature",
+                "Exception in @BeforeAll",
+                "--glue", "io.qameta.allure.cucumber7jvm.runhooks.beforeall"
+        );
+
+        assertThat(results.getTestResults())
+                .as("the run-level hook failed before a scenario could start")
+                .isEmpty();
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Cucumber test run failed, scenarios did not run: Exception in @BeforeAll"
+                );
+    }
+
+    /**
+     * A failed Cucumber {@code @AfterAll} hook is an error of the run, while scenarios completed before the hook
+     * keep their own results.
+     */
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Test
+    @Description
+    void shouldReportBrokenAfterAllAsGlobalError() {
+        final AllureResults results = runFeatureExpectingFailure(
+                "features/simple.feature",
+                "Exception in @AfterAll",
+                "--glue", "io.qameta.allure.cucumber7jvm.runhooks.afterall"
+        );
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("Add a to b", Status.PASSED));
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Cucumber test run failed: Exception in @AfterAll"
+                );
+    }
+
     @AllureFeatures.BrokenTests
     @Test
     void shouldHandleAmbigiousStepsExceptions() {
@@ -834,6 +896,26 @@ class AllureCucumber7JvmTest {
     private AllureResults runFeature(final String featureResource,
                                      final String... moreOptions) {
 
+        return runFeature(featureResource, Runtime::run, moreOptions);
+    }
+
+    @Step
+    private AllureResults runFeatureExpectingFailure(final String featureResource,
+                                                     final String expectedMessage,
+                                                     final String... moreOptions) {
+
+        return runFeature(
+                featureResource,
+                runtime -> assertThatThrownBy(runtime::run)
+                        .hasMessageContaining(expectedMessage),
+                moreOptions
+        );
+    }
+
+    private AllureResults runFeature(final String featureResource,
+                                     final Consumer<Runtime> run,
+                                     final String... moreOptions) {
+
         return RunUtils.runTests(lifecycle -> {
             final AllureCucumber7Jvm cucumber7jvm = new AllureCucumber7Jvm(lifecycle);
             final Supplier<ClassLoader> classLoader = ClassLoaders::getDefaultClassLoader;
@@ -859,8 +941,14 @@ class AllureCucumber7JvmTest {
                     .withFeatureSupplier(supplier)
                     .build();
 
-            runtime.run();
+            run.accept(runtime);
         });
+    }
+
+    private static List<GlobalError> getGlobalErrors(final AllureResults results) {
+        return results.getGlobals().stream()
+                .flatMap(globals -> globals.getErrors().stream())
+                .collect(Collectors.toList());
     }
 
 }

--- a/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/runhooks/afterall/BrokenAfterAllHooks.java
+++ b/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/runhooks/afterall/BrokenAfterAllHooks.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.cucumber7jvm.runhooks.afterall;
+
+import io.cucumber.java.AfterAll;
+
+public final class BrokenAfterAllHooks {
+
+    private BrokenAfterAllHooks() {
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        throw new IllegalStateException("Exception in @AfterAll");
+    }
+}

--- a/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/runhooks/afterall/BrokenAfterAllHooks.java
+++ b/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/runhooks/afterall/BrokenAfterAllHooks.java
@@ -24,6 +24,6 @@ public final class BrokenAfterAllHooks {
 
     @AfterAll
     public static void afterAll() {
-        throw new IllegalStateException("Exception in @AfterAll");
+        throw new RuntimeException("Exception in @AfterAll");
     }
 }

--- a/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/runhooks/beforeall/BrokenBeforeAllHooks.java
+++ b/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/runhooks/beforeall/BrokenBeforeAllHooks.java
@@ -24,6 +24,6 @@ public final class BrokenBeforeAllHooks {
 
     @BeforeAll
     public static void beforeAll() {
-        throw new IllegalStateException("Exception in @BeforeAll");
+        throw new RuntimeException("Exception in @BeforeAll");
     }
 }

--- a/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/runhooks/beforeall/BrokenBeforeAllHooks.java
+++ b/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/runhooks/beforeall/BrokenBeforeAllHooks.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.cucumber7jvm.runhooks.beforeall;
+
+import io.cucumber.java.BeforeAll;
+
+public final class BrokenBeforeAllHooks {
+
+    private BrokenBeforeAllHooks() {
+    }
+
+    @BeforeAll
+    public static void beforeAll() {
+        throw new IllegalStateException("Exception in @BeforeAll");
+    }
+}

--- a/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/util/ResultsUtils.java
@@ -22,6 +22,8 @@ import io.qameta.allure.Owner;
 import io.qameta.allure.Severity;
 import io.qameta.allure.SeverityLevel;
 import io.qameta.allure.Story;
+import io.qameta.allure.model.GlobalError;
+import io.qameta.allure.model.Globals;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Parameter;
@@ -727,6 +729,41 @@ public final class ResultsUtils {
                     getRichErrorProperty(throwable, EXPECTED).ifPresent(details::setExpected);
                     return details;
                 });
+    }
+
+    /**
+     * Returns the globals artifact for a failure that belongs to the test run rather than to any test result.
+     *
+     * <p>Adapters use this for failures they cannot attribute to a test without inventing one: a configuration
+     * method that failed outside any test, or a data provider that failed before the invocations it would have
+     * produced were known. A test result invented for such a failure carries a history id that no execution ever
+     * produces, so it distorts the run statistics and no retry can ever replace it.</p>
+     *
+     * <p>Write the result with {@link io.qameta.allure.AllureLifecycle#writeGlobals(Globals)} on the adapter's own
+     * lifecycle rather than through the {@link io.qameta.allure.Allure} facade, so that the error reaches the
+     * lifecycle the adapter reports to.</p>
+     *
+     * @param context     the description of what failed, and of what did not run when the failure kept tests from
+     *                    running
+     * @param throwable   the failure, may be null
+     * @return the globals artifact holding a single error
+     */
+    public static Globals createGlobalError(final String context, final Throwable throwable) {
+        final GlobalError error = new GlobalError()
+                .setTimestamp(System.currentTimeMillis())
+                .setMessage(context);
+
+        getStatusDetails(throwable).ifPresent(
+                details -> error
+                        .setMessage(context + ": " + details.getMessage())
+                        .setTrace(details.getTrace())
+                        .setActual(details.getActual())
+                        .setExpected(details.getExpected())
+        );
+
+        final Globals globals = new Globals();
+        globals.getErrors().add(error);
+        return globals;
     }
 
     /**

--- a/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
@@ -579,7 +579,7 @@ class ResultsUtilsTest {
     void shouldCreateGlobalErrorFromThrowable() {
         final Globals globals = ResultsUtils.createGlobalError(
                 "Configuration method com.example.Tests.setUp failed, tests depending on it did not run",
-                new IllegalStateException("no database")
+                new RuntimeException("no database")
         );
 
         assertThat(globals.getErrors()).hasSize(1);
@@ -589,7 +589,7 @@ class ResultsUtilsTest {
                         "Configuration method com.example.Tests.setUp failed, "
                                 + "tests depending on it did not run: no database"
                 );
-        assertThat(error.getTrace()).startsWith("java.lang.IllegalStateException: no database");
+        assertThat(error.getTrace()).startsWith("java.lang.RuntimeException: no database");
         assertThat(error.getTimestamp()).isPositive();
     }
 

--- a/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/ResultsUtilsTest.java
@@ -17,6 +17,8 @@ package io.qameta.allure;
 
 import io.github.glytching.junit.extension.system.SystemProperty;
 import io.github.glytching.junit.extension.system.SystemPropertyExtension;
+import io.qameta.allure.model.GlobalError;
+import io.qameta.allure.model.Globals;
 import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.util.ResultsUtils;
 import org.junit.jupiter.api.Test;
@@ -567,6 +569,41 @@ class ResultsUtilsTest {
 
     private static io.qameta.allure.model.Link link(String name, String url, String type) {
         return new io.qameta.allure.model.Link().setName(name).setUrl(url).setType(type);
+    }
+
+    /**
+     * A run-level error keeps the original failure message and stack trace next to the context that explains what
+     * did not run, so a report can show why tests are missing without a test result standing in for them.
+     */
+    @Test
+    void shouldCreateGlobalErrorFromThrowable() {
+        final Globals globals = ResultsUtils.createGlobalError(
+                "Configuration method com.example.Tests.setUp failed, tests depending on it did not run",
+                new IllegalStateException("no database")
+        );
+
+        assertThat(globals.getErrors()).hasSize(1);
+        final GlobalError error = globals.getErrors().get(0);
+        assertThat(error.getMessage())
+                .isEqualTo(
+                        "Configuration method com.example.Tests.setUp failed, "
+                                + "tests depending on it did not run: no database"
+                );
+        assertThat(error.getTrace()).startsWith("java.lang.IllegalStateException: no database");
+        assertThat(error.getTimestamp()).isPositive();
+    }
+
+    /**
+     * The context alone describes a run-level error when there is no failure to attach to it.
+     */
+    @Test
+    void shouldCreateGlobalErrorWithoutThrowable() {
+        final Globals globals = ResultsUtils.createGlobalError("the run did not start", null);
+
+        assertThat(globals.getErrors()).hasSize(1);
+        final GlobalError error = globals.getErrors().get(0);
+        assertThat(error.getMessage()).isEqualTo("the run did not start");
+        assertThat(error.getTrace()).isNull();
     }
 
     private static final class LambdaSubject {

--- a/allure-jbehave5/src/main/java/io/qameta/allure/jbehave5/AllureJbehave5.java
+++ b/allure-jbehave5/src/main/java/io/qameta/allure/jbehave5/AllureJbehave5.java
@@ -27,10 +27,12 @@ import io.qameta.allure.model.TestResult;
 import io.qameta.allure.util.ResultsUtils;
 import org.jbehave.core.failures.UUIDExceptionWrapper;
 import org.jbehave.core.model.ExamplesTable;
+import org.jbehave.core.model.Lifecycle;
 import org.jbehave.core.model.Scenario;
 import org.jbehave.core.model.Step;
 import org.jbehave.core.model.Story;
 import org.jbehave.core.reporters.NullStoryReporter;
+import org.jbehave.core.steps.StepCollector;
 import org.jbehave.core.steps.StepCreator;
 import org.jbehave.core.steps.Timing;
 
@@ -46,6 +48,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 import static io.qameta.allure.util.ResultsUtils.createFrameworkLabel;
+import static io.qameta.allure.util.ResultsUtils.createGlobalError;
 import static io.qameta.allure.util.ResultsUtils.createHostLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
 import static io.qameta.allure.util.ResultsUtils.createParameter;
@@ -64,7 +67,10 @@ import static java.util.Collections.singletonList;
  *
  * <p>Configure this reporter in JBehave so story, scenario, example, and step events become Allure containers, test results, steps, labels, and parameters. Use the default lifecycle for normal runs or pass a lifecycle for tests and embedded runtimes.</p>
  */
+@SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods"})
 public class AllureJbehave5 extends NullStoryReporter {
+
+    private static final String LIFECYCLE_STEP_FAILED = "JBehave %s lifecycle step failed";
 
     private final AllureLifecycle lifecycle;
 
@@ -75,6 +81,8 @@ public class AllureJbehave5 extends NullStoryReporter {
     private final Map<Scenario, List<AllureExternalKey>> scenarioKeys = new ConcurrentHashMap<>();
 
     private final ThreadLocal<Deque<Story>> givenStories = ThreadLocal.withInitial(LinkedList::new);
+
+    private final ThreadLocal<String> globalLifecycleContext = new InheritableThreadLocal<>();
 
     private final ReadWriteLock lock = new ReentrantReadWriteLock();
 
@@ -116,6 +124,42 @@ public class AllureJbehave5 extends NullStoryReporter {
             givenStories.get().pop();
         } else {
             currentStory.remove();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void beforeStoriesSteps(final StepCollector.Stage stage) {
+        globalLifecycleContext.set(storiesLifecycleContext(stage));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void afterStoriesSteps(final StepCollector.Stage stage) {
+        globalLifecycleContext.remove();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void beforeStorySteps(final StepCollector.Stage stage, final Lifecycle.ExecutionType type) {
+        if (currentScenario.get() == null) {
+            globalLifecycleContext.set(storyLifecycleContext(stage));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void afterStorySteps(final StepCollector.Stage stage, final Lifecycle.ExecutionType type) {
+        if (currentScenario.get() == null) {
+            globalLifecycleContext.remove();
         }
     }
 
@@ -191,6 +235,9 @@ public class AllureJbehave5 extends NullStoryReporter {
      */
     @Override
     public void beforeStep(final Step step) {
+        if (isGlobalStep()) {
+            return;
+        }
         getLifecycle().startStep(new StepResult().setName(step.getStepAsString()));
     }
 
@@ -199,7 +246,14 @@ public class AllureJbehave5 extends NullStoryReporter {
      */
     @Override
     public void successful(final String step) {
-        getLifecycle().updateTest(result -> result.setStatus(Status.PASSED));
+        if (isGlobalStep()) {
+            return;
+        }
+        getLifecycle().updateTest(result -> {
+            if (result.getStatus() == null) {
+                result.setStatus(Status.PASSED);
+            }
+        });
         getLifecycle().updateStep(result -> result.setStatus(Status.PASSED));
         getLifecycle().stopStep();
     }
@@ -209,6 +263,9 @@ public class AllureJbehave5 extends NullStoryReporter {
      */
     @Override
     public void ignorable(final String step) {
+        if (isGlobalStep()) {
+            return;
+        }
         getLifecycle().stopStep();
     }
 
@@ -217,6 +274,9 @@ public class AllureJbehave5 extends NullStoryReporter {
      */
     @Override
     public void pending(final StepCreator.PendingStep step) {
+        if (isGlobalStep()) {
+            return;
+        }
         getLifecycle().updateStep(result -> result.setStatus(Status.SKIPPED));
         getLifecycle().stopStep();
     }
@@ -226,6 +286,9 @@ public class AllureJbehave5 extends NullStoryReporter {
      */
     @Override
     public void notPerformed(final String step) {
+        if (isGlobalStep()) {
+            return;
+        }
         getLifecycle().stopStep();
     }
 
@@ -237,6 +300,12 @@ public class AllureJbehave5 extends NullStoryReporter {
         final Throwable unwrapped = cause instanceof UUIDExceptionWrapper
                 ? cause.getCause()
                 : cause;
+
+        final String globalContext = globalErrorContext();
+        if (globalContext != null) {
+            getLifecycle().writeGlobals(createGlobalError(globalContext, unwrapped));
+            return;
+        }
 
         final Status status = getStatus(unwrapped).orElse(Status.FAILED);
         final StatusDetails statusDetails = getStatusDetails(unwrapped).orElseGet(StatusDetails::new);
@@ -338,6 +407,48 @@ public class AllureJbehave5 extends NullStoryReporter {
 
     private boolean isGivenStory() {
         return !givenStories.get().isEmpty();
+    }
+
+    private boolean isGlobalStep() {
+        return globalErrorContext() != null;
+    }
+
+    private String globalErrorContext() {
+        final String lifecycleContext = globalLifecycleContext.get();
+        if (lifecycleContext != null) {
+            return lifecycleContext;
+        }
+        if (isGivenStory() && currentScenario.get() == null) {
+            return givenStoryContext();
+        }
+        return null;
+    }
+
+    private String givenStoryContext() {
+        final Story story = currentExecutingStory();
+        if (story == null) {
+            return "JBehave story-level GivenStories step failed";
+        }
+        return String.format("JBehave story-level GivenStories step failed for %s", story.getName());
+    }
+
+    private String storyLifecycleContext(final StepCollector.Stage stage) {
+        final Story story = currentExecutingStory();
+        final String scope = stage == StepCollector.Stage.BEFORE ? "before-story" : "after-story";
+        if (story == null) {
+            return String.format(LIFECYCLE_STEP_FAILED, scope);
+        }
+        return String.format("JBehave %s lifecycle step failed for %s", scope, story.getName());
+    }
+
+    private Story currentExecutingStory() {
+        final Deque<Story> currentGivenStories = givenStories.get();
+        return currentGivenStories.isEmpty() ? currentStory.get() : currentGivenStories.peek();
+    }
+
+    private static String storiesLifecycleContext(final StepCollector.Stage stage) {
+        final String scope = stage == StepCollector.Stage.BEFORE ? "before-stories" : "after-stories";
+        return String.format(LIFECYCLE_STEP_FAILED, scope);
     }
 
     private void usingReadLock(final Runnable runnable) {

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/AllureJbehave5Test.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/AllureJbehave5Test.java
@@ -15,11 +15,21 @@
  */
 package io.qameta.allure.jbehave5;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Issue;
+import io.qameta.allure.jbehave5.samples.BrokenAfterScenarioSteps;
+import io.qameta.allure.jbehave5.samples.BrokenAfterStoriesSteps;
+import io.qameta.allure.jbehave5.samples.BrokenAfterStorySteps;
+import io.qameta.allure.jbehave5.samples.BrokenBeforeGivenStorySteps;
+import io.qameta.allure.jbehave5.samples.BrokenBeforeScenarioSteps;
+import io.qameta.allure.jbehave5.samples.BrokenBeforeStoriesSteps;
+import io.qameta.allure.jbehave5.samples.BrokenBeforeStorySteps;
+import io.qameta.allure.jbehave5.samples.BrokenLifecycleStorySteps;
 import io.qameta.allure.jbehave5.samples.BrokenStorySteps;
 import io.qameta.allure.jbehave5.samples.RuntimeApiSteps;
 import io.qameta.allure.jbehave5.samples.SimpleStorySteps;
 import io.qameta.allure.model.Attachment;
+import io.qameta.allure.model.GlobalError;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Stage;
@@ -27,9 +37,11 @@ import io.qameta.allure.model.Status;
 import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.model.StepResult;
 import io.qameta.allure.model.TestResult;
+import io.qameta.allure.test.AllureFeatures;
 import io.qameta.allure.test.AllureResults;
 import io.qameta.allure.test.IsolatedLifecycle;
 import io.qameta.allure.test.RunUtils;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jbehave.core.configuration.MostUsefulConfiguration;
 import org.jbehave.core.embedder.Embedder;
 import org.jbehave.core.embedder.EmbedderControls;
@@ -45,8 +57,10 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static io.qameta.allure.Allure.step;
 import static io.qameta.allure.util.ResultsUtils.md5;
@@ -129,6 +143,233 @@ class AllureJbehave5Test {
         assertThat(results.getTestResults())
                 .extracting(TestResult::getStatus)
                 .containsExactlyInAnyOrder(Status.BROKEN);
+    }
+
+    /**
+     * A failed {@code @BeforeStories} method belongs to the entire JBehave run and is preserved as a global error.
+     */
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldReportBrokenBeforeStoriesAsGlobalError() {
+        final AllureResults results = runStoriesWithSteps(
+                new BrokenBeforeStoriesSteps(),
+                "stories/simple.story"
+        );
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .singleElement(InstanceOfAssertFactories.STRING)
+                .startsWith("JBehave before-stories lifecycle step failed:")
+                .contains("Exception in @BeforeStories");
+    }
+
+    /**
+     * A failed {@code @AfterStories} method is preserved as a global error after completed scenarios keep their
+     * results.
+     */
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldReportBrokenAfterStoriesAsGlobalError() {
+        final AllureResults results = runStoriesWithSteps(
+                new BrokenAfterStoriesSteps(),
+                "stories/simple.story"
+        );
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("Add a to b", Status.PASSED));
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .singleElement(InstanceOfAssertFactories.STRING)
+                .startsWith("JBehave after-stories lifecycle step failed:")
+                .contains("Exception in @AfterStories");
+    }
+
+    /**
+     * A failed {@code @BeforeStory} method has no scenario owner and is preserved as a story-scoped global error.
+     */
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldReportBrokenBeforeStoryAsGlobalError() {
+        final AllureResults results = runStoriesWithSteps(
+                new BrokenBeforeStorySteps(),
+                "stories/simple.story"
+        );
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .singleElement(InstanceOfAssertFactories.STRING)
+                .startsWith("JBehave before-story lifecycle step failed for simple.story:")
+                .contains("Exception in @BeforeStory");
+    }
+
+    /**
+     * A failed {@code @AfterStory} method has no scenario owner and is preserved as a story-scoped global error
+     * without replacing the completed scenario result.
+     */
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldReportBrokenAfterStoryAsGlobalError() {
+        final AllureResults results = runStoriesWithSteps(
+                new BrokenAfterStorySteps(),
+                "stories/simple.story"
+        );
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("Add a to b", Status.PASSED));
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .singleElement(InstanceOfAssertFactories.STRING)
+                .startsWith("JBehave after-story lifecycle step failed for simple.story:")
+                .contains("Exception in @AfterStory");
+    }
+
+    /**
+     * Declarative story setup uses the same global-error path as an annotation-based before-story method.
+     */
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldReportBrokenDeclarativeBeforeStoryAsGlobalError() {
+        final AllureResults results = runStoriesWithSteps(
+                new BrokenLifecycleStorySteps(),
+                "stories/broken-before-story-lifecycle.story"
+        );
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "JBehave before-story lifecycle step failed for broken-before-story-lifecycle.story: "
+                                + "Exception in declarative before-story lifecycle"
+                );
+    }
+
+    /**
+     * Declarative story teardown uses the same global-error path as an annotation-based after-story method.
+     */
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldReportBrokenDeclarativeAfterStoryAsGlobalError() {
+        final AllureResults results = runStoriesWithSteps(
+                new BrokenLifecycleStorySteps(),
+                "stories/broken-after-story-lifecycle.story"
+        );
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("Add a to b", Status.PASSED));
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "JBehave after-story lifecycle step failed for broken-after-story-lifecycle.story: "
+                                + "Exception in declarative after-story lifecycle"
+                );
+    }
+
+    /**
+     * A failed {@code @BeforeScenario} method remains owned by its scenario and is not duplicated globally.
+     */
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldKeepBrokenBeforeScenarioOnScenario() {
+        final AllureResults results = runStoriesWithSteps(
+                new BrokenBeforeScenarioSteps(),
+                "stories/simple.story"
+        );
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("Add a to b", Status.BROKEN));
+        assertThat(getGlobalErrors(results)).isEmpty();
+    }
+
+    /**
+     * A failed {@code @AfterScenario} method remains owned by its scenario and is not duplicated globally.
+     */
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldKeepBrokenAfterScenarioOnScenario() {
+        final AllureResults results = runStoriesWithSteps(
+                new BrokenAfterScenarioSteps(),
+                "stories/simple.story"
+        );
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("Add a to b", Status.BROKEN));
+        assertThat(getGlobalErrors(results)).isEmpty();
+    }
+
+    /**
+     * A story hook around scenario-level {@code GivenStories} executes inside the parent scenario and remains owned
+     * by that scenario instead of becoming a story-scoped global error.
+     */
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldKeepBrokenBeforeGivenStoryOnParentScenario() {
+        final AllureResults results = runStoriesWithSteps(
+                new BrokenBeforeGivenStorySteps(),
+                "stories/given.story"
+        );
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("Add a to b", Status.BROKEN));
+        assertThat(getGlobalErrors(results)).isEmpty();
+    }
+
+    /**
+     * A failed step in story-level {@code GivenStories} has no scenario owner and is preserved as a global error.
+     */
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldReportBrokenStoryLevelGivenStoryAsGlobalError() {
+        final AllureResults results = runStories("stories/story-level-broken-given.story");
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("Story with broken GivenStories", Status.PASSED));
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "JBehave story-level GivenStories step failed for broken.story: Oops"
+                );
+    }
+
+    /**
+     * A failed step in scenario-level {@code GivenStories} remains owned by its parent scenario.
+     */
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldKeepBrokenScenarioLevelGivenStoryOnParentScenario() {
+        final AllureResults results = runStories("stories/scenario-level-broken-given.story");
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("Scenario with broken GivenStories", Status.BROKEN));
+        assertThat(getGlobalErrors(results)).isEmpty();
     }
 
     @Test
@@ -319,6 +560,14 @@ class AllureJbehave5Test {
     }
 
     private AllureResults runStories(final String... storyResources) {
+        return runStories(List.of(), storyResources);
+    }
+
+    private AllureResults runStoriesWithSteps(final Object steps, final String... storyResources) {
+        return runStories(List.of(steps), storyResources);
+    }
+
+    private AllureResults runStories(final List<Object> additionalSteps, final String... storyResources) {
         return step("Run JBehave stories and collect Allure results", () -> RunUtils.runTests(lifecycle -> {
             final Embedder embedder = new Embedder();
             embedder.useEmbedderMonitor(new NullEmbedderMonitor());
@@ -342,15 +591,27 @@ class AllureJbehave5Test {
                             )
                             .useDefaultStoryReporter(new NullStoryReporter())
             );
+            final List<Object> stepInstances = new ArrayList<>(
+                    Arrays.asList(
+                            new SimpleStorySteps(),
+                            new BrokenStorySteps(),
+                            new RuntimeApiSteps()
+                    )
+            );
+            stepInstances.addAll(additionalSteps);
             final InjectableStepsFactory stepsFactory = new InstanceStepsFactory(
                     embedder.configuration(),
-                    new SimpleStorySteps(),
-                    new BrokenStorySteps(),
-                    new RuntimeApiSteps()
+                    stepInstances.toArray()
             );
             embedder.useStepsFactory(stepsFactory);
             embedder.runStoriesAsPaths(Arrays.asList(storyResources));
         }));
+    }
+
+    private static List<GlobalError> getGlobalErrors(final AllureResults results) {
+        return results.getGlobals().stream()
+                .flatMap(globals -> globals.getErrors().stream())
+                .collect(Collectors.toList());
     }
 
     static class ReportlessStoryReporterBuilder extends StoryReporterBuilder {

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterScenarioSteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterScenarioSteps.java
@@ -21,6 +21,6 @@ public class BrokenAfterScenarioSteps {
 
     @AfterScenario
     public void afterScenario() {
-        throw new IllegalStateException("Exception in @AfterScenario");
+        throw new RuntimeException("Exception in @AfterScenario");
     }
 }

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterScenarioSteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterScenarioSteps.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jbehave5.samples;
+
+import org.jbehave.core.annotations.AfterScenario;
+
+public class BrokenAfterScenarioSteps {
+
+    @AfterScenario
+    public void afterScenario() {
+        throw new IllegalStateException("Exception in @AfterScenario");
+    }
+}

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterStoriesSteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterStoriesSteps.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jbehave5.samples;
+
+import org.jbehave.core.annotations.AfterStories;
+
+public class BrokenAfterStoriesSteps {
+
+    @AfterStories
+    public void afterStories() {
+        throw new IllegalStateException("Exception in @AfterStories");
+    }
+}

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterStoriesSteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterStoriesSteps.java
@@ -21,6 +21,6 @@ public class BrokenAfterStoriesSteps {
 
     @AfterStories
     public void afterStories() {
-        throw new IllegalStateException("Exception in @AfterStories");
+        throw new RuntimeException("Exception in @AfterStories");
     }
 }

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterStorySteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterStorySteps.java
@@ -21,6 +21,6 @@ public class BrokenAfterStorySteps {
 
     @AfterStory
     public void afterStory() {
-        throw new IllegalStateException("Exception in @AfterStory");
+        throw new RuntimeException("Exception in @AfterStory");
     }
 }

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterStorySteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenAfterStorySteps.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jbehave5.samples;
+
+import org.jbehave.core.annotations.AfterStory;
+
+public class BrokenAfterStorySteps {
+
+    @AfterStory
+    public void afterStory() {
+        throw new IllegalStateException("Exception in @AfterStory");
+    }
+}

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeGivenStorySteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeGivenStorySteps.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jbehave5.samples;
+
+import org.jbehave.core.annotations.BeforeStory;
+
+public class BrokenBeforeGivenStorySteps {
+
+    @BeforeStory(uponGivenStory = true)
+    public void beforeGivenStory() {
+        throw new IllegalStateException("Exception in @BeforeStory for GivenStories");
+    }
+}

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeGivenStorySteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeGivenStorySteps.java
@@ -21,6 +21,6 @@ public class BrokenBeforeGivenStorySteps {
 
     @BeforeStory(uponGivenStory = true)
     public void beforeGivenStory() {
-        throw new IllegalStateException("Exception in @BeforeStory for GivenStories");
+        throw new RuntimeException("Exception in @BeforeStory for GivenStories");
     }
 }

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeScenarioSteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeScenarioSteps.java
@@ -21,6 +21,6 @@ public class BrokenBeforeScenarioSteps {
 
     @BeforeScenario
     public void beforeScenario() {
-        throw new IllegalStateException("Exception in @BeforeScenario");
+        throw new RuntimeException("Exception in @BeforeScenario");
     }
 }

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeScenarioSteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeScenarioSteps.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jbehave5.samples;
+
+import org.jbehave.core.annotations.BeforeScenario;
+
+public class BrokenBeforeScenarioSteps {
+
+    @BeforeScenario
+    public void beforeScenario() {
+        throw new IllegalStateException("Exception in @BeforeScenario");
+    }
+}

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeStoriesSteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeStoriesSteps.java
@@ -21,6 +21,6 @@ public class BrokenBeforeStoriesSteps {
 
     @BeforeStories
     public void beforeStories() {
-        throw new IllegalStateException("Exception in @BeforeStories");
+        throw new RuntimeException("Exception in @BeforeStories");
     }
 }

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeStoriesSteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeStoriesSteps.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jbehave5.samples;
+
+import org.jbehave.core.annotations.BeforeStories;
+
+public class BrokenBeforeStoriesSteps {
+
+    @BeforeStories
+    public void beforeStories() {
+        throw new IllegalStateException("Exception in @BeforeStories");
+    }
+}

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeStorySteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeStorySteps.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jbehave5.samples;
+
+import org.jbehave.core.annotations.BeforeStory;
+
+public class BrokenBeforeStorySteps {
+
+    @BeforeStory
+    public void beforeStory() {
+        throw new IllegalStateException("Exception in @BeforeStory");
+    }
+}

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeStorySteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenBeforeStorySteps.java
@@ -21,6 +21,6 @@ public class BrokenBeforeStorySteps {
 
     @BeforeStory
     public void beforeStory() {
-        throw new IllegalStateException("Exception in @BeforeStory");
+        throw new RuntimeException("Exception in @BeforeStory");
     }
 }

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenLifecycleStorySteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenLifecycleStorySteps.java
@@ -21,11 +21,11 @@ public class BrokenLifecycleStorySteps {
 
     @Given("before-story lifecycle fails")
     public void beforeStoryLifecycleFails() {
-        throw new IllegalStateException("Exception in declarative before-story lifecycle");
+        throw new RuntimeException("Exception in declarative before-story lifecycle");
     }
 
     @Given("after-story lifecycle fails")
     public void afterStoryLifecycleFails() {
-        throw new IllegalStateException("Exception in declarative after-story lifecycle");
+        throw new RuntimeException("Exception in declarative after-story lifecycle");
     }
 }

--- a/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenLifecycleStorySteps.java
+++ b/allure-jbehave5/src/test/java/io/qameta/allure/jbehave5/samples/BrokenLifecycleStorySteps.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jbehave5.samples;
+
+import org.jbehave.core.annotations.Given;
+
+public class BrokenLifecycleStorySteps {
+
+    @Given("before-story lifecycle fails")
+    public void beforeStoryLifecycleFails() {
+        throw new IllegalStateException("Exception in declarative before-story lifecycle");
+    }
+
+    @Given("after-story lifecycle fails")
+    public void afterStoryLifecycleFails() {
+        throw new IllegalStateException("Exception in declarative after-story lifecycle");
+    }
+}

--- a/allure-jbehave5/src/test/resources/stories/broken-after-story-lifecycle.story
+++ b/allure-jbehave5/src/test/resources/stories/broken-after-story-lifecycle.story
@@ -1,0 +1,11 @@
+Lifecycle:
+After:
+Scope: STORY
+Given after-story lifecycle fails
+
+Scenario: Add a to b
+
+Given a is 5
+And b is 10
+When I add a to b
+Then result is 15

--- a/allure-jbehave5/src/test/resources/stories/broken-before-story-lifecycle.story
+++ b/allure-jbehave5/src/test/resources/stories/broken-before-story-lifecycle.story
@@ -1,0 +1,11 @@
+Lifecycle:
+Before:
+Scope: STORY
+Given before-story lifecycle fails
+
+Scenario: Add a to b
+
+Given a is 5
+And b is 10
+When I add a to b
+Then result is 15

--- a/allure-jbehave5/src/test/resources/stories/scenario-level-broken-given.story
+++ b/allure-jbehave5/src/test/resources/stories/scenario-level-broken-given.story
@@ -1,0 +1,4 @@
+Scenario: Scenario with broken GivenStories
+GivenStories:stories/broken.story
+
+Given a is 5

--- a/allure-jbehave5/src/test/resources/stories/story-level-broken-given.story
+++ b/allure-jbehave5/src/test/resources/stories/story-level-broken-given.story
@@ -1,0 +1,5 @@
+GivenStories:stories/broken.story
+
+Scenario: Story with broken GivenStories
+
+Given a is 5

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
@@ -65,8 +65,8 @@ import java.util.stream.Stream;
 import static io.qameta.allure.model.Status.FAILED;
 import static io.qameta.allure.model.Status.PASSED;
 import static io.qameta.allure.model.Status.SKIPPED;
-import static io.qameta.allure.util.ResultsUtils.ALLURE_ID_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.createFrameworkLabel;
+import static io.qameta.allure.util.ResultsUtils.createGlobalError;
 import static io.qameta.allure.util.ResultsUtils.createHostLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
 import static io.qameta.allure.util.ResultsUtils.createPackageLabel;
@@ -319,11 +319,36 @@ public class AllureJunitPlatform implements TestExecutionListener {
         if (testIdentifier.isTest()) {
             stopTest(testIdentifier, status, statusDetails);
         } else if (testExecutionResult.getStatus() != TestExecutionResult.Status.SUCCESSFUL) {
-            // report failed containers as fake test results, linked to their own scope only
-            startTest(testIdentifier, Collections.singletonList(scopeKey(testIdentifier.getUniqueId())));
-            stopTest(testIdentifier, status, statusDetails);
+            reportContainerFailure(testIdentifier, testExecutionResult);
         }
         getLifecycle().writeScope(scopeKey(testIdentifier.getUniqueId()));
+    }
+
+    /**
+     * Reports a container that finished without success as a run-level error.
+     *
+     * <p>A container is not a test case: a test result standing in for it is counted in the run statistics and,
+     * having a history id no execution ever produces, survives every retry. The platform sends no events for the
+     * children of a container that fails or aborts in a class-level fixture, and even when it does — see
+     * {@link #executionSkipped(TestIdentifier, String)} — the invocations of its templates and factories are not
+     * in the plan, so their results cannot be backfilled with the identity a green run gives them. The failure
+     * itself is kept as an error of the run, next to the fixtures the container's scope already holds.</p>
+     */
+    private void reportContainerFailure(final TestIdentifier testIdentifier,
+                                        final TestExecutionResult testExecutionResult) {
+        final String outcome = testExecutionResult.getStatus() == TestExecutionResult.Status.ABORTED
+                ? "was aborted"
+                : "failed";
+        getLifecycle().writeGlobals(
+                createGlobalError(
+                        String.format(
+                                "Container %s %s, tests inside it did not run",
+                                testIdentifier.getDisplayName(),
+                                outcome
+                        ),
+                        testExecutionResult.getThrowable().orElse(null)
+                )
+        );
     }
 
     /**
@@ -342,14 +367,40 @@ public class AllureJunitPlatform implements TestExecutionListener {
         // only ancestors of the skipped node have running scopes: nodes inside the skipped
         // subtree never start, so their scopes are never registered
         final List<AllureExternalKey> scopeKeys = getParentScopeKeys(testIdentifier);
+        final List<TestIdentifier> unenumerated = new ArrayList<>();
         reportNested(
                 testPlan,
                 testIdentifier,
                 SKIPPED,
                 new StatusDetails().setMessage(reason),
                 new HashSet<>(),
-                scopeKeys
+                scopeKeys,
+                unenumerated
         );
+        if (!unenumerated.isEmpty()) {
+            getLifecycle().writeGlobals(createGlobalError(unenumeratedContext(testIdentifier, unenumerated, reason), null));
+        }
+    }
+
+    /**
+     * Describes a skipped node whose parameterised tests could not be reported: the node itself when it is the
+     * template, the templates inside it otherwise.
+     */
+    private static String unenumeratedContext(final TestIdentifier skipped,
+                                              final List<TestIdentifier> unenumerated,
+                                              final String reason) {
+        final String names = unenumerated.stream()
+                .map(TestIdentifier::getDisplayName)
+                .collect(Collectors.joining(", "));
+        final boolean self = unenumerated.size() == 1 && unenumerated.get(0).equals(skipped);
+        return self
+                ? String.format("%s skipped, and the invocations it would have had are unknown: %s", names, reason)
+                : String.format(
+                        "%s skipped, and the invocations of %s inside it are unknown: %s",
+                        skipped.getDisplayName(),
+                        names,
+                        reason
+                );
     }
 
     /**
@@ -465,21 +516,37 @@ public class AllureJunitPlatform implements TestExecutionListener {
         );
     }
 
+    /**
+     * Reports every test in a skipped subtree as skipped, with the identity it has in a real run, and collects the
+     * containers whose tests cannot be given one.
+     *
+     * <p>A test template or a test factory is a container in the plan whose children — the invocations — only come
+     * into existence when it runs. A skipped one has no children to report, and a result for the container itself
+     * would carry a history id that no invocation ever produces: it would be counted as an extra case, and no green
+     * rerun could replace it. Such containers are collected and reported once, as an error of the run.</p>
+     */
     private void reportNested(final TestPlan testPlan,
                               final TestIdentifier testIdentifier,
                               final Status status,
                               final StatusDetails statusDetails,
                               final Set<TestIdentifier> visited,
-                              final List<AllureExternalKey> scopeKeys) {
+                              final List<AllureExternalKey> scopeKeys,
+                              final List<TestIdentifier> unenumerated) {
         final Set<TestIdentifier> children = testPlan.getChildren(testIdentifier);
-        if (testIdentifier.isTest() || children.isEmpty()) {
+        if (testIdentifier.isTest()) {
             startTest(testIdentifier, scopeKeys);
             stopTest(testIdentifier, status, statusDetails);
+        } else if (children.isEmpty()) {
+            unenumerated.add(testIdentifier);
         }
         visited.add(testIdentifier);
         children.stream()
                 .filter(id -> !visited.contains(id))
-                .forEach(child -> reportNested(testPlan, child, status, statusDetails, visited, scopeKeys));
+                .forEach(
+                        child -> reportNested(
+                                testPlan, child, status, statusDetails, visited, scopeKeys, unenumerated
+                        )
+                );
     }
 
     /**
@@ -673,9 +740,6 @@ public class AllureJunitPlatform implements TestExecutionListener {
                           final StatusDetails statusDetails) {
         final AllureExternalKey testKey = testKey(testIdentifier.getUniqueId());
         getLifecycle().updateTest(testKey, result -> {
-            if (!testIdentifier.isTest()) {
-                result.getLabels().add(new Label().setName(ALLURE_ID_LABEL_NAME).setValue("-1"));
-            }
             result.setStatus(status);
 
             final StatusDetails currentSd = result.getStatusDetails();

--- a/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
+++ b/allure-junit-platform/src/main/java/io/qameta/allure/junitplatform/AllureJunitPlatform.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -148,6 +149,12 @@ public class AllureJunitPlatform implements TestExecutionListener {
     private static final String KARATE_JUNIT6_TEST = "io.karatelabs.junit6.Karate$Test";
 
     private final ThreadLocal<TestPlan> testPlanStorage = new InheritableThreadLocal<>();
+
+    /**
+     * The containers for which at least one descendant test started in the current plan. JUnit Platform may execute
+     * tests in parallel, so execution callbacks update this set concurrently.
+     */
+    private final Set<String> containersWithStartedTests = ConcurrentHashMap.newKeySet();
 
     private final AllureLifecycle lifecycle;
 
@@ -272,6 +279,7 @@ public class AllureJunitPlatform implements TestExecutionListener {
      */
     @Override
     public void testPlanExecutionStarted(final TestPlan testPlan) {
+        containersWithStartedTests.clear();
         testPlanStorage.set(testPlan);
     }
 
@@ -281,6 +289,7 @@ public class AllureJunitPlatform implements TestExecutionListener {
     @Override
     public void testPlanExecutionFinished(final TestPlan testPlan) {
         testPlanStorage.remove();
+        containersWithStartedTests.clear();
     }
 
     /**
@@ -288,6 +297,11 @@ public class AllureJunitPlatform implements TestExecutionListener {
      */
     @Override
     public void executionStarted(final TestIdentifier testIdentifier) {
+        if (testIdentifier.isTest()) {
+            getParents(testIdentifier).stream()
+                    .map(TestIdentifier::getUniqueId)
+                    .forEach(containersWithStartedTests::add);
+        }
         if (shouldSkipReportingFor(testIdentifier)) {
             return;
         }
@@ -332,20 +346,22 @@ public class AllureJunitPlatform implements TestExecutionListener {
      * children of a container that fails or aborts in a class-level fixture, and even when it does — see
      * {@link #executionSkipped(TestIdentifier, String)} — the invocations of its templates and factories are not
      * in the plan, so their results cannot be backfilled with the identity a green run gives them. The failure
-     * itself is kept as an error of the run, next to the fixtures the container's scope already holds.</p>
+     * itself is kept as an error of the run, next to the fixtures the container's scope already holds. The message
+     * only claims the children did not run when no descendant test started; once one did, the wording stays neutral
+     * because the event does not say whether some or all of the children completed.</p>
      */
     private void reportContainerFailure(final TestIdentifier testIdentifier,
                                         final TestExecutionResult testExecutionResult) {
         final String outcome = testExecutionResult.getStatus() == TestExecutionResult.Status.ABORTED
                 ? "was aborted"
                 : "failed";
+        final String context = String.format("Container %s %s", testIdentifier.getDisplayName(), outcome)
+                + (containersWithStartedTests.contains(testIdentifier.getUniqueId())
+                        ? ""
+                        : ", tests inside it did not run");
         getLifecycle().writeGlobals(
                 createGlobalError(
-                        String.format(
-                                "Container %s %s, tests inside it did not run",
-                                testIdentifier.getDisplayName(),
-                                outcome
-                        ),
+                        context,
                         testExecutionResult.getThrowable().orElse(null)
                 )
         );

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -274,8 +274,13 @@ public class AllureJunitPlatformTest {
                 .contains("java.lang.RuntimeException: Exception in @BeforeAll");
     }
 
+    /**
+     * A failed {@code @AfterAll} is reported as an error of the run after the class's tests have kept their results.
+     * Its message must not claim those tests did not run.
+     */
     @Test
     @AllureFeatures.BrokenTests
+    @Description
     void shouldProcessBrokenInAfterAllTests() {
         final AllureResults results = runClasses(BrokenInAfterAllTests.class);
 
@@ -299,7 +304,7 @@ public class AllureJunitPlatformTest {
                 .as("the tests ran and keep their results; the failed after all fixture is an error of the run")
                 .extracting(GlobalError::getMessage)
                 .containsExactly(
-                        "Container BrokenInAfterAllTests failed, tests inside it did not run: Exception in @AfterAll"
+                        "Container BrokenInAfterAllTests failed: Exception in @AfterAll"
                 );
     }
 

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -20,10 +20,13 @@ import io.qameta.allure.Description;
 import io.qameta.allure.Issue;
 import io.qameta.allure.junitplatform.features.ActualExpectedStatusDetailsTests;
 import io.qameta.allure.junitplatform.features.AllureIdAnnotationSupport;
+import io.qameta.allure.junitplatform.features.BrokenBeforeAllInParameterizedClass;
 import io.qameta.allure.junitplatform.features.BrokenInAfterAllTests;
 import io.qameta.allure.junitplatform.features.BrokenInBeforeAllTests;
 import io.qameta.allure.junitplatform.features.BrokenTests;
 import io.qameta.allure.junitplatform.features.DescriptionJavadocTest;
+import io.qameta.allure.junitplatform.features.DisabledClassWithTemplates;
+import io.qameta.allure.junitplatform.features.DisabledParameterizedClass;
 import io.qameta.allure.junitplatform.features.DisabledRepeatedTests;
 import io.qameta.allure.junitplatform.features.DisabledTests;
 import io.qameta.allure.junitplatform.features.DynamicTests;
@@ -70,6 +73,7 @@ import io.qameta.allure.junitplatform.features.TestWithSteps;
 import io.qameta.allure.junitplatform.features.TestWithSystemErr;
 import io.qameta.allure.junitplatform.features.TestWithSystemOut;
 import io.qameta.allure.model.Attachment;
+import io.qameta.allure.model.GlobalError;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Parameter;
@@ -83,6 +87,7 @@ import io.qameta.allure.test.AllureFeatures;
 import io.qameta.allure.test.AllureResults;
 import io.qameta.allure.test.IsolatedLifecycle;
 import io.qameta.allure.test.RunUtils;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -244,22 +249,29 @@ public class AllureJunitPlatformTest {
                 .hasFieldOrProperty("trace");
     }
 
+    /**
+     * A class whose {@code @BeforeAll} throws is reported as an error of the test run, not as a test result: the
+     * platform sends no events for the tests inside it, and a result standing in for the class would be counted in
+     * the run statistics and could never be replaced by a later green run.
+     */
     @Test
     @AllureFeatures.BrokenTests
+    @Description
     void shouldProcessBrokenInBeforeAllTests() {
         final AllureResults results = runClasses(BrokenInBeforeAllTests.class);
 
-        final List<TestResult> testResults = results.getTestResults();
+        assertThat(results.getTestResults())
+                .as("no test case is invented for the failed class")
+                .isEmpty();
 
-        assertThat(testResults)
-                .extracting(
-                        TestResult::getName,
-                        TestResult::getStatus,
-                        tr -> Optional.of(tr).map(TestResult::getStatusDetails).map(StatusDetails::getMessage).orElse(null)
-                )
-                .containsExactlyInAnyOrder(
-                        tuple("BrokenInBeforeAllTests", Status.BROKEN, "Exception in @BeforeAll")
+        final List<GlobalError> globalErrors = getGlobalErrors(results);
+        assertThat(globalErrors)
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Container BrokenInBeforeAllTests failed, tests inside it did not run: Exception in @BeforeAll"
                 );
+        assertThat(globalErrors.get(0).getTrace())
+                .contains("java.lang.RuntimeException: Exception in @BeforeAll");
     }
 
     @Test
@@ -276,12 +288,18 @@ public class AllureJunitPlatformTest {
                         tr -> Optional.of(tr).map(TestResult::getStatusDetails).map(StatusDetails::getMessage).orElse(null)
                 )
                 .containsExactlyInAnyOrder(
-                        tuple("BrokenInAfterAllTests", Status.BROKEN, "Exception in @AfterAll"),
                         tuple("parameterisedTest(String) [1] value = \"a\"", Status.PASSED, null),
                         tuple("parameterisedTest(String) [2] value = \"b\"", Status.PASSED, null),
                         tuple("parameterisedTest(String) [3] value = \"c\"", Status.PASSED, null),
                         tuple("test1()", Status.PASSED, null),
                         tuple("test2()", Status.PASSED, null)
+                );
+
+        assertThat(getGlobalErrors(results))
+                .as("the tests ran and keep their results; the failed after all fixture is an error of the run")
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Container BrokenInAfterAllTests failed, tests inside it did not run: Exception in @AfterAll"
                 );
     }
 
@@ -305,24 +323,26 @@ public class AllureJunitPlatformTest {
                 .hasFieldOrProperty("trace");
     }
 
+    /**
+     * A failed assumption in {@code @BeforeAll} aborts the class container. The platform sends no events for the
+     * tests inside it, so nothing can be reported with the identity of a real run; the abort is an error of the run.
+     */
     @Test
     @AllureFeatures.SkippedTests
+    @Description
     void shouldProcessSkippedInBeforeAllTests() {
         final AllureResults results = runClasses(SkippedInBeforeAllTests.class);
 
-        final List<TestResult> testResults = results.getTestResults();
-        assertThat(testResults)
-                .hasSize(1);
+        assertThat(results.getTestResults())
+                .as("no test case is invented for the aborted class")
+                .isEmpty();
 
-        final TestResult testResult = testResults.get(0);
-        assertThat(testResult)
-                .isNotNull()
-                .hasFieldOrPropertyWithValue("name", "SkippedInBeforeAllTests")
-                .hasFieldOrPropertyWithValue("status", Status.SKIPPED);
-
-        assertThat(testResult.getStatusDetails())
-                .hasFieldOrPropertyWithValue("message", "Assumption failed: Skip in @BeforeAll")
-                .hasFieldOrProperty("trace");
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Container SkippedInBeforeAllTests was aborted, tests inside it did not run: "
+                                + "Assumption failed: Skip in @BeforeAll"
+                );
     }
 
     @Test
@@ -1069,16 +1089,25 @@ public class AllureJunitPlatformTest {
                 );
     }
 
+    /**
+     * A disabled repeated test is a template whose repetitions never come into existence, so no skipped result can be
+     * given the identity a repetition would have had. It is reported as an error of the run rather than as a result
+     * no green rerun could replace.
+     */
     @AllureFeatures.MarkerAnnotations
     @Test
+    @Description
     void shouldSupportDisabledRepeatedTests() {
         final AllureResults results = runClasses(DisabledRepeatedTests.class);
-        final List<TestResult> testResults = results.getTestResults();
-        assertThat(testResults)
-                .hasSize(1)
-                .allMatch(hasStatus(Status.SKIPPED))
-                .allMatch(hasLabel(OWNER_LABEL_NAME, "other guy"));
 
+        assertThat(results.getTestResults())
+                .as("no result is invented for repetitions that never existed")
+                .isEmpty();
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .singleElement(InstanceOfAssertFactories.STRING)
+                .startsWith("first() skipped, and the invocations it would have had are unknown: ");
     }
 
     @AllureFeatures.MarkerAnnotations
@@ -1518,18 +1547,96 @@ public class AllureJunitPlatformTest {
         );
     }
 
+    /**
+     * The failure of a class container carries the original exception into the run-level error, so the cause stays
+     * inspectable in the report even though the platform listener alone cannot see the fixture that threw it — that
+     * evidence comes from the Jupiter extension when it is installed.
+     */
     @Test
     @AllureFeatures.Fixtures
-    void shouldLinkFailedContainerFakeTestToItsScope() {
+    @Description
+    void shouldKeepBrokenBeforeAllCauseInTheGlobalError() {
         final AllureResults results = runClasses(BrokenInBeforeAllTests.class);
 
-        final List<TestResult> testResults = results.getTestResults();
-        assertThat(testResults)
-                .hasSize(1);
+        assertThat(results.getTestResults()).isEmpty();
+        assertThat(getGlobalErrors(results))
+                .singleElement()
+                .satisfies(error -> {
+                    assertThat(error.getTrace()).contains("java.lang.RuntimeException: Exception in @BeforeAll");
+                    assertThat(error.getTrace()).contains("BrokenInBeforeAllTests.exception");
+                    assertThat(error.getTimestamp()).isPositive();
+                });
+    }
 
-        final String uuid = testResults.get(0).getUuid();
-        assertThat(results.getTestResultContainers())
-                .filteredOn(container -> container.getChildren().contains(uuid))
-                .hasSize(1);
+    /**
+     * A disabled class keeps a skipped result for every test the platform can name — plain and nested tests carry
+     * the identity they have in a real run, so a green rerun replaces them — while its templates and factories, whose
+     * invocations never came into existence, are reported once as an error of the run instead of as results whose
+     * identity nothing could ever replace.
+     */
+    @Test
+    @AllureFeatures.SkippedTests
+    @Description
+    void shouldBackfillOnlyEnumerableTestsOfADisabledClass() {
+        final AllureResults results = runClasses(DisabledClassWithTemplates.class);
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactlyInAnyOrder(
+                        tuple("plainTest()", Status.SKIPPED),
+                        tuple("nestedTest()", Status.SKIPPED)
+                );
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .singleElement(InstanceOfAssertFactories.STRING)
+                .startsWith("DisabledClassWithTemplates skipped, and the invocations of ")
+                .contains("parameterisedTest(String)")
+                .contains("dynamicTests()")
+                .endsWith(" inside it are unknown: whole class disabled");
+    }
+
+    /**
+     * A parameterized class is itself a template: its invocations only exist once it runs. When it is disabled,
+     * nothing inside it can be reported with the identity of a real run, and the skip is an error of the run.
+     */
+    @Test
+    @AllureFeatures.SkippedTests
+    @Description
+    void shouldNotInventInvocationsForADisabledParameterizedClass() {
+        final AllureResults results = runClasses(DisabledParameterizedClass.class);
+
+        assertThat(results.getTestResults()).isEmpty();
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "DisabledParameterizedClass skipped, and the invocations it would have had are unknown: "
+                                + "disabled param class"
+                );
+    }
+
+    /**
+     * A parameterized class whose {@code @BeforeAll} throws fails as a container like any other class, and is
+     * reported as an error of the run without a test result standing in for it.
+     */
+    @Test
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldReportBrokenBeforeAllOfAParameterizedClassAsGlobalError() {
+        final AllureResults results = runClasses(BrokenBeforeAllInParameterizedClass.class);
+
+        assertThat(results.getTestResults()).isEmpty();
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Container BrokenBeforeAllInParameterizedClass failed, tests inside it did not run: "
+                                + "param class before all failed"
+                );
+    }
+
+    private static List<GlobalError> getGlobalErrors(final AllureResults results) {
+        return results.getGlobals().stream()
+                .flatMap(globals -> globals.getErrors().stream())
+                .collect(Collectors.toList());
     }
 }

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/BrokenBeforeAllInParameterizedClass.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/BrokenBeforeAllInParameterizedClass.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@ParameterizedClass
+@ValueSource(strings = {"p", "q"})
+public class BrokenBeforeAllInParameterizedClass {
+
+    @Parameter
+    String value;
+
+    @BeforeAll
+    static void beforeAll() {
+        throw new RuntimeException("param class before all failed");
+    }
+
+    @Test
+    void inParamClass() {
+    }
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/DisabledClassWithTemplates.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/DisabledClassWithTemplates.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+@Disabled("whole class disabled")
+public class DisabledClassWithTemplates {
+
+    @Test
+    void plainTest() {
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a", "b"})
+    void parameterisedTest(final String value) {
+    }
+
+    @TestFactory
+    Stream<DynamicTest> dynamicTests() {
+        return Stream.of("x", "y").map(v -> DynamicTest.dynamicTest("dyn " + v, () -> {
+        }));
+    }
+
+    @Nested
+    class Inner {
+
+        @Test
+        void nestedTest() {
+        }
+    }
+}

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/DisabledParameterizedClass.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/features/DisabledParameterizedClass.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junitplatform.features;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@Disabled("disabled param class")
+@ParameterizedClass
+@ValueSource(strings = {"p", "q"})
+public class DisabledParameterizedClass {
+
+    @Parameter
+    String value;
+
+    @Test
+    void inParamClass() {
+    }
+}

--- a/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
+++ b/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
@@ -440,10 +440,11 @@ public class AllureJunit4 extends RunListener {
 
     /**
      * Returns whether the description is the synthetic {@code initializationError} test JUnit 4 reports when a
-     * runner could not be built for a class.
+     * runner could not be built for a class. Unlike an ordinary test whose method happens to have the same name,
+     * the synthetic description carries no framework annotations.
      */
     private static boolean isInitializationError(final Description description) {
-        return INITIALIZATION_ERROR.equals(description.getMethodName());
+        return INITIALIZATION_ERROR.equals(description.getMethodName()) && description.getAnnotations().isEmpty();
     }
 
     private boolean shouldIgnore(final Description description) {

--- a/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
+++ b/allure-junit4/src/main/java/io/qameta/allure/junit4/AllureJunit4.java
@@ -43,6 +43,7 @@ import java.util.stream.Stream;
 import static io.qameta.allure.util.AnnotationUtils.getLabels;
 import static io.qameta.allure.util.AnnotationUtils.getLinks;
 import static io.qameta.allure.util.ResultsUtils.createFrameworkLabel;
+import static io.qameta.allure.util.ResultsUtils.createGlobalError;
 import static io.qameta.allure.util.ResultsUtils.createHostLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
 import static io.qameta.allure.util.ResultsUtils.createPackageLabel;
@@ -62,10 +63,15 @@ import static io.qameta.allure.util.ResultsUtils.md5;
  * Allure Junit4 listener.
  */
 @RunListener.ThreadSafe
-@SuppressWarnings({"checkstyle:ClassFanOutComplexity"})
+@SuppressWarnings({"checkstyle:ClassFanOutComplexity", "PMD.GodClass"})
 public class AllureJunit4 extends RunListener {
 
     private static final boolean HAS_CUCUMBERJVM7_IN_CLASSPATH = isClassAvailableOnClasspath("io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm");
+
+    /**
+     * The method name JUnit 4 gives the synthetic test it reports when a runner cannot be built for a class.
+     */
+    private static final String INITIALIZATION_ERROR = "initializationError";
 
     private final AllureLifecycle lifecycle;
 
@@ -115,7 +121,7 @@ public class AllureJunit4 extends RunListener {
      */
     @Override
     public void testStarted(final Description description) {
-        if (shouldIgnore(description)) {
+        if (shouldIgnore(description) || isInitializationError(description)) {
             return;
         }
         final AllureExternalKey testKey = getTestKey(description);
@@ -130,7 +136,7 @@ public class AllureJunit4 extends RunListener {
      */
     @Override
     public void testFinished(final Description description) {
-        if (shouldIgnore(description)) {
+        if (shouldIgnore(description) || isInitializationError(description)) {
             return;
         }
         final AllureExternalKey testKey = getTestKey(description);
@@ -151,6 +157,9 @@ public class AllureJunit4 extends RunListener {
         if (shouldIgnore(failure.getDescription())) {
             return;
         }
+        if (reportRunFailure(failure, "failed")) {
+            return;
+        }
         final AllureExternalKey testKey = getTestKey(failure.getDescription());
         getLifecycle().updateTest(
                 testKey, testResult -> {
@@ -166,6 +175,9 @@ public class AllureJunit4 extends RunListener {
     @Override
     public void testAssumptionFailure(final Failure failure) {
         if (shouldIgnore(failure.getDescription())) {
+            return;
+        }
+        if (reportRunFailure(failure, "was skipped by an assumption")) {
             return;
         }
         final AllureExternalKey testKey = getTestKey(failure.getDescription());
@@ -377,6 +389,61 @@ public class AllureJunit4 extends RunListener {
                 .map(DisplayName::value).orElse(className);
 
         return List.of(createSuiteLabel(suite));
+    }
+
+    /**
+     * Reports a failure that belongs to the run rather than to a test as a run-level error, and returns whether it
+     * did.
+     *
+     * <p>JUnit 4 sends two kinds of failure no test result can stand in for. A class-level failure — a
+     * {@code @BeforeClass}, {@code @AfterClass} or {@code @ClassRule} that threw, or a {@code @BeforeClass}
+     * assumption — arrives on the description of the class itself, with no events for the tests a before failure
+     * prevented;
+     * an {@code initializationError} — an invalid test class, or a {@code Parameterized} class whose parameters
+     * method threw — arrives as a synthetic test with that name. A test result written for either is counted in the
+     * run statistics under an identity no green run ever produces, so no retry could ever replace it. Nothing else
+     * is backfilled either: JUnit 4 does not name the tests a class-level failure prevented, and a class whose
+     * runner failed to initialise never enumerated them.</p>
+     */
+    private boolean reportRunFailure(final Failure failure, final String outcome) {
+        final Description description = failure.getDescription();
+        final String context;
+        if (isInitializationError(description)) {
+            context = String.format(
+                    "Test class %s could not be initialized, its tests did not run",
+                    description.getClassName()
+            );
+        } else if (isClassLevel(description)) {
+            // JUnit 4 reports @BeforeClass, @AfterClass and @ClassRule failures on the same class description,
+            // so whether the class's tests ran cannot be told from the event: an after failure comes once
+            // they all have, a before failure before any of them. Name the count without claiming either.
+            context = String.format(
+                    "Test class %s %s outside its %d tests",
+                    description.getClassName(),
+                    outcome,
+                    description.testCount()
+            );
+        } else {
+            return false;
+        }
+        getLifecycle().writeGlobals(createGlobalError(context, failure.getException()));
+        return true;
+    }
+
+    /**
+     * Returns whether the description names a class rather than a test in it: a class-level fixture or rule
+     * failure is reported on such a description, with no method name.
+     */
+    private static boolean isClassLevel(final Description description) {
+        return description.isSuite() && Objects.isNull(description.getMethodName());
+    }
+
+    /**
+     * Returns whether the description is the synthetic {@code initializationError} test JUnit 4 reports when a
+     * runner could not be built for a class.
+     */
+    private static boolean isInitializationError(final Description description) {
+        return INITIALIZATION_ERROR.equals(description.getMethodName());
     }
 
     private boolean shouldIgnore(final Description description) {

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
@@ -15,9 +15,15 @@
  */
 package io.qameta.allure.junit4;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Step;
 import io.qameta.allure.junit4.samples.ActualExpectedStatusDetailsTest;
 import io.qameta.allure.junit4.samples.AssumptionFailedTest;
+import io.qameta.allure.junit4.samples.AssumptionInBeforeClassTest;
+import io.qameta.allure.junit4.samples.BrokenAfterClassTest;
+import io.qameta.allure.junit4.samples.BrokenBeforeClassTest;
+import io.qameta.allure.junit4.samples.BrokenClassRuleTest;
+import io.qameta.allure.junit4.samples.BrokenParametersTest;
 import io.qameta.allure.junit4.samples.BrokenTest;
 import io.qameta.allure.junit4.samples.BrokenWithoutMessageTest;
 import io.qameta.allure.junit4.samples.DescriptionsJavadoc;
@@ -27,6 +33,7 @@ import io.qameta.allure.junit4.samples.FlakyMutedOnClassTest;
 import io.qameta.allure.junit4.samples.FlakyMutedTest;
 import io.qameta.allure.junit4.samples.IgnoredClassTest;
 import io.qameta.allure.junit4.samples.IgnoredTests;
+import io.qameta.allure.junit4.samples.InvalidTestClass;
 import io.qameta.allure.junit4.samples.MetaAnnotationTest;
 import io.qameta.allure.junit4.samples.OneTest;
 import io.qameta.allure.junit4.samples.RuntimeParametersTest;
@@ -37,6 +44,7 @@ import io.qameta.allure.junit4.samples.TestWithAnnotations;
 import io.qameta.allure.junit4.samples.TestWithSteps;
 import io.qameta.allure.junit4.samples.TestWithTimeout;
 import io.qameta.allure.junit4.samples.TheoriesTest;
+import io.qameta.allure.model.GlobalError;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Parameter;
@@ -51,12 +59,14 @@ import io.qameta.allure.test.IsolatedLifecycle;
 import io.qameta.allure.test.RunUtils;
 import io.qameta.allure.testfilter.TestPlan;
 import io.qameta.allure.testfilter.TestPlanV1_0;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static io.qameta.allure.junit4.samples.TaggedTests.CLASS_TAG1;
 import static io.qameta.allure.junit4.samples.TaggedTests.CLASS_TAG2;
@@ -605,5 +615,136 @@ class AllureJunit4Test {
 
             core.run(request);
         });
+    }
+
+    /**
+     * A {@code @BeforeClass} that throws used to vanish from the report: JUnit 4 reports it on the class itself,
+     * with no events for the tests it prevented, and no test result was ever written. It is now an error of the run
+     * that names the class, the count of tests inside it, and the cause.
+     */
+    @Test
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldReportBrokenBeforeClassAsGlobalError() {
+        final AllureResults results = runClasses(BrokenBeforeClassTest.class);
+
+        assertThat(results.getTestResults())
+                .as("JUnit 4 names no tests for a failed before class, so none can be backfilled")
+                .isEmpty();
+
+        final List<GlobalError> globalErrors = getGlobalErrors(results);
+        assertThat(globalErrors)
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Test class io.qameta.allure.junit4.samples.BrokenBeforeClassTest failed outside its 2 tests: "
+                                + "before class failed"
+                );
+        assertThat(globalErrors.get(0).getTrace()).contains("java.lang.RuntimeException: before class failed");
+    }
+
+    /**
+     * A failed assumption in {@code @BeforeClass} is reported the same way, worded as a skip rather than a failure.
+     */
+    @Test
+    @AllureFeatures.SkippedTests
+    @Description
+    void shouldReportAssumptionInBeforeClassAsGlobalError() {
+        final AllureResults results = runClasses(AssumptionInBeforeClassTest.class);
+
+        assertThat(results.getTestResults()).isEmpty();
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Test class io.qameta.allure.junit4.samples.AssumptionInBeforeClassTest was skipped by an "
+                                + "assumption outside its 1 tests: environment not ready"
+                );
+    }
+
+    /**
+     * A {@code @ClassRule} that throws is reported on the class like a before class failure.
+     */
+    @Test
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldReportBrokenClassRuleAsGlobalError() {
+        final AllureResults results = runClasses(BrokenClassRuleTest.class);
+
+        assertThat(results.getTestResults()).isEmpty();
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Test class io.qameta.allure.junit4.samples.BrokenClassRuleTest failed outside its 1 tests: "
+                                + "class rule failed"
+                );
+    }
+
+    /**
+     * A {@code @AfterClass} that throws is reported on the same class description as a before class failure, once
+     * the tests have run and kept their results. The message claims nothing about whether they ran.
+     */
+    @Test
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldKeepPassedTestsWhenAfterClassIsBroken() {
+        final AllureResults results = runClasses(BrokenAfterClassTest.class);
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("first", Status.PASSED));
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Test class io.qameta.allure.junit4.samples.BrokenAfterClassTest failed outside its 1 tests: "
+                                + "after class failed"
+                );
+    }
+
+    /**
+     * A {@code Parameterized} class whose parameters method throws never enumerated its cases. JUnit 4 reports a
+     * synthetic {@code initializationError} test for it, whose identity matches none of the cases a green run
+     * produces; it is reported as an error of the run instead of as a result no rerun could replace.
+     */
+    @Test
+    @AllureFeatures.Parameters
+    @Description
+    void shouldNotInventInitializationErrorForBrokenParametersMethod() {
+        final AllureResults results = runClasses(BrokenParametersTest.class);
+
+        assertThat(results.getTestResults())
+                .as("the synthetic initializationError test is not a test case")
+                .isEmpty();
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Test class io.qameta.allure.junit4.samples.BrokenParametersTest could not be initialized, "
+                                + "its tests did not run: parameters method failed"
+                );
+    }
+
+    /**
+     * An invalid test class is reported through the same synthetic {@code initializationError} test and becomes an
+     * error of the run carrying JUnit's explanation of what is invalid.
+     */
+    @Test
+    @AllureFeatures.BrokenTests
+    @Description
+    void shouldNotInventInitializationErrorForInvalidTestClass() {
+        final AllureResults results = runClasses(InvalidTestClass.class);
+
+        assertThat(results.getTestResults()).isEmpty();
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .singleElement(InstanceOfAssertFactories.STRING)
+                .startsWith(
+                        "Test class io.qameta.allure.junit4.samples.InvalidTestClass could not be initialized, "
+                                + "its tests did not run: "
+                )
+                .contains("Method bad should have no parameters");
+    }
+
+    private static List<GlobalError> getGlobalErrors(final AllureResults results) {
+        return results.getGlobals().stream()
+                .flatMap(globals -> globals.getErrors().stream())
+                .collect(Collectors.toList());
     }
 }

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
@@ -28,6 +28,7 @@ import io.qameta.allure.junit4.samples.BrokenTest;
 import io.qameta.allure.junit4.samples.BrokenWithoutMessageTest;
 import io.qameta.allure.junit4.samples.DescriptionsJavadoc;
 import io.qameta.allure.junit4.samples.FailedTest;
+import io.qameta.allure.junit4.samples.FailedTestNamedInitializationError;
 import io.qameta.allure.junit4.samples.FilterSimpleTests;
 import io.qameta.allure.junit4.samples.FlakyMutedOnClassTest;
 import io.qameta.allure.junit4.samples.FlakyMutedTest;
@@ -697,6 +698,27 @@ class AllureJunit4Test {
                         "Test class io.qameta.allure.junit4.samples.BrokenAfterClassTest failed outside its 1 tests: "
                                 + "after class failed"
                 );
+    }
+
+    /**
+     * An ordinary test is still a test when its legal method name matches JUnit 4's reserved name for synthetic
+     * runner failures. Its failure stays attached to the test and does not become an initialization error of the
+     * run.
+     */
+    @Test
+    @AllureFeatures.FailedTests
+    @Description
+    void shouldReportOrdinaryTestNamedInitializationError() {
+        final AllureResults results = runClasses(FailedTestNamedInitializationError.class);
+
+        assertThat(results.getTestResults())
+                .extracting(
+                        TestResult::getName,
+                        TestResult::getStatus,
+                        result -> result.getStatusDetails().getMessage()
+                )
+                .containsExactly(tuple("initializationError", Status.FAILED, "ordinary test failed"));
+        assertThat(getGlobalErrors(results)).isEmpty();
     }
 
     /**

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/AssumptionInBeforeClassTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/AssumptionInBeforeClassTest.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AssumptionInBeforeClassTest {
+
+    @BeforeClass
+    public static void setUp() {
+        Assume.assumeTrue("environment not ready", false);
+    }
+
+    @Test
+    public void first() {
+    }
+}

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/BrokenAfterClassTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/BrokenAfterClassTest.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+
+public class BrokenAfterClassTest {
+
+    @AfterClass
+    public static void tearDown() {
+        throw new RuntimeException("after class failed");
+    }
+
+    @Test
+    public void first() {
+    }
+}

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/BrokenBeforeClassTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/BrokenBeforeClassTest.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class BrokenBeforeClassTest {
+
+    @BeforeClass
+    public static void setUp() {
+        throw new RuntimeException("before class failed");
+    }
+
+    @Test
+    public void first() {
+    }
+
+    @Test
+    public void second() {
+    }
+}

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/BrokenClassRuleTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/BrokenClassRuleTest.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+
+public class BrokenClassRuleTest {
+
+    @ClassRule
+    public static final ExternalResource RESOURCE = new ExternalResource() {
+        @Override
+        protected void before() {
+            throw new RuntimeException("class rule failed");
+        }
+    };
+
+    @Test
+    public void first() {
+    }
+}

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/BrokenParametersTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/BrokenParametersTest.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class BrokenParametersTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        throw new RuntimeException("parameters method failed");
+    }
+
+    public BrokenParametersTest(final String value) {
+    }
+
+    @Test
+    public void param() {
+    }
+}

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/FailedTestNamedInitializationError.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/FailedTestNamedInitializationError.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+public class FailedTestNamedInitializationError {
+
+    @Test
+    public void initializationError() {
+        fail("ordinary test failed");
+    }
+}

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/InvalidTestClass.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/InvalidTestClass.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.junit4.samples;
+
+import org.junit.Test;
+
+/**
+ * A test method with a parameter is invalid in JUnit 4: the runner cannot be built and reports an
+ * {@code initializationError} instead.
+ */
+public class InvalidTestClass {
+
+    @Test
+    public void bad(final String parameter) {
+    }
+}

--- a/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
+++ b/allure-spock2/src/main/java/io/qameta/allure/spock2/AllureSpock2.java
@@ -64,8 +64,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static io.qameta.allure.util.ResultsUtils.ALLURE_ID_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.createFrameworkLabel;
+import static io.qameta.allure.util.ResultsUtils.createGlobalError;
 import static io.qameta.allure.util.ResultsUtils.createHostLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
 import static io.qameta.allure.util.ResultsUtils.createPackageLabel;
@@ -93,6 +93,7 @@ import static io.qameta.allure.util.ResultsUtils.md5;
 public class AllureSpock2 extends AbstractRunListener implements IGlobalExtension, IBlockListener {
 
     private static final String BLOCK = "block";
+    private static final String LIST_SEPARATOR = ", ";
 
     private final ThreadLocal<String> testResults = new ThreadLocal<>();
 
@@ -313,31 +314,35 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         return defaultLabels;
     }
 
+    /**
+     * Reports a failed {@code setupSpec} as an error of the run, and the features it prevented as skipped where
+     * their identity can be known.
+     *
+     * <p>The fixture itself is not a test case: a result standing in for it is counted in the run statistics and,
+     * having a history id no execution ever produces, survives every retry. It stays in the spec scope as a broken
+     * fixture, and the failure becomes a run-level error.</p>
+     *
+     * <p>Spock reports nothing for the features of a spec whose {@code setupSpec} failed, so they are backfilled
+     * here from the spec's own list. A plain feature can be given the identity it has in a real run. A data-driven
+     * feature cannot: its iterations, and the values that tell them apart, only exist once the feature runs, and a
+     * result for the feature itself would carry a history id no iteration ever produces. Such features are named
+     * in the run-level error instead.</p>
+     */
     private void reportSetupSpecFailure(final IMethodInvocation invocation,
                                         final String containerUuid,
-                                        final String fixtureName,
                                         final Throwable throwable) {
         final StatusDetails failureDetails = getStatusDetails(throwable).orElse(null);
         final SpecInfo fixtureSpec = invocation.getSpec();
-        final TestResult configurationResult = createTestResult(
-                fixtureSpec,
-                invocation.getMethod().getReflection(),
-                Collections.emptySet(),
-                fixtureName,
-                fixtureName,
-                fixtureName,
-                Collections.emptyList()
-        ).setStatus(getStatus(throwable).orElse(Status.BROKEN));
-        configurationResult.getLabels().add(
-                new Label().setName(ALLURE_ID_LABEL_NAME).setValue("-1")
-        );
-        copyFailureDetails(failureDetails, configurationResult.getStatusDetails());
-        writeCompletedTest(containerUuid, configurationResult, fixtureSpec);
+        final List<String> dataDriven = new ArrayList<>();
 
         fixtureSpec.getBottomSpec().getAllFeaturesInExecutionOrder().stream()
                 .filter(feature -> !feature.isExcluded())
                 .filter(feature -> !feature.isSkipped())
                 .forEach(feature -> {
+                    if (feature.isParameterized()) {
+                        dataDriven.add(feature.getDisplayName());
+                        return;
+                    }
                     final TestResult skippedResult = createTestResult(
                             feature,
                             feature.getName(),
@@ -353,6 +358,29 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
                     );
                     writeCompletedTest(containerUuid, skippedResult, feature.getSpec());
                 });
+
+        final String context = dataDriven.isEmpty()
+                ? String.format("setup spec of %s failed, its features did not run", fixtureSpec.getName())
+                : String.format(
+                        "setup spec of %s failed, its features did not run, "
+                                + "and the iterations of %s are unknown",
+                        fixtureSpec.getName(),
+                        String.join(LIST_SEPARATOR, dataDriven)
+                );
+        getLifecycle().writeGlobals(createGlobalError(context, throwable));
+    }
+
+    /**
+     * Reports a failed {@code cleanupSpec} as an error of the run. Its features have already run and keep their
+     * results; the failure would otherwise be visible only as a broken fixture in the spec scope.
+     */
+    private void reportCleanupSpecFailure(final IMethodInvocation invocation, final Throwable throwable) {
+        getLifecycle().writeGlobals(
+                createGlobalError(
+                        String.format("cleanup spec of %s failed", invocation.getSpec().getName()),
+                        throwable
+                )
+        );
     }
 
     private void copyFailureDetails(final StatusDetails source, final StatusDetails target) {
@@ -583,7 +611,7 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
         final String description = texts.stream()
                 .filter(Objects::nonNull)
                 .map(text -> resolveBlockText(iteration, text))
-                .collect(Collectors.joining(", "));
+                .collect(Collectors.joining(LIST_SEPARATOR));
         return description.isEmpty() ? kind : kind + ": " + description;
     }
 
@@ -757,7 +785,9 @@ public class AllureSpock2 extends AbstractRunListener implements IGlobalExtensio
 
             if (Objects.nonNull(failure)) {
                 if (MethodKind.SETUP_SPEC.equals(kind)) {
-                    reportSetupSpecFailure(invocation, containerUuid, fixtureName, failure);
+                    reportSetupSpecFailure(invocation, containerUuid, failure);
+                } else if (MethodKind.CLEANUP_SPEC.equals(kind)) {
+                    reportCleanupSpecFailure(invocation, failure);
                 }
                 throw ExceptionUtils.sneakyThrow(failure);
             }

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
@@ -15,9 +15,11 @@
  */
 package io.qameta.allure.spock2;
 
+import io.qameta.allure.Description;
 import io.qameta.allure.Step;
 import io.qameta.allure.model.ExecutableItem;
 import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.GlobalError;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Parameter;
@@ -35,6 +37,7 @@ import io.qameta.allure.spock2.samples.FailedCleanup;
 import io.qameta.allure.spock2.samples.FailedCleanupSpec;
 import io.qameta.allure.spock2.samples.FailedSetup;
 import io.qameta.allure.spock2.samples.FailedSetupSpec;
+import io.qameta.allure.spock2.samples.FailedSetupSpecDataDrivenOnly;
 import io.qameta.allure.spock2.samples.FailedTest;
 import io.qameta.allure.spock2.samples.FailedTestWithAnnotations;
 import io.qameta.allure.spock2.samples.FixturesTest;
@@ -659,7 +662,14 @@ class AllureSpock2Test {
                 );
     }
 
+    /**
+     * A failed {@code setupSpec} is reported as an error of the run rather than as a test result. The plain feature
+     * it prevented is backfilled as skipped with the identity it has in a real run, so a green rerun replaces it.
+     * The data-driven feature is not: its iterations only exist once it runs, and a result for the feature itself
+     * would carry an identity no iteration ever produces. It is named in the run-level error instead.
+     */
     @Test
+    @Description
     void shouldReportSetupSpecFixtureFailureAndSkippedFeatures() {
         final AllureResults results = runClasses(FailedSetupSpec.class);
 
@@ -669,25 +679,20 @@ class AllureSpock2Test {
                         TestResult::getStatus,
                         result -> result.getStatusDetails().getMessage()
                 )
-                .containsExactlyInAnyOrder(
-                        tuple("setup spec", Status.BROKEN, "setup spec: exception"),
+                .containsExactly(
                         tuple(
                                 "regular feature",
-                                Status.SKIPPED,
-                                "Skipped because setup spec failed: setup spec: exception"
-                        ),
-                        tuple(
-                                "data feature",
                                 Status.SKIPPED,
                                 "Skipped because setup spec failed: setup spec: exception"
                         )
                 );
 
-        final TestResult dataFeature = results.getTestResults().stream()
-                .filter(result -> "data feature".equals(result.getName()))
-                .findFirst()
-                .orElseThrow(() -> new AssertionError("can't find the data feature"));
-        assertThat(dataFeature.getParameters()).isEmpty();
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "setup spec of FailedSetupSpec failed, its features did not run, "
+                                + "and the iterations of data feature are unknown: setup spec: exception"
+                );
 
         final TestResultContainer specContainer = results.getTestResultContainers().stream()
                 .filter(
@@ -808,9 +813,18 @@ class AllureSpock2Test {
         assertThat(fixtureContainer.getChildren()).containsExactly(testResult.getUuid());
     }
 
+    /**
+     * A failed {@code cleanupSpec} keeps its broken fixture in the spec scope and its feature's passed result, and
+     * is also an error of the run — before, the failure was visible only to a reader who opened the fixture.
+     */
     @Test
+    @Description
     void shouldReportCleanupSpecFixtureFailure() {
         final AllureResults results = runClasses(FailedCleanupSpec.class);
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly("cleanup spec of FailedCleanupSpec failed: cleanup spec: exception");
 
         assertThat(results.getTestResults()).hasSize(1);
         final TestResult testResult = results.getTestResults().get(0);
@@ -847,7 +861,12 @@ class AllureSpock2Test {
         assertThat(fixtureContainer.getChildren()).containsExactly(testResult.getUuid());
     }
 
+    /**
+     * The backfill respects the test plan: only the selected plain feature is reported as skipped, and the
+     * deselected data-driven feature is neither backfilled nor named in the run-level error.
+     */
     @Test
+    @Description
     void shouldReportOnlySelectedFeaturesWhenSetupSpecFails() {
         final TestPlanV1_0 plan = new TestPlanV1_0().setTests(
                 Collections.singletonList(new TestPlanV1_0.TestCase().setId("1"))
@@ -857,9 +876,12 @@ class AllureSpock2Test {
 
         assertThat(results.getTestResults())
                 .extracting(TestResult::getName, TestResult::getStatus)
-                .containsExactlyInAnyOrder(
-                        tuple("setup spec", Status.BROKEN),
-                        tuple("regular feature", Status.SKIPPED)
+                .containsExactly(tuple("regular feature", Status.SKIPPED));
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "setup spec of FailedSetupSpec failed, its features did not run: setup spec: exception"
                 );
     }
 
@@ -1100,4 +1122,31 @@ class AllureSpock2Test {
                 .orElseThrow(() -> new AssertionError("can't find the name parameter"));
     }
 
+    /**
+     * When every feature of a spec whose {@code setupSpec} failed is data-driven, nothing can be backfilled with the
+     * identity of a real run, and the run-level error names them all.
+     */
+    @Test
+    @Description
+    void shouldNotInventIterationsForDataDrivenFeaturesWhenSetupSpecFails() {
+        final AllureResults results = runClasses(FailedSetupSpecDataDrivenOnly.class);
+
+        assertThat(results.getTestResults())
+                .as("no result is invented for iterations that never existed")
+                .isEmpty();
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "setup spec of FailedSetupSpecDataDrivenOnly failed, its features did not run, "
+                                + "and the iterations of data feature, unrolled feature #value are unknown: "
+                                + "setup spec: exception"
+                );
+    }
+
+    private static List<GlobalError> getGlobalErrors(final AllureResults results) {
+        return results.getGlobals().stream()
+                .flatMap(globals -> globals.getErrors().stream())
+                .collect(Collectors.toList());
+    }
 }

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedSetupSpecDataDrivenOnly.groovy
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/FailedSetupSpecDataDrivenOnly.groovy
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.spock2.samples
+
+import spock.lang.Specification
+
+class FailedSetupSpecDataDrivenOnly extends Specification {
+
+    def setupSpec() {
+        throw new RuntimeException("setup spec: exception")
+    }
+
+    def "data feature"() {
+        expect:
+        value > 0
+
+        where:
+        value << [1, 2]
+    }
+
+    def "unrolled feature #value"() {
+        expect:
+        value > 0
+
+        where:
+        value << [3, 4]
+    }
+}

--- a/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
+++ b/allure-testng/src/main/java/io/qameta/allure/testng/AllureTestNg.java
@@ -49,6 +49,7 @@ import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
+import org.testng.SkipException;
 import org.testng.TestRunner;
 import org.testng.annotations.Parameters;
 import org.testng.internal.ConstructorOrMethod;
@@ -76,8 +77,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.qameta.allure.util.ResultsUtils.ALLURE_ID_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.createFrameworkLabel;
+import static io.qameta.allure.util.ResultsUtils.createGlobalError;
 import static io.qameta.allure.util.ResultsUtils.createHostLabel;
 import static io.qameta.allure.util.ResultsUtils.createLanguageLabel;
 import static io.qameta.allure.util.ResultsUtils.createPackageLabel;
@@ -122,6 +123,11 @@ public class AllureTestNg
     private static final Logger LOGGER = LoggerFactory.getLogger(AllureTestNg.class);
 
     private static final String ALLURE_UUID = "ALLURE_UUID";
+    /**
+     * How far the cause chain of a failure is walked when looking for the intent behind it.
+     */
+    private static final int MAX_CAUSE_DEPTH = 10;
+
     private static final List<Class<?>> INJECTED_TYPES = Arrays.asList(
             ITestContext.class, ITestResult.class, XmlTest.class, Method.class, Object[].class
     );
@@ -568,6 +574,10 @@ public class AllureTestNg
             return;
         }
 
+        if (reportUnknownInvocations(result)) {
+            return;
+        }
+
         final String uuid = ensureTestStarted(result);
         final Throwable throwable = result.getThrowable();
         final Status status = getStatus(throwable);
@@ -588,8 +598,83 @@ public class AllureTestNg
             return;
         }
 
+        if (reportUnknownInvocations(result)) {
+            return;
+        }
+
         final String uuid = ensureTestStarted(result);
         stopTest(uuid, result.getThrowable(), Status.SKIPPED);
+    }
+
+    /**
+     * Reports a parameterised test method that ended without the values of an invocation as a run-level error,
+     * and returns whether it did.
+     *
+     * <p>TestNG ends such a method once, with no parameters, whenever its values were never produced: the data
+     * provider itself failed, or a failed dependency or fixture kept it from running at all. The number of
+     * invocations and their values are exactly what is unknown, so a test result built from that end has a history
+     * id that no successful run ever produces — it is counted as an extra case, and no later green run can replace
+     * it.</p>
+     *
+     * <p>The method's own declaration is what tells whether its identity depends on values: a method that declares
+     * a parameter TestNG does not inject can only ever run with values for it, wherever they come from — a data
+     * provider on the method, one on the class it inherits, or the suite XML. {@link ITestNGMethod#isDataDriven()}
+     * is deliberately not consulted: it reads the method-level annotation alone, and reports false for a method
+     * that inherits its provider from a class-level {@code @Test}.</p>
+     *
+     * <p>A method that carries values is left alone: each result has the identity the invocation would have had and
+     * a green rerun replaces it. So is a method that declares no such parameters, whose identity does not depend on
+     * any value, and one whose provider skipped it on purpose: a deliberate skip is an outcome the user asked for,
+     * not a failure to produce values, and reporting it as an error of the run would be exactly the misleading
+     * statistic this reporting avoids.</p>
+     *
+     * <p>Called from every terminal callback such a method can reach: TestNG skips it by default, and reports it as
+     * a failure when configured to propagate data provider failures as test failures.</p>
+     */
+    private boolean reportUnknownInvocations(final ITestResult result) {
+        final ITestNGMethod method = result.getMethod();
+        final boolean valuesUnknown = result.getParameters().length == 0
+                && declaresValueParameters(method);
+        if (!valuesUnknown || isIntentionalSkip(result.getThrowable())) {
+            return false;
+        }
+        getLifecycle().writeGlobals(
+                createGlobalError(
+                        String.format(
+                                "Parameterised test %s did not run, and the values of the invocations it would "
+                                        + "have had are unknown",
+                                getQualifiedName(method)
+                        ),
+                        result.getThrowable()
+                )
+        );
+        return true;
+    }
+
+    /**
+     * Returns whether the method declares at least one parameter that TestNG does not inject on its own, and so
+     * needs values from a data provider, a factory, or the suite XML to run at all.
+     */
+    private boolean declaresValueParameters(final ITestNGMethod method) {
+        return getMethod(method)
+                .map(m -> Stream.of(m.getParameterTypes()).anyMatch(type -> !INJECTED_TYPES.contains(type)))
+                .orElse(false);
+    }
+
+    /**
+     * Returns whether the given failure is a deliberate skip. TestNG wraps a {@link SkipException} thrown by a data
+     * provider in a plain runtime exception, so the intent is only visible through the cause chain. The chain is
+     * walked to a bounded depth, so a self-referencing or cyclic cause cannot spin.
+     */
+    private static boolean isIntentionalSkip(final Throwable throwable) {
+        Throwable current = throwable;
+        for (int depth = 0; nonNull(current) && depth < MAX_CAUSE_DEPTH; depth++) {
+            if (current instanceof SkipException && ((SkipException) current).isSkip()) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
     }
 
     /**
@@ -793,38 +878,45 @@ public class AllureTestNg
         //do nothing
     }
 
+    /**
+     * Reports a failed configuration method as a run-level error rather than as a test result.
+     *
+     * <p>The configuration method is not a test case: a test result standing in for it is counted in the run
+     * statistics and, having a history id no execution ever produces, survives every retry. The tests the failure
+     * prevented are reported by TestNG itself through {@link #onTestSkipped(ITestResult)}, with their real
+     * parameters, so they keep their own identity and a later green run replaces them.</p>
+     */
     @Override
     public void onConfigurationFailure(final ITestResult itr) {
         if (config.isHideConfigurationFailures()) {
             return; //do nothing
         }
 
-        final String uuid = UUID.randomUUID().toString();
-        final String parentUuid = UUID.randomUUID().toString();
-
-        startTest(itr, parentUuid, uuid);
-
-        linkTestToScope(getUniqueUuid(itr.getTestContext()), uuid);
-        linkTestToScope(getUniqueUuid(itr.getTestContext().getSuite()), uuid);
-        linkTestToScope(
-                getOrCreateClassScope(itr.getTestContext(), itr.getMethod().getTestClass(), itr.getInstance()),
-                uuid
-        );
-        if (itr.getMethod().isBeforeGroupsConfiguration()) {
-            linkTestToScope(getOrCreateGroupsScope(itr.getTestContext(), itr.getMethod().getBeforeGroups()), uuid);
-        }
-        if (itr.getMethod().isAfterGroupsConfiguration()) {
-            linkTestToScope(getOrCreateGroupsScope(itr.getTestContext(), itr.getMethod().getAfterGroups()), uuid);
-        }
-        // results created for configuration failure should not be considered as test cases.
-        getLifecycle().updateTest(
-                testKey(uuid),
-                tr -> tr.getLabels().add(
-                        new Label().setName(ALLURE_ID_LABEL_NAME).setValue("-1")
+        final ITestNGMethod method = itr.getMethod();
+        final String context = isBeforeConfiguration(method)
+                ? String.format(
+                        "Configuration method %s failed, tests depending on it did not run",
+                        getQualifiedName(method)
                 )
-        );
+                : String.format(
+                        "After configuration method %s failed",
+                        getQualifiedName(method)
+                );
 
-        stopTest(uuid, itr.getThrowable(), getStatus(itr.getThrowable()));
+        getLifecycle().writeGlobals(createGlobalError(context, itr.getThrowable()));
+    }
+
+    /**
+     * Returns whether the given configuration method runs before the tests it belongs to, and so keeps them from
+     * running when it fails. The failure of an after configuration method is reported without claiming anything
+     * about whether its tests ran: an {@code alwaysRun} after method also runs for a test that a failed before
+     * fixture already skipped.
+     */
+    @SuppressWarnings("BooleanExpressionComplexity")
+    private static boolean isBeforeConfiguration(final ITestNGMethod method) {
+        return method.isBeforeSuiteConfiguration() || method.isBeforeTestConfiguration()
+                || method.isBeforeClassConfiguration() || method.isBeforeGroupsConfiguration()
+                || method.isBeforeMethodConfiguration();
     }
 
     @Override

--- a/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
@@ -16,17 +16,18 @@
 package io.qameta.allure.testng;
 
 import io.qameta.allure.AllureLifecycle;
+import io.qameta.allure.Description;
 import io.qameta.allure.Issue;
 import io.qameta.allure.Param;
 import io.qameta.allure.Step;
 import io.qameta.allure.model.Attachment;
 import io.qameta.allure.model.FixtureResult;
+import io.qameta.allure.model.GlobalError;
 import io.qameta.allure.model.Label;
 import io.qameta.allure.model.Link;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Stage;
 import io.qameta.allure.model.Status;
-import io.qameta.allure.model.StatusDetails;
 import io.qameta.allure.model.StepResult;
 import io.qameta.allure.model.TestResult;
 import io.qameta.allure.model.TestResultContainer;
@@ -40,11 +41,15 @@ import io.qameta.allure.testfilter.TestPlan;
 import io.qameta.allure.testfilter.TestPlanV1_0;
 import io.qameta.allure.testng.config.AllureTestNgConfig;
 import io.qameta.allure.testng.samples.CustomListenerAttachments;
+import io.qameta.allure.testng.samples.FailedBeforeClassWithDataProvider;
+import io.qameta.allure.testng.samples.FailedDependency;
+import io.qameta.allure.testng.samples.InheritedDataProviderDependency;
 import io.qameta.allure.testng.samples.PriorityTests;
 import io.qameta.allure.testng.samples.RuntimeParametersTest;
 import io.qameta.allure.testng.samples.SuccessPercentageTest;
 import io.qameta.allure.testng.samples.TestsWithIdForFilter;
 import org.assertj.core.api.Condition;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -72,7 +77,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -200,6 +204,9 @@ public class AllureTestNgTest {
         assertThat(results.getTestResults())
                 .extracting(TestResult::getName, TestResult::getStatus)
                 .containsOnly(tuple("someTest", Status.SKIPPED));
+        assertThat(getGlobalErrors(results))
+                .as("hiding configuration failures hides the run-level error too")
+                .isEmpty();
     }
 
     @Test
@@ -943,8 +950,14 @@ public class AllureTestNgTest {
                 .extracting(TestResult::getName, TestResult::getStatus)
                 .containsExactlyInAnyOrder(
                         tuple("skippedTest", Status.SKIPPED),
-                        tuple("skipSuite", Status.BROKEN),
                         tuple("testWithOneStep", Status.SKIPPED)
+                );
+        assertThat(getGlobalErrors(results))
+                .as("the failed before suite fixture is reported as an error of the run")
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Configuration method io.qameta.allure.testng.samples.SkippedSuite.skipSuite failed, "
+                                + "tests depending on it did not run: Skip all"
                 );
         assertThat(testContainers)
                 .as("Unexpected quantity of testng containers has been written")
@@ -1501,6 +1514,17 @@ public class AllureTestNgTest {
                         Tuple.tuple("afterTest", Status.BROKEN),
                         Tuple.tuple("afterMethod", Status.BROKEN)
                 );
+
+        assertThat(results.getTestResults())
+                .as("the tests of a failed after fixture ran and keep their own results")
+                .extracting(TestResult::getStatus)
+                .containsOnly(Status.PASSED);
+
+        assertThat(getGlobalErrors(results))
+                .as("an after fixture failure claims nothing about whether its tests ran")
+                .extracting(GlobalError::getMessage)
+                .allSatisfy(message -> assertThat(message).startsWith("After configuration method "))
+                .hasSize(3);
     }
 
     @AllureFeatures.Parameters
@@ -1637,33 +1661,122 @@ public class AllureTestNgTest {
         });
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * A failed configuration method is reported as an error of the test run, not as a test result: it is not a test
+     * case, and a result standing in for it would be counted in the run statistics and could never be replaced by a
+     * later green run. The tests it prevented keep their own results, reported as skipped.
+     */
     @AllureFeatures.Fixtures
     @Issue("135")
     @Test
+    @Description
     public void shouldProcessConfigurationFailure() {
         final AllureResults results = runTestNgSuites("suites/gh-135.xml");
 
         assertThat(results.getTestResults())
+                .as("only the prevented test is reported as a test case")
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("someTest", Status.SKIPPED));
+
+        final List<GlobalError> globalErrors = getGlobalErrors(results);
+        assertThat(globalErrors)
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Configuration method io.qameta.allure.testng.samples.ConfigurationFailure.setUp failed, "
+                                + "tests depending on it did not run: fail"
+                );
+        assertThat(globalErrors.get(0).getTrace())
+                .as("the global error keeps the original stack trace")
+                .contains("java.lang.RuntimeException: fail");
+        assertThat(globalErrors.get(0).getTimestamp()).isPositive();
+    }
+
+    /**
+     * Results backfilled for the tests a failed fixture prevented carry the same identity the tests would have had
+     * if they had run, including the parameters of every data provider row, so a later green run replaces them
+     * instead of leaving them in the report forever.
+     */
+    @AllureFeatures.Fixtures
+    @Test
+    @Description
+    public void shouldBackfillSkippedTestsWithTheIdentityOfARealRun() {
+        final AllureResults skippedRun = runFailedBeforeClassWithDataProvider(true);
+        final AllureResults passedRun = runFailedBeforeClassWithDataProvider(false);
+
+        assertThat(skippedRun.getTestResults())
                 .extracting(TestResult::getName, TestResult::getStatus)
                 .containsExactlyInAnyOrder(
-                        tuple("someTest", Status.SKIPPED),
-                        tuple("failed configuration", Status.BROKEN)
+                        tuple("parameterisedTest", Status.SKIPPED),
+                        tuple("parameterisedTest", Status.SKIPPED),
+                        tuple("parameterisedTest", Status.SKIPPED),
+                        tuple("plainTest", Status.SKIPPED)
                 );
 
-        assertThat(results.getTestResults())
-                .filteredOn("name", "failed configuration")
-                .extracting(TestResult::getStatusDetails)
-                .extracting(StatusDetails::getMessage)
-                .containsExactly("fail");
-
-        assertThat(results.getTestResults())
-                .filteredOn("name", "failed configuration")
-                .flatExtracting(TestResult::getLabels)
-                .extracting(Label::getName, Label::getValue)
-                .contains(
-                        tuple("AS_ID", "-1")
+        assertThat(skippedRun.getTestResults())
+                .filteredOn("name", "parameterisedTest")
+                .flatExtracting(TestResult::getParameters)
+                .extracting(Parameter::getName, Parameter::getValue)
+                .containsExactlyInAnyOrder(
+                        tuple("value", "a"),
+                        tuple("value", "b"),
+                        tuple("value", "c")
                 );
+
+        final Map<String, String> skippedIdentities = identitiesByHistoryId(skippedRun);
+        assertThat(skippedIdentities)
+                .as("every result has its own history id")
+                .hasSize(4);
+        assertThat(skippedIdentities)
+                .as("a green rerun produces exactly the history ids of the skipped results, and so replaces them")
+                .isEqualTo(identitiesByHistoryId(passedRun));
+
+        assertThat(getGlobalErrors(skippedRun))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Configuration method "
+                                + "io.qameta.allure.testng.samples.FailedBeforeClassWithDataProvider.setUp failed, "
+                                + "tests depending on it did not run: before class failed"
+                );
+    }
+
+    private AllureResults runFailedBeforeClassWithDataProvider(final boolean failSetUp) {
+        final String initial = System.getProperty(FailedBeforeClassWithDataProvider.FAIL_SETUP_PROPERTY);
+        System.setProperty(
+                FailedBeforeClassWithDataProvider.FAIL_SETUP_PROPERTY,
+                Boolean.toString(failSetUp)
+        );
+        try {
+            return runTestNgSuites("suites/failed-before-class-with-data-provider.xml");
+        } finally {
+            if (Objects.isNull(initial)) {
+                System.clearProperty(FailedBeforeClassWithDataProvider.FAIL_SETUP_PROPERTY);
+            } else {
+                System.setProperty(FailedBeforeClassWithDataProvider.FAIL_SETUP_PROPERTY, initial);
+            }
+        }
+    }
+
+    /**
+     * Maps every result's history id to the name and parameters it was computed from, so that two runs can be
+     * compared on which case each identity belongs to rather than on the set of identities alone.
+     */
+    private static Map<String, String> identitiesByHistoryId(final AllureResults results) {
+        return results.getTestResults().stream()
+                .collect(
+                        Collectors.toMap(
+                                TestResult::getHistoryId,
+                                result -> result.getName() + result.getParameters().stream()
+                                        .map(parameter -> parameter.getName() + "=" + parameter.getValue())
+                                        .sorted()
+                                        .collect(Collectors.joining(",", "[", "]"))
+                        )
+                );
+    }
+
+    private static List<GlobalError> getGlobalErrors(final AllureResults results) {
+        return results.getGlobals().stream()
+                .flatMap(globals -> globals.getErrors().stream())
+                .collect(Collectors.toList());
     }
 
     @AllureFeatures.IgnoredTests
@@ -1749,6 +1862,47 @@ public class AllureTestNgTest {
                 .extracting(StepResult::getName)
                 .containsExactly(
                         "first", "second"
+                );
+    }
+
+    /**
+     * When a before method fails and an alwaysRun after method fails too, the test keeps its own skipped result and
+     * each fixture failure is reported as an error of the run whose wording stays true: only the before fixture
+     * kept the test from running.
+     */
+    @AllureFeatures.Fixtures
+    @Test
+    @Description
+    public void shouldReportBothFixtureFailuresOfASkippedTestTruthfully() {
+        final AllureResults results = runTestNgSuites("suites/failed-set-up-and-tear-down.xml");
+
+        assertThat(results.getTestResults())
+                .as("the skipped test keeps its own result and no fixture is reported as a test")
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("skippedTest", Status.SKIPPED));
+
+        assertThat(results.getTestResultContainers())
+                .flatExtracting(TestResultContainer::getBefores)
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .contains(tuple("setUp", Status.BROKEN));
+        assertThat(results.getTestResultContainers())
+                .flatExtracting(TestResultContainer::getAfters)
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .contains(tuple("tearDownAlways", Status.BROKEN));
+
+        assertThat(getGlobalErrors(results))
+                .as(
+                        "an alwaysRun after method runs for a test the before fixture already skipped, "
+                                + "so only the before fixture may claim that tests did not run"
+                )
+                .extracting(GlobalError::getMessage)
+                .containsExactlyInAnyOrder(
+                        "Configuration method "
+                                + "io.qameta.allure.testng.samples.FailedSetUpAndTearDown.setUp failed, "
+                                + "tests depending on it did not run: set up failed",
+                        "After configuration method "
+                                + "io.qameta.allure.testng.samples.FailedSetUpAndTearDown.tearDownAlways failed: "
+                                + "tear down failed"
                 );
     }
 
@@ -2016,21 +2170,33 @@ public class AllureTestNgTest {
         );
     }
 
+    /**
+     * A failed before fixture of any scope is reported as an error of the test run and keeps its own broken fixture
+     * result, so the failure and its evidence stay in the report without a test case being invented for it.
+     */
     @ParameterizedTest
     @MethodSource("failedFixtures")
     @AllureFeatures.Fixtures
-    public void shouldAddBeforeFixtureToFakeTestResult(final String suite, final String fixture) {
+    @Description
+    public void shouldReportFailedBeforeFixtureWithoutInventingATestResult(final String suite, final String fixture) {
         final AllureResults results = runTestNgSuites(suite);
-        final Optional<TestResult> result = results.getTestResults().stream()
-                .filter(r -> r.getName().contains(fixture))
-                .findAny();
-        assertThat(result).as("Before failed fake test result").isNotEmpty();
-        final Optional<TestResultContainer> befores = results.getTestResultContainers().stream()
-                .filter(c -> Objects.nonNull(c.getBefores()) && !c.getBefores().isEmpty())
-                .findAny();
-        assertThat(result).as("Before failed configuration container").isNotEmpty();
-        assertThat(befores.get().getChildren())
-                .contains(result.get().getUuid());
+
+        assertThat(results.getTestResults())
+                .as("no test case is invented for the failed fixture")
+                .extracting(TestResult::getName)
+                .doesNotContain(fixture);
+
+        assertThat(results.getTestResultContainers())
+                .flatExtracting(TestResultContainer::getBefores)
+                .as("the failed fixture is still reported as a broken fixture")
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .contains(tuple(fixture, Status.BROKEN));
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .singleElement(InstanceOfAssertFactories.STRING)
+                .contains(fixture)
+                .contains("tests depending on it did not run");
     }
 
     @Test
@@ -2386,9 +2552,208 @@ public class AllureTestNgTest {
                 .contains("attachment");
     }
 
+    /**
+     * Results backfilled for tests a failed dependency prevented keep the identity of a real run when the adapter
+     * can know it. A dependent test without a data provider keeps its result; a data driven dependent test never
+     * reaches its provider, so its rows are unknown and it is reported as an error of the run instead of as a
+     * result no green rerun could replace.
+     */
+    @AllureFeatures.SkippedTests
+    @Test
+    @Description
+    public void shouldNotInventInvocationsForADataDrivenTestSkippedByAFailedDependency() {
+        final AllureResults skippedRun = runFailedDependency(true);
+        final AllureResults passedRun = runFailedDependency(false);
+
+        assertThat(skippedRun.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactlyInAnyOrder(
+                        tuple("upstreamTest", Status.BROKEN),
+                        tuple("dependentTest", Status.SKIPPED)
+                );
+
+        final Map<String, String> skippedIdentities = identitiesByHistoryId(skippedRun);
+        assertThat(skippedIdentities.keySet())
+                .as(
+                        "the results that are reported keep the identity they have in a green run, so a rerun "
+                                + "replaces them"
+                )
+                .isSubsetOf(identitiesByHistoryId(passedRun).keySet());
+
+        assertThat(getGlobalErrors(skippedRun))
+                .extracting(GlobalError::getMessage)
+                .singleElement(InstanceOfAssertFactories.STRING)
+                .startsWith(
+                        "Parameterised test "
+                                + "io.qameta.allure.testng.samples.FailedDependency.dependentParameterisedTest "
+                                + "did not run, and the values of the invocations it would have had are unknown"
+                );
+    }
+
+    /**
+     * A method that inherits its data provider from the class-level {@code @Test} is recognised as parameterised
+     * from its own declaration, so a dependency skip does not invent an invocation for it either. TestNG's
+     * {@code isDataDriven} reads the method-level annotation alone and would miss this case.
+     */
+    @AllureFeatures.SkippedTests
+    @Test
+    @Description
+    public void shouldNotInventInvocationsForATestInheritingItsDataProviderFromTheClass() {
+        final AllureResults skippedRun = runInheritedDataProviderDependency(true);
+        final AllureResults passedRun = runInheritedDataProviderDependency(false);
+
+        assertThat(skippedRun.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("upstreamTest", Status.BROKEN));
+
+        assertThat(passedRun.getTestResults())
+                .as("the inherited provider does feed the dependent test in a green run")
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactlyInAnyOrder(
+                        tuple("upstreamTest", Status.PASSED),
+                        tuple("dependentInheritedTest", Status.PASSED),
+                        tuple("dependentInheritedTest", Status.PASSED)
+                );
+
+        assertThat(identitiesByHistoryId(skippedRun).keySet())
+                .as("every reported result keeps the identity it has in a green run")
+                .isSubsetOf(identitiesByHistoryId(passedRun).keySet());
+
+        assertThat(getGlobalErrors(skippedRun))
+                .extracting(GlobalError::getMessage)
+                .singleElement(InstanceOfAssertFactories.STRING)
+                .startsWith(
+                        "Parameterised test io.qameta.allure.testng.samples.InheritedDataProviderDependency"
+                                + ".dependentInheritedTest did not run, and the values of the invocations it "
+                                + "would have had are unknown"
+                );
+    }
+
+    private AllureResults runInheritedDataProviderDependency(final boolean failUpstream) {
+        final String initial = System.getProperty(InheritedDataProviderDependency.FAIL_UPSTREAM_PROPERTY);
+        System.setProperty(
+                InheritedDataProviderDependency.FAIL_UPSTREAM_PROPERTY,
+                Boolean.toString(failUpstream)
+        );
+        try {
+            return runTestNgSuites("suites/inherited-data-provider-dependency.xml");
+        } finally {
+            if (Objects.isNull(initial)) {
+                System.clearProperty(InheritedDataProviderDependency.FAIL_UPSTREAM_PROPERTY);
+            } else {
+                System.setProperty(InheritedDataProviderDependency.FAIL_UPSTREAM_PROPERTY, initial);
+            }
+        }
+    }
+
+    private AllureResults runFailedDependency(final boolean failUpstream) {
+        final String initial = System.getProperty(FailedDependency.FAIL_UPSTREAM_PROPERTY);
+        System.setProperty(FailedDependency.FAIL_UPSTREAM_PROPERTY, Boolean.toString(failUpstream));
+        try {
+            return runTestNgSuites("suites/failed-dependency.xml");
+        } finally {
+            if (Objects.isNull(initial)) {
+                System.clearProperty(FailedDependency.FAIL_UPSTREAM_PROPERTY);
+            } else {
+                System.setProperty(FailedDependency.FAIL_UPSTREAM_PROPERTY, initial);
+            }
+        }
+    }
+
+    /**
+     * A failed after class or after groups fixture keeps its own broken fixture result and is reported as an error
+     * of the run, while the tests it follows keep the results they already produced.
+     */
+    @AllureFeatures.Fixtures
+    @Test
+    @Description
+    public void shouldReportFailedAfterClassAndAfterGroupsFixtures() {
+        final AllureResults results = runTestNgSuites("suites/failed-after-class-and-groups.xml");
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("passingTest", Status.PASSED));
+
+        assertThat(results.getTestResultContainers())
+                .flatExtracting(TestResultContainer::getAfters)
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .contains(
+                        tuple("afterClass", Status.BROKEN),
+                        tuple("afterGroups", Status.BROKEN)
+                );
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactlyInAnyOrder(
+                        "After configuration method "
+                                + "io.qameta.allure.testng.samples.FailedAfterClassAndGroups.afterClass failed: "
+                                + "after class failed",
+                        "After configuration method "
+                                + "io.qameta.allure.testng.samples.FailedAfterClassAndGroups.afterGroups failed: "
+                                + "after groups failed"
+                );
+    }
+
+    /**
+     * A data provider that skips on purpose keeps its test's skipped result. The deliberate skip is the outcome
+     * the user asked for, not a failure to produce rows, so it is not turned into an error of the run.
+     */
+    @AllureFeatures.SkippedTests
+    @Test
+    @Description
+    public void shouldKeepTheSkippedResultOfATestItsDataProviderSkippedOnPurpose() {
+        final AllureResults results = runTestNgSuites("suites/skipped-data-provider.xml");
+
+        assertThat(results.getTestResults())
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("skippedTest", Status.SKIPPED));
+
+        assertThat(getGlobalErrors(results))
+                .as("a deliberate skip is not an error of the run")
+                .isEmpty();
+    }
+
+    /**
+     * A data provider failure that TestNG is configured to propagate as a test failure reaches the listener through
+     * a different callback, and is reported the same way: as an error of the test run, without a test result whose
+     * identity no run ever produces.
+     */
+    @AllureFeatures.Fixtures
+    @Test
+    @Description
+    public void shouldProcessFailedDataProviderPropagatedAsTestFailure() {
+        final AllureResults results = runTestNgSuites(
+                TestNG::propagateDataProviderFailureAsTestFailure,
+                "suites/failed-data-provider.xml"
+        );
+
+        assertThat(results.getTestResultContainers())
+                .flatExtracting(TestResultContainer::getBefores)
+                .extracting(FixtureResult::getName, FixtureResult::getStatus)
+                .contains(Tuple.tuple("dataProvider", Status.BROKEN));
+
+        assertThat(results.getTestResults())
+                .as("no test case is invented for invocations the data provider never produced")
+                .isEmpty();
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Parameterised test io.qameta.allure.testng.samples.FailedDataProvider.test did not run, "
+                                + "and the values of the invocations it would have had are unknown: "
+                                + "java.lang.RuntimeException: Data provider failed"
+                );
+    }
+
+    /**
+     * A test whose data provider failed is reported as an error of the test run rather than as a skipped test: the
+     * number of invocations and their parameters are exactly what the data provider failed to produce, so any test
+     * result invented for it would have an identity no run ever produces.
+     */
     @AllureFeatures.Fixtures
     @Test
     @DisplayName("Should process failed data provider in setup")
+    @Description
     public void shouldProcessFailedDataProviderInSetup() {
         final AllureResults results = runTestNgSuites("suites/failed-data-provider.xml");
 
@@ -2396,6 +2761,18 @@ public class AllureTestNgTest {
                 .flatExtracting(TestResultContainer::getBefores)
                 .extracting(FixtureResult::getName, FixtureResult::getStatus)
                 .contains(Tuple.tuple("dataProvider", Status.BROKEN));
+
+        assertThat(results.getTestResults())
+                .as("no test case is invented for invocations the data provider never produced")
+                .isEmpty();
+
+        assertThat(getGlobalErrors(results))
+                .extracting(GlobalError::getMessage)
+                .containsExactly(
+                        "Parameterised test io.qameta.allure.testng.samples.FailedDataProvider.test did not run, "
+                                + "and the values of the invocations it would have had are unknown: "
+                                + "java.lang.RuntimeException: Data provider failed"
+                );
     }
 
     @AllureFeatures.Fixtures
@@ -2411,6 +2788,15 @@ public class AllureTestNgTest {
                         Tuple.tuple("provide", Status.BROKEN),
                         Tuple.tuple("provide", Status.PASSED)
                 );
+
+        assertThat(results.getTestResults())
+                .as("the retried provider produced its rows, so the test ran and keeps its result")
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactly(tuple("test", Status.PASSED));
+
+        assertThat(getGlobalErrors(results))
+                .as("a provider that fails and then succeeds kept nothing from running")
+                .isEmpty();
     }
 
     @AllureFeatures.Fixtures

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/FailedAfterClassAndGroups.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/FailedAfterClassAndGroups.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterGroups;
+import org.testng.annotations.Test;
+
+public class FailedAfterClassAndGroups {
+
+    @Test(groups = "regression")
+    public void passingTest() {
+    }
+
+    @AfterGroups(groups = "regression")
+    public void afterGroups() {
+        throw new RuntimeException("after groups failed");
+    }
+
+    @AfterClass
+    public void afterClass() {
+        throw new RuntimeException("after class failed");
+    }
+}

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/FailedBeforeClassWithDataProvider.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/FailedBeforeClassWithDataProvider.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class FailedBeforeClassWithDataProvider {
+
+    /**
+     * Set to run the same suite with a passing fixture, so that the results of a skipped run and of a real run can
+     * be compared.
+     */
+    public static final String FAIL_SETUP_PROPERTY = "allure.testng.sample.failBeforeClass";
+
+    @BeforeClass
+    public void setUp() {
+        if (Boolean.getBoolean(FAIL_SETUP_PROPERTY)) {
+            throw new RuntimeException("before class failed");
+        }
+    }
+
+    @DataProvider(name = "rows")
+    public Object[][] rows() {
+        return new Object[][]{{"a"}, {"b"}, {"c"}};
+    }
+
+    @Test(dataProvider = "rows")
+    public void parameterisedTest(final String value) {
+    }
+
+    @Test
+    public void plainTest() {
+    }
+
+}

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/FailedDependency.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/FailedDependency.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class FailedDependency {
+
+    /**
+     * Set to run the same suite with a passing upstream test, so that the results of a run whose dependency failed
+     * and of a real run can be compared.
+     */
+    public static final String FAIL_UPSTREAM_PROPERTY = "allure.testng.sample.failUpstream";
+
+    @DataProvider(name = "rows")
+    public Object[][] rows() {
+        return new Object[][]{{"a"}, {"b"}, {"c"}};
+    }
+
+    @Test
+    public void upstreamTest() {
+        if (Boolean.getBoolean(FAIL_UPSTREAM_PROPERTY)) {
+            throw new RuntimeException("upstream failed");
+        }
+    }
+
+    @Test(dependsOnMethods = "upstreamTest")
+    public void dependentTest() {
+    }
+
+    @Test(
+            dataProvider = "rows",
+            dependsOnMethods = "upstreamTest"
+    )
+    public void dependentParameterisedTest(final String value) {
+    }
+}

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/FailedSetUpAndTearDown.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/FailedSetUpAndTearDown.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class FailedSetUpAndTearDown {
+
+    @BeforeMethod
+    public void setUp() {
+        throw new RuntimeException("set up failed");
+    }
+
+    @Test
+    public void skippedTest() {
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDownAlways() {
+        throw new RuntimeException("tear down failed");
+    }
+}

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/InheritedDataProviderDependency.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/InheritedDataProviderDependency.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * The data provider is declared on the class-level {@code @Test}, and inherited by the dependent method whose own
+ * {@code @Test} annotation only declares the dependency.
+ */
+@Test(dataProvider = "rows")
+public class InheritedDataProviderDependency {
+
+    /**
+     * Set to run the same suite with a passing upstream test, so that the results of a run whose dependency failed
+     * and of a real run can be compared.
+     */
+    public static final String FAIL_UPSTREAM_PROPERTY = "allure.testng.sample.failInheritedUpstream";
+
+    @DataProvider(name = "rows")
+    public Object[][] rows() {
+        return new Object[][]{{"a"}, {"b"}};
+    }
+
+    @DataProvider(name = "none")
+    public Object[][] none() {
+        return new Object[][]{{}};
+    }
+
+    @Test(dataProvider = "none")
+    public void upstreamTest() {
+        if (Boolean.getBoolean(FAIL_UPSTREAM_PROPERTY)) {
+            throw new RuntimeException("upstream failed");
+        }
+    }
+
+    @Test(dependsOnMethods = "upstreamTest")
+    public void dependentInheritedTest(final String value) {
+    }
+}

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/SkippedDataProvider.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/SkippedDataProvider.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.testng.samples;
+
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class SkippedDataProvider {
+
+    @DataProvider(name = "rows")
+    public Object[][] rows() {
+        throw new SkipException("no data for this environment");
+    }
+
+    @Test(dataProvider = "rows")
+    public void skippedTest(final String value) {
+    }
+}

--- a/allure-testng/src/test/resources/suites/failed-after-class-and-groups.xml
+++ b/allure-testng/src/test/resources/suites/failed-after-class-and-groups.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="FailedAfterClassAndGroups Suite" verbose="1" parallel="false" thread-count="1">
+    <test name="FailedAfterClassAndGroups Test">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.FailedAfterClassAndGroups" />
+        </classes>
+    </test>
+</suite>

--- a/allure-testng/src/test/resources/suites/failed-before-class-with-data-provider.xml
+++ b/allure-testng/src/test/resources/suites/failed-before-class-with-data-provider.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="Failed Before Class With Data Provider Suite" verbose="1" parallel="false" thread-count="1">
+    <test name="Failed Before Class With Data Provider Test">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.FailedBeforeClassWithDataProvider" />
+        </classes>
+    </test>
+</suite>

--- a/allure-testng/src/test/resources/suites/failed-dependency.xml
+++ b/allure-testng/src/test/resources/suites/failed-dependency.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="FailedDependency Suite" verbose="1" parallel="false" thread-count="1">
+    <test name="FailedDependency Test">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.FailedDependency" />
+        </classes>
+    </test>
+</suite>

--- a/allure-testng/src/test/resources/suites/failed-set-up-and-tear-down.xml
+++ b/allure-testng/src/test/resources/suites/failed-set-up-and-tear-down.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="Failed Set Up And Tear Down Suite" verbose="1" parallel="false" thread-count="1">
+    <test name="Failed Set Up And Tear Down Test">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.FailedSetUpAndTearDown" />
+        </classes>
+    </test>
+</suite>

--- a/allure-testng/src/test/resources/suites/inherited-data-provider-dependency.xml
+++ b/allure-testng/src/test/resources/suites/inherited-data-provider-dependency.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="InheritedDataProviderDependency Suite" verbose="1" parallel="false" thread-count="1">
+    <test name="InheritedDataProviderDependency Test">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.InheritedDataProviderDependency" />
+        </classes>
+    </test>
+</suite>

--- a/allure-testng/src/test/resources/suites/skipped-data-provider.xml
+++ b/allure-testng/src/test/resources/suites/skipped-data-provider.xml
@@ -1,0 +1,8 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="SkippedDataProvider Suite" verbose="1" parallel="false" thread-count="1">
+    <test name="SkippedDataProvider Test">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.SkippedDataProvider" />
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Report failures outside individual tests as run-level errors across TestNG, JUnit Platform, JUnit 4, Spock 2, Cucumber 7, and JBehave 5. This covers configuration methods, data providers, failed containers, class and specification fixtures, run hooks, and story lifecycle steps.

These failures are no longer lost or represented as synthetic test cases that distort statistics and remain in history after successful retries. Real tests retain stable identities, blocked tests are reported as skipped when their identities are known, and unknown parameterized or template invocations are not invented.

fixes #643
fixes #912
fixes #1128
fixes #1155

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java