### PR TITLE
Add Scala 3 support to Allure ScalaTest

### DIFF
--- a/allure-bom/build.gradle.kts
+++ b/allure-bom/build.gradle.kts
@@ -4,10 +4,19 @@ plugins {
 
 description = "Allure Java (Bill of Materials)"
 
+val scalaTestBinaryVersions = listOf("2.12", "2.13", "3")
+
 dependencies {
     constraints {
-        rootProject.subprojects.sorted()
-                .forEach { api("${it.group}:${it.name}:${it.version}") }
+        rootProject.subprojects.sorted().forEach {
+            if (it.name == "allure-scalatest") {
+                scalaTestBinaryVersions.forEach { scalaBinaryVersion ->
+                    api("${it.group}:${it.name}_$scalaBinaryVersion:${it.version}")
+                }
+            } else {
+                api("${it.group}:${it.name}:${it.version}")
+            }
+        }
     }
 }
 

--- a/allure-scalatest/README.md
+++ b/allure-scalatest/README.md
@@ -9,7 +9,7 @@ Use this module when your ScalaTest suites should produce Allure results with su
 - Allure Java 3.x requires Java 17 or newer.
 - This module targets ScalaTest 3.2.x.
 - The current build validates against ScalaTest 3.2.20.
-- Artifacts are cross-built for Scala 2.12.21 and Scala 2.13.18.
+- Artifacts are cross-built for Scala 2.12.21, Scala 2.13.18, and Scala 3.3.8 LTS.
 
 ## Installation
 
@@ -20,9 +20,11 @@ Gradle:
 ```kotlin
 dependencies {
     testImplementation(platform("io.qameta.allure:allure-bom:<allure-version>"))
-    testImplementation("io.qameta.allure:allure-scalatest_2.13")
+    testImplementation("io.qameta.allure:allure-scalatest_3")
 }
 ```
+
+Use the `_2.12` or `_2.13` artifact instead when targeting the corresponding Scala 2 binary version.
 
 sbt:
 

--- a/allure-scalatest/build.gradle.kts
+++ b/allure-scalatest/build.gradle.kts
@@ -7,17 +7,20 @@ plugins {
 
 val scala212 = "2.12"
 val scala213 = "2.13"
+val scala3 = "3"
+val scalaTestVersion = "3.2.20"
 
 project.base.archivesName.set("allure-scalatest")
 
 crossBuild {
     scalaVersionsCatalog = mapOf(
         scala212 to "2.12.21",
-        scala213 to "2.13.18"
+        scala213 to "2.13.18",
+        scala3 to "3.3.8"
     )
     builds {
         register("scala") {
-            scalaVersions = setOf(scala212, scala213)
+            scalaVersions = setOf(scala212, scala213, scala3)
         }
     }
 }
@@ -71,18 +74,35 @@ publishing {
             }
             artifact(crossBuildScala_213ScaladocJar)
         }
+        create<MavenPublication>("crossBuildScala_3") {
+            from(components["crossBuildScala_3"])
+
+            val crossBuildScala_3SourcesJar by tasks.creating(Jar::class) {
+                from(sourceSets["crossBuildScala_3"].allSource)
+                archiveBaseName.set("allure-scalatest_$scala3")
+                archiveClassifier.set("sources")
+            }
+            artifact(crossBuildScala_3SourcesJar)
+
+            val crossBuildScala_3ScaladocJar by tasks.creating(Jar::class) {
+                from(tasks.scaladoc)
+                archiveBaseName.set("allure-scalatest_$scala3")
+                archiveClassifier.set("javadoc")
+            }
+            artifact(crossBuildScala_3ScaladocJar)
+        }
     }
 }
 
 dependencies {
     api(project(":allure-java-commons"))
-    compileOnly("org.scalatest:scalatest_$scala213:3.2.20")
+    compileOnly("org.scalatest:scalatest_$scala213:$scalaTestVersion")
     compileOnly("org.scala-lang.modules:scala-collection-compat_$scala213:2.14.0")
     testImplementation("io.github.glytching:junit-extensions")
     testImplementation("org.assertj:assertj-core")
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
-    testImplementation("org.scalatest:scalatest_$scala213:3.2.20")
+    testImplementation("org.scalatest:scalatest_$scala213:$scalaTestVersion")
     testImplementation("org.scala-lang.modules:scala-collection-compat_$scala213:2.14.0")
     testImplementation("org.slf4j:slf4j-simple")
     testImplementation(project(":allure-assertj"))


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Allure ScalaTest is now published for Scala 3 alongside Scala 2.12 and 2.13. Scala 3 projects can use `allure-scalatest_3` and manage its version through `allure-bom`, with sources and API documentation included.

The integration now targets ScalaTest 3.2.20 and Scala 3.3.8 LTS. The installation guide documents the Scala 3 coordinate and how to select the matching artifact for Scala 2 projects.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java