### PR TITLE
Honor metadata label tags across Java test integrations

### DIFF
--- a/allure-cucumber7-jvm/README.md
+++ b/allure-cucumber7-jvm/README.md
@@ -8,7 +8,8 @@ Use this module when your BDD tests run on Cucumber JVM 7 and you want features,
 
 - Allure Java 3.x requires Java 17 or newer.
 - This module targets Cucumber JVM 7.x.
-- The current build validates against Cucumber JVM 7.34.3 and Gherkin 36.1.0.
+- The main test suite validates against Cucumber JVM 7.34.7, and a focused compatibility test validates the
+  metadata-label tag contract against the oldest runtime supported by the current adapter API, 7.3.0.
 
 ## Installation
 

--- a/allure-cucumber7-jvm/build.gradle.kts
+++ b/allure-cucumber7-jvm/build.gradle.kts
@@ -1,6 +1,7 @@
 description = "Allure CucumberJVM 7.0"
 
 val cucumberVersion = "7.34.7"
+val minimumCucumberVersion = "7.3.0"
 
 dependencies {
     api(project(":allure-java-commons"))
@@ -35,4 +36,41 @@ tasks.jar {
 
 tasks.test {
     useJUnitPlatform()
+    systemProperty("allure.test.cucumber.version", cucumberVersion)
+}
+
+val minimumCucumberTestRuntimeClasspath = configurations.testRuntimeClasspath.get().copyRecursive().apply {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "io.cucumber" && requested.name == "cucumber-bom") {
+            useVersion(minimumCucumberVersion)
+            because("7.3.0 is the oldest Cucumber JVM runtime supported by the current adapter API")
+        }
+    }
+}
+
+val cucumber7MinimumVersionTest = tasks.register<Test>("cucumber7MinimumVersionTest") {
+    description = "Runs the metadata-label tag regression against Cucumber JVM $minimumCucumberVersion"
+    group = "verification"
+    dependsOn(tasks.testClasses)
+    mustRunAfter(tasks.test)
+
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.main.get().output + sourceSets.test.get().output + minimumCucumberTestRuntimeClasspath
+    useJUnitPlatform()
+    filter {
+        includeTestsMatching(
+            "io.qameta.allure.cucumber7jvm.AllureCucumber7JvmTest.shouldPreferMetadataTagHierarchyOverDefaults"
+        )
+    }
+
+    val standardTest = tasks.test.get()
+    systemProperties(standardTest.systemProperties)
+    systemProperty("allure.test.cucumber.version", minimumCucumberVersion)
+    jvmArgs = standardTest.jvmArgs
+    maxHeapSize = standardTest.maxHeapSize
+    maxParallelForks = standardTest.maxParallelForks
+}
+
+tasks.check {
+    dependsOn(cucumber7MinimumVersionTest)
 }

--- a/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
+++ b/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
@@ -59,6 +59,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static io.qameta.allure.util.ResultsUtils.PACKAGE_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.PARENT_SUITE_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.SUB_SUITE_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.SUITE_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.TEST_CLASS_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.TEST_METHOD_LABEL_NAME;
@@ -70,6 +72,8 @@ import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
 import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
 @IsolatedLifecycle
 class AllureCucumber7JvmTest {
+
+    private static final String EXPECTED_CUCUMBER_VERSION_PROPERTY = "allure.test.cucumber.version";
 
     @AllureFeatures.Base
     @Test
@@ -374,6 +378,46 @@ class AllureCucumber7JvmTest {
                         tuple("tag", "FeatureTag"),
                         tuple("tag", "good")
                 );
+    }
+
+    /**
+     * Metadata tags must replace Cucumber's generated hierarchy defaults so report generation cannot place the
+     * same scenario under both hierarchies.
+     */
+    @Description
+    @Test
+    void shouldPreferMetadataTagHierarchyOverDefaults() {
+        assertThat(Runtime.class.getPackage().getImplementationVersion())
+                .as("Cucumber runtime version")
+                .isEqualTo(System.getProperty(EXPECTED_CUCUMBER_VERSION_PROPERTY));
+
+        final AllureResults results = runFeature("features/metadata-tags.feature");
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .hasSize(3)
+                .allSatisfy(testResult -> {
+                    assertThat(testResult.getLabels())
+                            .filteredOn(
+                                    label -> PARENT_SUITE_LABEL_NAME.equals(label.getName())
+                                            || SUITE_LABEL_NAME.equals(label.getName())
+                                            || SUB_SUITE_LABEL_NAME.equals(label.getName())
+                            )
+                            .extracting(Label::getName, Label::getValue)
+                            .containsExactlyInAnyOrder(
+                                    tuple(PARENT_SUITE_LABEL_NAME, "Cucumber"),
+                                    tuple(SUITE_LABEL_NAME, "Petstore"),
+                                    tuple(SUB_SUITE_LABEL_NAME, "CRUD")
+                            );
+                    assertThat(testResult.getLabels())
+                            .filteredOn(label -> "tag".equals(label.getName()))
+                            .extracting(Label::getValue)
+                            .doesNotContain(
+                                    "allure.label.parentSuite:Cucumber",
+                                    "allure.label.suite:Petstore",
+                                    "allure.label.subSuite:CRUD"
+                            );
+                });
     }
 
     @AllureFeatures.Links

--- a/allure-cucumber7-jvm/src/test/resources/features/metadata-tags.feature
+++ b/allure-cucumber7-jvm/src/test/resources/features/metadata-tags.feature
@@ -1,0 +1,16 @@
+@allure.label.parentSuite:Cucumber
+@allure.label.suite:Petstore
+@allure.label.subSuite:CRUD
+Feature: Arithmetic_operations
+
+  Scenario Outline: Addition
+    Given a is <a>
+    And b is <b>
+    When I add a to b
+    Then result is <result>
+
+    Examples:
+      | a | b | result |
+      | 1 | 1 | 2      |
+      | 2 | 1 | 3      |
+      | 2 | 7 | 9      |

--- a/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
+++ b/allure-java-commons/src/main/java/io/qameta/allure/AllureLifecycle.java
@@ -64,9 +64,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static io.qameta.allure.AllureConstants.ATTACHMENT_FILE_SUFFIX;
+import static io.qameta.allure.util.ResultsUtils.TAG_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.createLabel;
 import static io.qameta.allure.util.ResultsUtils.firstNonEmpty;
 import static io.qameta.allure.util.ResultsUtils.getStatus;
 import static io.qameta.allure.util.ResultsUtils.getStatusDetails;
@@ -100,6 +104,10 @@ import static io.qameta.allure.util.ServiceLoaderUtils.load;
 public class AllureLifecycle {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AllureLifecycle.class);
+
+    private static final Pattern ALLURE_LABEL_TAG = Pattern.compile(
+            "^@?allure\\.label\\.(?<name>.+)[:=](?<value>.+)$"
+    );
 
     private static final String EXTERNAL_KEY = "external key";
 
@@ -346,8 +354,8 @@ public class AllureLifecycle {
      * Registers default labels for the test with given key. Default labels do not appear on the test result until
      * the test stops: {@link #stopTest(AllureExternalKey)} merges them after scope metadata, adding, for each
      * distinct label name, the default labels with that name only when the test has no labels with that name by
-     * then. Labels provided by the user — through annotations, the runtime API, or before fixtures — thus take
-     * precedence over defaults instead of being duplicated by them. Repeated calls accumulate.
+     * then. Labels provided by the user — through annotations, framework tags, the runtime API, or before fixtures
+     * — thus take precedence over defaults instead of being duplicated by them. Repeated calls accumulate.
      *
      * <p>Intended for the framework-computed grouping labels a user may legitimately override: the suite family
      * and BDD structure labels. System labels — framework, language, host, thread, package, testClass, testMethod
@@ -366,11 +374,12 @@ public class AllureLifecycle {
     }
 
     /**
-     * Stops test by given key. The test must be running; scope metadata is merged into the test here, then default
-     * labels are applied for each label name the test still has no labels for. If the test has a test case id but
-     * no history id, a compatibility history id is generated from the test case id and the final parameters. A
-     * history id supplied by a {@link TestLifecycleListener#beforeTestStop(TestResult)} listener is preserved.
-     * Unbinds the calling thread only if the test is the calling thread's root.
+     * Stops test by given key. The test must be running; scope metadata is merged into the test here, Allure label
+     * metadata carried by framework tags is promoted to labels, then default labels are applied for each label name
+     * the test still has no labels for. If the test has a test case id but no history id, a compatibility history id
+     * is generated from the test case id and the final parameters. A history id supplied by a
+     * {@link TestLifecycleListener#beforeTestStop(TestResult)} listener is preserved. Unbinds the calling thread only
+     * if the test is the calling thread's root.
      *
      * @param key the external test key
      */
@@ -395,6 +404,7 @@ public class AllureLifecycle {
             testResult.setParameters(new ArrayList<>());
         }
         applyScopeMetadata(item);
+        applyAllureLabelTags(testResult);
         applyDefaultLabels(item);
         if (Objects.isNull(testResult.getHistoryId()) && Objects.nonNull(testResult.getTestCaseId())) {
             testResult.setHistoryId(calculateHistoryId(testResult.getTestCaseId(), testResult.getParameters()));
@@ -1348,9 +1358,42 @@ public class AllureLifecycle {
     }
 
     /**
+     * Replaces tag labels that use the report's {@code allure.label.<name>[:=]<value>} convention with their
+     * represented labels. Processing the convention before defaults are selected lets metadata from every
+     * lifecycle-based framework adapter override same-name grouping defaults, while consuming the source tag keeps
+     * report generation from applying it a second time.
+     */
+    private static void applyAllureLabelTags(final TestResult testResult) {
+        final List<Label> labels = testResult.getLabels();
+        if (Objects.isNull(labels) || labels.isEmpty()) {
+            return;
+        }
+        final List<Label> normalizedLabels = new ArrayList<>(labels.size());
+        for (final Label label : labels) {
+            if (Objects.isNull(label) || !TAG_LABEL_NAME.equals(label.getName())
+                    || Objects.isNull(label.getValue())) {
+                normalizedLabels.add(label);
+                continue;
+            }
+            final Matcher matcher = ALLURE_LABEL_TAG.matcher(label.getValue());
+            if (matcher.matches()) {
+                normalizedLabels.add(
+                        createLabel(
+                                matcher.group("name"),
+                                matcher.group("value").replace("_", " ")
+                        )
+                );
+            } else {
+                normalizedLabels.add(label);
+            }
+        }
+        testResult.setLabels(normalizedLabels);
+    }
+
+    /**
      * Adds the test's registered default labels — for each distinct label name, only when the test has no labels
-     * with that name. Runs after scope metadata is merged, so labels set from before fixtures also take precedence
-     * over defaults.
+     * with that name. Runs after scope metadata is merged and Allure label tags are promoted, so framework tags and
+     * labels set from before fixtures also take precedence over defaults.
      */
     private static void applyDefaultLabels(final TestItem item) {
         if (item.defaultLabels().isEmpty()) {

--- a/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
+++ b/allure-java-commons/src/test/java/io/qameta/allure/AllureLifecycleTest.java
@@ -822,6 +822,61 @@ class AllureLifecycleTest {
         });
     }
 
+    /**
+     * Allure label metadata carried by framework tag labels must be promoted before fallback labels are chosen,
+     * so every lifecycle-based adapter gets custom labels without report-time duplicates.
+     */
+    @Description
+    @Test
+    void shouldConvertAllureLabelTagsBeforeApplyingDefaults() {
+        final String testUuid = randomId();
+        final AllureExternalKey testKey = testKey(testUuid);
+        lifecycle.scheduleTest(
+                testKey,
+                new TestResult()
+                        .setUuid(testUuid)
+                        .setName(randomName())
+                        .setLabels(
+                                List.of(
+                                        new Label().setName("tag").setValue("smoke"),
+                                        new Label().setName("tag")
+                                                .setValue("@allure.label.parentSuite:Platform"),
+                                        new Label().setName("tag").setValue("allure.label.suite=API_Tests"),
+                                        new Label().setName("tag").setValue("allure.label.story:first_story"),
+                                        new Label().setName("tag").setValue("allure.label.story:second_story")
+                                )
+                        )
+        );
+        lifecycle.addDefaultLabels(
+                testKey,
+                List.of(
+                        new Label().setName("suite").setValue("default suite"),
+                        new Label().setName("story").setValue("default story"),
+                        new Label().setName("feature").setValue("default feature")
+                )
+        );
+        lifecycle.startTest(testKey);
+        lifecycle.stopTest(testKey);
+        lifecycle.writeTest(testKey);
+
+        final ArgumentCaptor<TestResult> captor = forClass(TestResult.class);
+        verify(writer, times(1)).write(captor.capture());
+
+        Allure.step("Verify metadata tags replace same-name defaults", step -> {
+            step.parameter("test uuid", testUuid);
+            assertThat(captor.getValue().getLabels())
+                    .extracting(Label::getName, Label::getValue)
+                    .containsExactly(
+                            tuple("tag", "smoke"),
+                            tuple("parentSuite", "Platform"),
+                            tuple("suite", "API Tests"),
+                            tuple("story", "first story"),
+                            tuple("story", "second story"),
+                            tuple("feature", "default feature")
+                    );
+        });
+    }
+
     @Test
     void shouldPreferUserLabelsOverDefaultLabels() {
         final String testUuid = randomId();

--- a/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
+++ b/allure-junit-platform/src/test/java/io/qameta/allure/junitplatform/AllureJunitPlatformTest.java
@@ -107,6 +107,7 @@ import java.util.stream.Collectors;
 
 import static io.qameta.allure.junitplatform.AllureJunitPlatform.JUNIT_PLATFORM_UNIQUE_ID;
 import static io.qameta.allure.junitplatform.AllureJunitPlatformTestUtils.runClasses;
+import static io.qameta.allure.junitplatform.features.TaggedTests.ALLURE_LABEL_TAG;
 import static io.qameta.allure.junitplatform.features.TaggedTests.CLASS_TAG;
 import static io.qameta.allure.junitplatform.features.TaggedTests.METHOD_TAG;
 import static io.qameta.allure.test.AllurePredicates.hasLabel;
@@ -495,6 +496,29 @@ public class AllureJunitPlatformTest {
                         tuple(TAG_LABEL_NAME, CLASS_TAG),
                         tuple(TAG_LABEL_NAME, METHOD_TAG)
                 );
+    }
+
+    /**
+     * Allure label metadata from native JUnit tags must replace generated hierarchy defaults through the shared
+     * lifecycle, without leaving the metadata source tag for report generation to process again.
+     */
+    @Description
+    @Test
+    @AllureFeatures.MarkerAnnotations
+    void shouldConvertAllureLabelTags() {
+        final AllureResults results = runClasses(TaggedTests.class);
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults).hasSize(1);
+
+        final List<Label> labels = testResults.get(0).getLabels();
+        assertThat(labels)
+                .filteredOn(label -> SUITE_LABEL_NAME.equals(label.getName()))
+                .extracting(Label::getValue)
+                .containsExactly("Tagged tests");
+        assertThat(labels)
+                .extracting(Label::getName, Label::getValue)
+                .doesNotContain(tuple(TAG_LABEL_NAME, ALLURE_LABEL_TAG));
     }
 
     @Test

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/AllureJunit4Test.java
@@ -36,6 +36,7 @@ import io.qameta.allure.junit4.samples.IgnoredClassTest;
 import io.qameta.allure.junit4.samples.IgnoredTests;
 import io.qameta.allure.junit4.samples.InvalidTestClass;
 import io.qameta.allure.junit4.samples.MetaAnnotationTest;
+import io.qameta.allure.junit4.samples.MetadataTagTest;
 import io.qameta.allure.junit4.samples.OneTest;
 import io.qameta.allure.junit4.samples.RuntimeParametersTest;
 import io.qameta.allure.junit4.samples.SeverityTest;
@@ -69,6 +70,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static io.qameta.allure.junit4.samples.MetadataTagTest.ALLURE_LABEL_TAG;
+import static io.qameta.allure.junit4.samples.MetadataTagTest.PLAIN_TAG;
 import static io.qameta.allure.junit4.samples.TaggedTests.CLASS_TAG1;
 import static io.qameta.allure.junit4.samples.TaggedTests.CLASS_TAG2;
 import static io.qameta.allure.junit4.samples.TaggedTests.METHOD_TAG1;
@@ -77,6 +80,8 @@ import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
 import static io.qameta.allure.util.ResultsUtils.HOST_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.PACKAGE_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.SEVERITY_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.SUITE_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.TAG_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.THREAD_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.md5;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -490,6 +495,29 @@ class AllureJunit4Test {
                 .filteredOn(label -> "tag".equals(label.getName()))
                 .extracting(Label::getValue)
                 .containsExactlyInAnyOrder(CLASS_TAG1, CLASS_TAG2, METHOD_TAG1, METHOD_TAG2);
+    }
+
+    /**
+     * Allure label metadata supplied through JUnit 4 tag annotations must replace the generated suite while an
+     * ordinary tag remains available for filtering.
+     */
+    @Description
+    @Test
+    @AllureFeatures.MarkerAnnotations
+    void shouldConvertAllureLabelTags() {
+        final AllureResults results = runClasses(MetadataTagTest.class);
+
+        assertThat(results.getTestResults()).hasSize(1);
+        final List<Label> labels = results.getTestResults().get(0).getLabels();
+
+        assertThat(labels)
+                .filteredOn(Label::getName, SUITE_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly("JUnit 4 metadata");
+        assertThat(labels)
+                .extracting(Label::getName, Label::getValue)
+                .contains(tuple(TAG_LABEL_NAME, PLAIN_TAG))
+                .doesNotContain(tuple(TAG_LABEL_NAME, ALLURE_LABEL_TAG));
     }
 
     @Test

--- a/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/MetadataTagTest.java
+++ b/allure-junit4/src/test/java/io/qameta/allure/junit4/samples/MetadataTagTest.java
@@ -13,20 +13,20 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.junitplatform.features;
+package io.qameta.allure.junit4.samples;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-@Tag(TaggedTests.CLASS_TAG)
-public class TaggedTests {
+import io.qameta.allure.junit4.Tag;
+import io.qameta.allure.junit4.Tags;
+import org.junit.Test;
 
-    public static final String ALLURE_LABEL_TAG = "allure.label.suite:Tagged_tests";
-    public static final String CLASS_TAG = "class_tag";
-    public static final String METHOD_TAG = "single_tag";
+public class MetadataTagTest {
+
+    public static final String ALLURE_LABEL_TAG = "allure.label.suite:JUnit_4_metadata";
+    public static final String PLAIN_TAG = "smoke";
 
     @Test
-    @Tag(ALLURE_LABEL_TAG)
-    @Tag(METHOD_TAG)
-    void taggedTest() {
+    @Tags({@Tag(ALLURE_LABEL_TAG), @Tag(PLAIN_TAG)})
+    public void metadataTag() {
     }
+
 }

--- a/allure-karate/src/test/java/io/qameta/allure/karate/AllureKarateTest.java
+++ b/allure-karate/src/test/java/io/qameta/allure/karate/AllureKarateTest.java
@@ -18,6 +18,7 @@ package io.qameta.allure.karate;
 import io.karatelabs.core.Runner;
 import io.qameta.allure.Allure;
 import io.qameta.allure.AllureLifecycle;
+import io.qameta.allure.Description;
 import io.qameta.allure.FileSystemResultsWriter;
 import io.qameta.allure.http.HttpExchange;
 import io.qameta.allure.model.Attachment;
@@ -250,6 +251,30 @@ class AllureKarateTest extends TestRunner {
                         tuple("layer", "unit_tests"),
                         tuple("severity", "blocker")
                 );
+    }
+
+    /**
+     * Allure label metadata supplied through a Karate tag must replace the feature-name default without leaving a
+     * metadata source tag in the result.
+     */
+    @Description
+    @Test
+    void shouldPreferMetadataTagFeatureOverDefault() {
+        final AllureResults results = run("classpath:testdata/tags.feature");
+
+        final List<Label> labels = results.getTestResults().stream()
+                .filter(result -> "Test with custom feature".equals(result.getName()))
+                .findFirst()
+                .orElseThrow()
+                .getLabels();
+
+        assertThat(labels)
+                .filteredOn(Label::getName, "feature")
+                .extracting(Label::getValue)
+                .containsExactly("CustomFeature");
+        assertThat(labels)
+                .extracting(Label::getName, Label::getValue)
+                .doesNotContain(tuple("tag", "allure.label.feature:CustomFeature"));
     }
 
     @Test

--- a/allure-karate/src/test/resources/testdata/tags.feature
+++ b/allure-karate/src/test/resources/testdata/tags.feature
@@ -15,6 +15,11 @@ Feature: labels
     * print 'First step'
     * print 'Second step'
 
+  @allure.label.feature:CustomFeature
+  Scenario: Test with custom feature
+    * print 'First step'
+    * print 'Second step'
+
   @Karate_tag:1
   Scenario: Test without allure labels
     * print 'First step'

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/AllureSpock2Test.java
@@ -48,6 +48,7 @@ import io.qameta.allure.spock2.samples.ParameterizedBlocks;
 import io.qameta.allure.spock2.samples.ParametersTest;
 import io.qameta.allure.spock2.samples.RuntimeParameterTest;
 import io.qameta.allure.spock2.samples.SpecFixtures;
+import io.qameta.allure.spock2.samples.SpockMetadataTag;
 import io.qameta.allure.spock2.samples.SpockTags;
 import io.qameta.allure.spock2.samples.StepsAndBlocks;
 import io.qameta.allure.spock2.samples.TestWithAnnotations;
@@ -88,9 +89,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static io.qameta.allure.spock2.samples.SpockMetadataTag.ALLURE_LABEL_TAG;
+import static io.qameta.allure.spock2.samples.SpockMetadataTag.PLAIN_TAG;
 import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
 import static io.qameta.allure.util.ResultsUtils.PACKAGE_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.SEVERITY_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.SUITE_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.TAG_LABEL_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
@@ -378,6 +383,29 @@ class AllureSpock2Test {
                         tuple("tag", "first"),
                         tuple("tag", "second")
                 );
+    }
+
+    /**
+     * Allure label metadata supplied through native Spock tags must replace the generated spec suite while an
+     * ordinary tag remains available for filtering.
+     */
+    @Description
+    @Test
+    @AllureFeatures.MarkerAnnotations
+    void shouldConvertAllureLabelTags() {
+        final AllureResults results = runClasses(SpockMetadataTag.class);
+
+        assertThat(results.getTestResults()).hasSize(1);
+        final List<Label> labels = results.getTestResults().get(0).getLabels();
+
+        assertThat(labels)
+                .filteredOn(Label::getName, SUITE_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly("Spock metadata");
+        assertThat(labels)
+                .extracting(Label::getName, Label::getValue)
+                .contains(tuple(TAG_LABEL_NAME, PLAIN_TAG))
+                .doesNotContain(tuple(TAG_LABEL_NAME, ALLURE_LABEL_TAG));
     }
 
     @Test

--- a/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/SpockMetadataTag.groovy
+++ b/allure-spock2/src/test/groovy/io/qameta/allure/spock2/samples/SpockMetadataTag.groovy
@@ -13,20 +13,20 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.junitplatform.features;
+package io.qameta.allure.spock2.samples
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-@Tag(TaggedTests.CLASS_TAG)
-public class TaggedTests {
+import spock.lang.Specification
+import spock.lang.Tag
 
-    public static final String ALLURE_LABEL_TAG = "allure.label.suite:Tagged_tests";
-    public static final String CLASS_TAG = "class_tag";
-    public static final String METHOD_TAG = "single_tag";
+class SpockMetadataTag extends Specification {
 
-    @Test
+    public static final String ALLURE_LABEL_TAG = "allure.label.suite:Spock_metadata"
+    public static final String PLAIN_TAG = "smoke"
+
     @Tag(ALLURE_LABEL_TAG)
-    @Tag(METHOD_TAG)
-    void taggedTest() {
+    @Tag(PLAIN_TAG)
+    def "metadata tag"() {
+        expect:
+        true
     }
 }

--- a/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/AllureTestNgTest.java
@@ -84,7 +84,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static io.qameta.allure.test.AllureTestCommonsUtils.expectedHistoryId;
+import static io.qameta.allure.testng.samples.MetadataTagTest.ALLURE_LABEL_TAG;
+import static io.qameta.allure.testng.samples.MetadataTagTest.PLAIN_TAG;
 import static io.qameta.allure.util.ResultsUtils.ALLURE_SEPARATE_LINES_SYSPROP;
+import static io.qameta.allure.util.ResultsUtils.SUITE_LABEL_NAME;
+import static io.qameta.allure.util.ResultsUtils.TAG_LABEL_NAME;
 import static io.qameta.allure.util.ResultsUtils.md5;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -1267,6 +1271,29 @@ public class AllureTestNgTest {
                         tuple("io.qameta.allure.testng.samples.TagClassTest.testWithTag", "[class-tag,method-tag-single]"),
                         tuple("io.qameta.allure.testng.samples.TagClassTest.testWithTags", "[class-tag,method-tag-1,method-tag-2]")
                 );
+    }
+
+    /**
+     * Allure label metadata supplied through TestNG tag annotations must replace the XML suite default while an
+     * ordinary tag remains available for filtering.
+     */
+    @Description
+    @AllureFeatures.MarkerAnnotations
+    @Test
+    public void shouldConvertAllureLabelTags() {
+        final AllureResults results = runTestNgSuites("suites/metadata-tag.xml");
+
+        assertThat(results.getTestResults()).hasSize(1);
+        final List<Label> labels = results.getTestResults().get(0).getLabels();
+
+        assertThat(labels)
+                .filteredOn(Label::getName, SUITE_LABEL_NAME)
+                .extracting(Label::getValue)
+                .containsExactly("TestNG metadata");
+        assertThat(labels)
+                .extracting(Label::getName, Label::getValue)
+                .contains(tuple(TAG_LABEL_NAME, PLAIN_TAG))
+                .doesNotContain(tuple(TAG_LABEL_NAME, ALLURE_LABEL_TAG));
     }
 
     @AllureFeatures.Attachments

--- a/allure-testng/src/test/java/io/qameta/allure/testng/samples/MetadataTagTest.java
+++ b/allure-testng/src/test/java/io/qameta/allure/testng/samples/MetadataTagTest.java
@@ -13,20 +13,20 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package io.qameta.allure.junitplatform.features;
+package io.qameta.allure.testng.samples;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-@Tag(TaggedTests.CLASS_TAG)
-public class TaggedTests {
+import io.qameta.allure.testng.Tag;
+import io.qameta.allure.testng.Tags;
+import org.testng.annotations.Test;
 
-    public static final String ALLURE_LABEL_TAG = "allure.label.suite:Tagged_tests";
-    public static final String CLASS_TAG = "class_tag";
-    public static final String METHOD_TAG = "single_tag";
+@Tags({@Tag(MetadataTagTest.ALLURE_LABEL_TAG), @Tag(MetadataTagTest.PLAIN_TAG)})
+public class MetadataTagTest {
+
+    public static final String ALLURE_LABEL_TAG = "allure.label.suite:TestNG_metadata";
+    public static final String PLAIN_TAG = "smoke";
 
     @Test
-    @Tag(ALLURE_LABEL_TAG)
-    @Tag(METHOD_TAG)
-    void taggedTest() {
+    public void metadataTag() {
     }
+
 }

--- a/allure-testng/src/test/resources/suites/metadata-tag.xml
+++ b/allure-testng/src/test/resources/suites/metadata-tag.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Default parent suite">
+    <test name="Default suite">
+        <classes>
+            <class name="io.qameta.allure.testng.samples.MetadataTagTest"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

`allure.label.*` framework tags are now converted into result labels before generated hierarchy defaults are applied. In Cucumber JVM, custom `parentSuite`, `suite`, and `subSuite` tags replace the automatic hierarchy instead of causing scenarios to appear twice in the Suite view.

The convention now behaves consistently across Cucumber JVM 7, JUnit Platform, JUnit 4, TestNG, Spock 2, and Karate. Ordinary tags remain available, while metadata tags are consumed once so the report does not reapply them.

fixes #1030

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java