### PR TITLE
Report undefined and ambiguous Cucumber steps as broken

### DIFF
--- a/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/AllureCucumber7Jvm.java
+++ b/allure-cucumber7-jvm/src/main/java/io/qameta/allure/cucumber7jvm/AllureCucumber7Jvm.java
@@ -98,6 +98,7 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
     private static final String CSV_ESCAPED_QUOTE = CSV_QUOTE + CSV_QUOTE;
     private static final String NEW_LINE = "\n";
     private static final String CARRIAGE_RETURN = "\r";
+    private static final String UNDEFINED_STEP_MESSAGE = "Undefined Step. Please add step definition";
 
     private final AllureLifecycle lifecycle;
 
@@ -254,8 +255,7 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
         final String uuid = testCase.getId().toString();
         final Result result = event.getResult();
         final Status status = translateTestCaseStatus(result);
-        final StatusDetails statusDetails = getStatusDetails(result.getError())
-                .orElseGet(StatusDetails::new);
+        final StatusDetails statusDetails = translateStatusDetails(result);
 
         final TagParser tagParser = new TagParser(feature, testCase);
         statusDetails
@@ -417,9 +417,18 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
                 return Status.SKIPPED;
             case AMBIGUOUS:
             case UNDEFINED:
+                return Status.BROKEN;
             default:
                 return null;
         }
+    }
+
+    private StatusDetails translateStatusDetails(final Result result) {
+        if (result.getStatus() == io.cucumber.plugin.event.Status.UNDEFINED) {
+            return new StatusDetails().setMessage(UNDEFINED_STEP_MESSAGE);
+        }
+        return getStatusDetails(result.getError())
+                .orElseGet(StatusDetails::new);
     }
 
     private List<Parameter> getExamplesAsParameters(
@@ -537,10 +546,7 @@ public class AllureCucumber7Jvm implements ConcurrentEventListener {
 
         final Status stepStatus = translateTestCaseStatus(eventResult);
 
-        final StatusDetails statusDetails = eventResult.getStatus() == io.cucumber.plugin.event.Status.UNDEFINED
-                ? new StatusDetails().setMessage("Undefined Step. Please add step definition")
-                : getStatusDetails(eventResult.getError())
-                        .orElse(new StatusDetails());
+        final StatusDetails statusDetails = translateStatusDetails(eventResult);
 
         final TagParser tagParser = new TagParser(feature, testCase);
         statusDetails

--- a/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
+++ b/allure-cucumber7-jvm/src/test/java/io/qameta/allure/cucumber7jvm/AllureCucumber7JvmTest.java
@@ -74,6 +74,7 @@ import static org.junit.jupiter.api.parallel.Resources.SYSTEM_PROPERTIES;
 class AllureCucumber7JvmTest {
 
     private static final String EXPECTED_CUCUMBER_VERSION_PROPERTY = "allure.test.cucumber.version";
+    private static final String UNDEFINED_STEP_MESSAGE = "Undefined Step. Please add step definition";
 
     @AllureFeatures.Base
     @Test
@@ -496,8 +497,13 @@ class AllureCucumber7JvmTest {
                 .doesNotContain(TEST_CLASS_LABEL_NAME, TEST_METHOD_LABEL_NAME);
     }
 
+    /**
+     * An undefined step breaks the scenario and carries a useful explanation; later steps stay skipped.
+     */
+    @AllureFeatures.BrokenTests
     @AllureFeatures.Steps
     @Test
+    @Description
     void shouldProcessUndefinedSteps() {
         final AllureResults results = runFeature("features/undefined.feature");
 
@@ -505,16 +511,55 @@ class AllureCucumber7JvmTest {
         assertThat(testResults)
                 .extracting(TestResult::getName, TestResult::getStatus)
                 .containsExactlyInAnyOrder(
-                        tuple("Step is not defined", null)
+                        tuple("Step is not defined", Status.BROKEN)
                 );
 
-        assertThat(testResults.get(0).getSteps())
+        final TestResult testResult = testResults.get(0);
+        assertThat(testResult.getStatusDetails().getMessage())
+                .isEqualTo(UNDEFINED_STEP_MESSAGE);
+
+        final List<StepResult> steps = testResult.getSteps();
+        assertThat(steps)
                 .extracting(StepResult::getName, StepResult::getStatus)
-                .containsExactlyInAnyOrder(
+                .containsExactly(
                         tuple("Given a is 5", Status.PASSED),
-                        tuple("When step is undefined", null),
+                        tuple("When step is undefined", Status.BROKEN),
                         tuple("Then b is 10", Status.SKIPPED)
                 );
+        assertThat(steps.get(1).getStatusDetails().getMessage())
+                .isEqualTo(UNDEFINED_STEP_MESSAGE);
+    }
+
+    /**
+     * An undefined final step still breaks both the step and its scenario.
+     */
+    @AllureFeatures.BrokenTests
+    @AllureFeatures.Steps
+    @Test
+    @Description
+    void shouldProcessUndefinedLastStep() {
+        final AllureResults results = runFeature("features/undefined-last.feature");
+
+        final List<TestResult> testResults = results.getTestResults();
+        assertThat(testResults)
+                .extracting(TestResult::getName, TestResult::getStatus)
+                .containsExactlyInAnyOrder(
+                        tuple("Last step is not defined", Status.BROKEN)
+                );
+
+        final TestResult testResult = testResults.get(0);
+        assertThat(testResult.getStatusDetails().getMessage())
+                .isEqualTo(UNDEFINED_STEP_MESSAGE);
+
+        final List<StepResult> steps = testResult.getSteps();
+        assertThat(steps)
+                .extracting(StepResult::getName, StepResult::getStatus)
+                .containsExactly(
+                        tuple("Given a is 5", Status.PASSED),
+                        tuple("When step is undefined", Status.BROKEN)
+                );
+        assertThat(steps.get(1).getStatusDetails().getMessage())
+                .isEqualTo(UNDEFINED_STEP_MESSAGE);
     }
 
     @AllureFeatures.SkippedTests
@@ -831,8 +876,14 @@ class AllureCucumber7JvmTest {
                 );
     }
 
+    /**
+     * An ambiguous step breaks the scenario and preserves the matching step definitions and exception trace
+     * on both results; later steps stay skipped.
+     */
     @AllureFeatures.BrokenTests
+    @AllureFeatures.Steps
     @Test
+    @Description
     void shouldHandleAmbigiousStepsExceptions() {
         final AllureResults results = runFeature("features/ambigious.feature");
 
@@ -840,15 +891,32 @@ class AllureCucumber7JvmTest {
         assertThat(testResults)
                 .extracting(TestResult::getName, TestResult::getStatus)
                 .containsExactlyInAnyOrder(
-                        tuple("Simple scenario with ambigious steps", null)
+                        tuple("Simple scenario with ambigious steps", Status.BROKEN)
                 );
 
-        assertThat(testResults.get(0).getSteps())
+        final TestResult testResult = testResults.get(0);
+        final StatusDetails statusDetails = testResult.getStatusDetails();
+        assertThat(statusDetails.getMessage())
+                .contains(
+                        "\"ambigious step present\" matches more than one step definition",
+                        "AmbigiousSteps.ambigious_1()",
+                        "AmbigiousSteps.ambigious_2()"
+                );
+        assertThat(statusDetails.getTrace())
+                .contains("io.cucumber.core.runner.AmbiguousStepDefinitionsException:", "\tat ");
+
+        final List<StepResult> steps = testResult.getSteps();
+        assertThat(steps)
                 .extracting(StepResult::getName, StepResult::getStatus)
                 .containsExactly(
-                        tuple("When ambigious step present", null),
+                        tuple("When ambigious step present", Status.BROKEN),
                         tuple("Then something bad should happen", Status.SKIPPED)
                 );
+        final StatusDetails stepStatusDetails = steps.get(0).getStatusDetails();
+        assertThat(stepStatusDetails.getMessage())
+                .isEqualTo(statusDetails.getMessage());
+        assertThat(stepStatusDetails.getTrace())
+                .isEqualTo(statusDetails.getTrace());
     }
 
     @ResourceLock(

--- a/allure-cucumber7-jvm/src/test/resources/features/undefined-last.feature
+++ b/allure-cucumber7-jvm/src/test/resources/features/undefined-last.feature
@@ -1,0 +1,5 @@
+Feature: Simple feature with an undefined last step
+
+  Scenario: Last step is not defined
+    Given a is 5
+    When step is undefined


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Cucumber 7 scenarios containing undefined or ambiguous steps are now reported as broken. This prevents an undefined final step from making a scenario appear passed. The affected step is also marked broken, while subsequent steps remain skipped.

Both the scenario and affected step include diagnostic details: undefined steps explain that a step definition is missing, and ambiguous steps preserve Cucumber’s exception message and stack trace identifying the conflicting definitions.

fixes #1029
#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-java