### PR TITLE
Preserve parameterized test identity when JUnit setup fails

### DIFF
--- a/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiter.java
+++ b/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiter.java
@@ -24,6 +24,7 @@ import io.qameta.allure.model.Parameter;
 import io.qameta.allure.model.Status;
 import io.qameta.allure.util.ParameterUtils;
 import io.qameta.allure.util.ResultsUtils;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
@@ -31,7 +32,9 @@ import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Reports JUnit Jupiter fixture and parameter execution details to Allure.
@@ -42,17 +45,23 @@ import java.util.List;
  * Platform unique ids — see {@link AllureJunitPlatform#scopeKey(String)} and
  * {@link AllureJunitPlatform#testKey(String)}.</p>
  */
-public class AllureJupiter implements InvocationInterceptor {
+public class AllureJupiter implements InvocationInterceptor, BeforeEachCallback {
 
     private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(AllureJupiter.class);
 
     private static final String TEST = "test";
     private static final String TEMPLATE = "template";
+    private static final String PARAMETERS = "parameters";
     private static final String PREPARE = "prepare";
     private static final String TEAR_DOWN = "tear_down";
+    private static final String CAPTURED_PARAMETERS = "captured_parameters";
 
-    // parameterized class support requires the ParameterInfo API of junit-jupiter-params 6.x
-    private static final boolean CLASS_PARAMETERS_SUPPORTED = isClassAvailableOnClasspath("org.junit.jupiter.params.ParameterInfo");
+    private static final boolean CURRENT_PARAMETER_INFO_SUPPORTED = isClassAvailableOnClasspath(
+            "org.junit.jupiter.params.ParameterInfo"
+    );
+    private static final boolean LEGACY_PARAMETER_INFO_SUPPORTED = isClassAvailableOnClasspath(
+            "org.junit.jupiter.params.support.ParameterInfo"
+    );
 
     /**
      * Returns the lifecycle. Resolved at call time, so the extension follows process-wide lifecycle swaps.
@@ -67,6 +76,24 @@ public class AllureJupiter implements InvocationInterceptor {
      * {@inheritDoc}
      */
     @Override
+    public void beforeEach(final ExtensionContext extensionContext) {
+        final Method testMethod = extensionContext.getRequiredTestMethod();
+        if (!shouldHandle(extensionContext, PARAMETERS, testMethod)) {
+            return;
+        }
+        final List<Parameter> parameters = getParameters(extensionContext);
+        if (parameters.isEmpty()) {
+            return;
+        }
+        extensionContext.getStore(NAMESPACE)
+                .put(CAPTURED_PARAMETERS, new ParameterCapture(parameters));
+        addParameters(extensionContext, parameters);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void interceptTestMethod(final Invocation<Void> invocation,
                                     final ReflectiveInvocationContext<Method> invocationContext,
                                     final ExtensionContext extensionContext)
@@ -75,7 +102,7 @@ public class AllureJupiter implements InvocationInterceptor {
             invocation.proceed();
             return;
         }
-        addParameters(extensionContext, getClassParameters(invocationContext, extensionContext));
+        replaceCapturedParameters(extensionContext, getClassParameters(invocationContext, extensionContext));
         invocation.proceed();
     }
 
@@ -93,7 +120,7 @@ public class AllureJupiter implements InvocationInterceptor {
         }
         final List<Parameter> testParameters = new ArrayList<>(getClassParameters(invocationContext, extensionContext));
         testParameters.addAll(getArgumentParameters(invocationContext));
-        addParameters(extensionContext, testParameters);
+        replaceCapturedParameters(extensionContext, testParameters);
         invocation.proceed();
     }
 
@@ -108,15 +135,53 @@ public class AllureJupiter implements InvocationInterceptor {
         );
     }
 
+    private void replaceCapturedParameters(final ExtensionContext extensionContext,
+                                           final List<Parameter> testParameters) {
+        final ParameterCapture capture = extensionContext.getStore(NAMESPACE)
+                .remove(CAPTURED_PARAMETERS, ParameterCapture.class);
+        if (capture == null) {
+            addParameters(extensionContext, testParameters);
+            return;
+        }
+
+        // ParameterInfo exposes source arguments before setup. Once the invocation exists, prefer its converted
+        // values and remove only the objects captured here so parameters added by user code remain untouched.
+        final Set<Parameter> capturedParameters = Collections.newSetFromMap(new IdentityHashMap<>());
+        capturedParameters.addAll(capture.parameters());
+        getLifecycle().updateTest(
+                AllureJunitPlatform.testKey(extensionContext.getUniqueId()),
+                testResult -> {
+                    testResult.getParameters().removeIf(capturedParameters::contains);
+                    testResult.getParameters().addAll(testParameters);
+                }
+        );
+    }
+
+    private List<Parameter> getParameters(final ExtensionContext extensionContext) {
+        if (CURRENT_PARAMETER_INFO_SUPPORTED) {
+            return AllureJupiterParameterInfoSupport.getParameters(extensionContext);
+        }
+        if (LEGACY_PARAMETER_INFO_SUPPORTED) {
+            return AllureJupiterLegacyParameterInfoSupport.getParameters(extensionContext);
+        }
+        return Collections.emptyList();
+    }
+
     private List<Parameter> getClassParameters(final ReflectiveInvocationContext<Method> invocationContext,
                                                final ExtensionContext extensionContext) {
-        if (!CLASS_PARAMETERS_SUPPORTED) {
-            return Collections.emptyList();
+        if (CURRENT_PARAMETER_INFO_SUPPORTED) {
+            return AllureJupiterParameterInfoSupport.getClassParameters(
+                    extensionContext,
+                    invocationContext.getExecutable()
+            );
         }
-        return AllureJupiterParameterInfoSupport.getClassParameters(
-                extensionContext,
-                invocationContext.getExecutable()
-        );
+        if (LEGACY_PARAMETER_INFO_SUPPORTED) {
+            return AllureJupiterLegacyParameterInfoSupport.getClassParameters(
+                    extensionContext,
+                    invocationContext.getExecutable()
+            );
+        }
+        return Collections.emptyList();
     }
 
     private List<Parameter> getArgumentParameters(final ReflectiveInvocationContext<Method> invocationContext) {
@@ -257,5 +322,8 @@ public class AllureJupiter implements InvocationInterceptor {
                 .getStore(NAMESPACE)
                 .getOrComputeIfAbsent(key, ignored -> marker);
         return marker.equals(storedMarker);
+    }
+
+    private record ParameterCapture(List<Parameter> parameters) {
     }
 }

--- a/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiterLegacyParameterInfoSupport.java
+++ b/allure-jupiter/src/main/java/io/qameta/allure/jupiter/AllureJupiterLegacyParameterInfoSupport.java
@@ -18,9 +18,9 @@ package io.qameta.allure.jupiter;
 import io.qameta.allure.model.Parameter;
 import io.qameta.allure.util.ParameterUtils;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.params.ParameterInfo;
 import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.junit.jupiter.params.support.ParameterDeclaration;
+import org.junit.jupiter.params.support.ParameterInfo;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -33,13 +33,14 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 /**
- * Reads the JUnit Jupiter {@link ParameterInfo} API to report parameterized invocation arguments. The API exists
- * since junit-jupiter-params 6.0 — every reference to it stays inside this class, which is loaded only after a
- * classpath check.
+ * Reads the legacy JUnit Jupiter {@link ParameterInfo} API to report arguments with junit-jupiter-params 5.13. The
+ * API is deprecated in JUnit 6 — every reference to it stays inside this class, which is loaded only after a
+ * classpath check and only when the replacement API is unavailable.
  */
-/* package-private */ final class AllureJupiterParameterInfoSupport {
+@SuppressWarnings({"deprecation", "removal"})
+/* package-private */ final class AllureJupiterLegacyParameterInfoSupport {
 
-    private AllureJupiterParameterInfoSupport() {
+    private AllureJupiterLegacyParameterInfoSupport() {
         throw new IllegalStateException("do not instance");
     }
 

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/AllureJupiterTest.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/AllureJupiterTest.java
@@ -22,6 +22,7 @@ import io.qameta.allure.jupiter.features.FixtureTests;
 import io.qameta.allure.jupiter.features.GlobalErrorTests;
 import io.qameta.allure.jupiter.features.NestedTemplatesTests;
 import io.qameta.allure.jupiter.features.ParamAnnotationTests;
+import io.qameta.allure.jupiter.features.ParameterizedBeforeEachTests;
 import io.qameta.allure.jupiter.features.ParameterizedClassTests;
 import io.qameta.allure.model.FixtureResult;
 import io.qameta.allure.model.GlobalError;
@@ -133,6 +134,45 @@ class AllureJupiterTest {
                 .orElseThrow(() -> new AssertionError("no scope with the broken fixture"));
         assertThat(methodScope.getChildren())
                 .containsExactly(testResult.getUuid());
+    }
+
+    @Test
+    @AllureFeatures.Fixtures
+    @AllureFeatures.Parameters
+    @AllureFeatures.History
+    void shouldKeepParametersWhenBeforeEachFails() {
+        final AllureResults failedResults;
+        ParameterizedBeforeEachTests.failBeforeEach(true);
+        try {
+            failedResults = runClasses(ParameterizedBeforeEachTests.class);
+        } finally {
+            ParameterizedBeforeEachTests.failBeforeEach(false);
+        }
+        final AllureResults passedResults = runClasses(ParameterizedBeforeEachTests.class);
+
+        assertThat(failedResults.getTestResults()).singleElement()
+                .extracting(TestResult::getStatus)
+                .isEqualTo(Status.BROKEN);
+        assertThat(passedResults.getTestResults()).singleElement()
+                .extracting(TestResult::getStatus)
+                .isEqualTo(Status.PASSED);
+
+        final TestResult failed = failedResults.getTestResults().get(0);
+        final TestResult passed = passedResults.getTestResults().get(0);
+        assertThat(failed.getParameters())
+                .extracting(Parameter::getName)
+                .containsExactlyInAnyOrder("UniqueId", "first", "second");
+        assertThat(failed.getParameters())
+                .filteredOn(parameter -> !"UniqueId".equals(parameter.getName()))
+                .extracting(Parameter::getName, Parameter::getValue)
+                .containsExactlyInAnyOrder(
+                        tuple("first", "first value"),
+                        tuple("second", "second value")
+                );
+        assertThat(failed.getParameters())
+                .containsExactlyInAnyOrderElementsOf(passed.getParameters());
+        assertThat(failed.getTestCaseId()).isEqualTo(passed.getTestCaseId());
+        assertThat(failed.getHistoryId()).isEqualTo(passed.getHistoryId());
     }
 
     @Test

--- a/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/ParameterizedBeforeEachTests.java
+++ b/allure-jupiter/src/test/java/io/qameta/allure/jupiter/features/ParameterizedBeforeEachTests.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright 2016-2026 Qameta Software Inc
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.qameta.allure.jupiter.features;
+
+import io.qameta.allure.Param;
+import io.qameta.allure.jupiter.AllureJupiter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@ExtendWith(AllureJupiter.class)
+public class ParameterizedBeforeEachTests {
+
+    private static boolean failBeforeEach;
+
+    public static void failBeforeEach(final boolean fail) {
+        failBeforeEach = fail;
+    }
+
+    @BeforeEach
+    void setUp() {
+        if (failBeforeEach) {
+            throw new IllegalStateException("fail in beforeEach");
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource("first value, second value")
+    void parameterizedTest(@Param("first") final String first,
+                           @Param("second") final String second) {
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Parameterized JUnit Jupiter tests that fail in `@BeforeEach` now retain their invocation parameters. A later successful attempt receives the same test case and history identity, allowing Allure Report and Allure TestOps to group the setup failure as a retry instead of displaying a separate result.

Successful invocations continue to report their resolved argument values. Per-test setup failures remain attached to the real test invocation, while class- and container-level fixture failures continue to be reported as global errors without creating phantom tests.

fixes #1061

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java